### PR TITLE
Propagate storageClass to Glance template

### DIFF
--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -32,6 +32,9 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		if glance.Spec.DatabaseInstance == "" {
 			glance.Spec.DatabaseInstance = "openstack"
 		}
+		if glance.Spec.StorageClass == "" {
+			glance.Spec.StorageClass = instance.Spec.StorageClass
+		}
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), glance, helper.GetScheme())
 		if err != nil {
 			return err


### PR DESCRIPTION
If the `glanceTemplate` in an `OpenStackControlPlane` CR lacks `storageClass`, set it to the `OpenStackControlPlane`'s `storageClass` (as we do for other embedded templates)