### PR TITLE
Add storageClass to sample CR's Glance template

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -24,4 +24,5 @@ spec:
     containerImage: quay.io/tripleotraincentos8/centos-binary-placement-api:current-tripleo
   glanceTemplate:
     containerImage: quay.io/tripleotraincentos8/centos-binary-glance-api:current-tripleo
+    storageClass: ""
     storageRequest: 10G


### PR DESCRIPTION
We need to explicitly include `glanceTemplate.storageClass: ""` in the sample `OpenStackControlPlane` CR so that an upcoming change to `install_yamls` will be able to use `Kustomize` to replace the value with the value of an environment variable. This is needed to allow for flexibility in storage classes across CRC dev environments and non-CRC CI environments. The empty-string is chosen because this is what the CR already had implicitly for the `glanceTemplate.storageClass` field by excluding the field from the sample spec.