### PR TITLE
Check if our go.mod files are in sync

### DIFF
--- a/.github/workflows/go-mod-sync.yaml
+++ b/.github/workflows/go-mod-sync.yaml
@@ -1,0 +1,13 @@
+name: Golang lint, vet and unit test pipeline
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: go-mod-sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project code
+        uses: actions/checkout@v2
+      - name: run verify-go-mod-sync.sh
+        run: ./verify-go-mod-sync.sh

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Build
 
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
+build: verify-go-mod-sync generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 	go build -o bin/csv-merger cmd/csv-merger/csv-merger.go
 
@@ -289,3 +289,7 @@ gowork: ## Generate go.work file to support our multi module repository
 operator-lint: gowork ## Runs operator-lint
 	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@latest
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./apis/...
+
+.PHONY: verify-go-mod-sync
+verify-go-mod-sync: ## Checks if dependencies to other operators are in sync between the main and the ./apis go.mod files
+	./verify-go-mod-sync.sh

--- a/verify-go-mod-sync.sh
+++ b/verify-go-mod-sync.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+deps="
+github.com/openstack-k8s-operators/cinder-operator/api
+github.com/openstack-k8s-operators/glance-operator/api
+github.com/openstack-k8s-operators/keystone-operator/api
+github.com/openstack-k8s-operators/mariadb-operator/api
+github.com/openstack-k8s-operators/placement-operator/api
+github.com/rabbitmq/cluster-operator
+"
+result=0
+for dep in $deps;
+do
+        if [ $(grep $dep go.mod ./apis/go.mod | tr $'\t' ' ' | cut -d ' ' -f3 | sort -u | wc -l) -ne 1 ]; then
+                echo "go.mod and ./apis/go.mod has different versions from $dep"
+                ((result+=1))
+        fi
+done
+exit $result


### PR DESCRIPTION
Both the main go.mod and the ./apis/go.mod file points to other operators. But if the version of those operators are not in sync between the two go.mod files then we can get strange CRD validation errors when the openstack-operator is deployed. To avoid that a check is added to the Makefile and to our github workflows