### PR TITLE
Add CI targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,3 +236,38 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+
+# CI tools repo for running tests
+CI_TOOLS_REPO := https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
+CI_TOOLS_REPO_DIR = $(shell pwd)/CI_TOOLS_REPO
+.PHONY: get-ci-tools
+get-ci-tools:
+	if [ -d  "$(CI_TOOLS_REPO_DIR)" ]; then \
+		echo "Ci tools exists"; \
+		pushd "$(CI_TOOLS_REPO_DIR)"; \
+		git pull --rebase; \
+		popd; \
+	else \
+		git clone $(CI_TOOLS_REPO) "$(CI_TOOLS_REPO_DIR)"; \
+	fi
+
+# Run go fmt against code
+gofmt: get-ci-tools
+	$(CI_TOOLS_REPO_DIR)/test-runner/gofmt.sh
+
+# Run go vet against code
+govet: get-ci-tools
+	$(CI_TOOLS_REPO_DIR)/test-runner/govet.sh
+
+# Run go test against code
+gotest: get-ci-tools
+	$(CI_TOOLS_REPO_DIR)/test-runner/gotest.sh
+
+# Run golangci-lint test against code
+golangci: get-ci-tools
+	$(CI_TOOLS_REPO_DIR)/test-runner/golangci.sh
+
+# Run go lint against code
+golint: get-ci-tools
+	PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh


### PR DESCRIPTION
These make build targets are available for other Operators.
Adding these here so that we can use them in Prow jobs.
Prow jobs are currently failing due to lack of Make targets.

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/31993/rehearse-31993-pull-ci-openstack-k8s-operators-openstack-operator-master-golint/1566731274410790912