### PR TITLE
Fix invalid: metadata.annotations: Too long

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
     rm -f apis/bases/* && cp -a config/crd/bases apis/
 
 .PHONY: generate


### PR DESCRIPTION
This change adds crd:maxDescLen=0 to the Makefile to prevent the error reported in issue #55

Closes: #55