### PR TITLE
Add renovatebot config to update openstack deps

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  platform: 'github',
+  branchPrefix: 'renovate/',
+  username: 'renovate-release',
+  gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
+  onboardingConfig: {
+    extends: ['config:base'],
+  },
+  repositories: ['openstack-k8s-operators/openstack-operator']
+};

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,18 @@
+name: Run Renovate Bot
+
+on:
+  schedule:
+    - cron:  '0/30 * * * *'
+
+jobs:
+  renovate:
+    name: Renovatebot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v34.29.2
+        with:
+          configurationFile: .github/renovate-config.js
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ testbin/*
 
 bundle/*
 bundle.Dockerfile
+custom-bundle.Dockerfile.pinned
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -188,10 +188,11 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
+	/bin/bash hack/pin-custom-bundle-dockerfile.sh
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	podman build -f custom-bundle.Dockerfile -t $(BUNDLE_IMG) .
+	podman build -f custom-bundle.Dockerfile.pinned -t $(BUNDLE_IMG) .
 
 
 .PHONY: bundle-push

--- a/hack/pin-custom-bundle-dockerfile.sh
+++ b/hack/pin-custom-bundle-dockerfile.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+cp custom-bundle.Dockerfile custom-bundle.Dockerfile.pinned
+#loop over each openstack-k8s-operators go.mod entry
+for X in $(go list -m -json all | jq -r '. | select(.Path | contains("openstack")) | "\(.Path)=\(.Version)"'); do
+  #example: github.com/openstack-k8s-operators/placement-operator/api=v0.0.0-20221007105015-13dce7450573
+  BASE=$(echo $X | sed -e 's|github.com/openstack-k8s-operators/\([^-\)]*\).*|\1|')
+  REF=$(echo $X | sed -e 's|github.com/[^\=]*=v0.0.0-[0-9]*-\(.*\)$|\1|')
+  #echo "BASE: $BASE REF: $REF"
+  if  ! echo "$BASE" | grep -e "lib" -e "openstack" &> /dev/null; then
+      #SHA=$(curl -s -H 'Accept: application/vnd.github+json' -H "Authorization: Bearer <YOUR-TOKEN>" \
+            #https://api.github.com/repos/openstack-k8s-operators/$BASE/commits/$REF | jq -r .sha)
+      SHA=$(curl -s https://quay.io/api/v1/repository/openstack-k8s-operators/$BASE-operator-bundle/tag/ \
+            | jq -r .tags[].name | grep $REF)
+      #echo "SHA: $SHA"
+      sed -i custom-bundle.Dockerfile.pinned -e "s|FROM quay.io/openstack-k8s-operators/${BASE}-operator-bundle.*|FROM quay.io/openstack-k8s-operators/${BASE}-operator-bundle:$SHA as ${BASE}-bundle|"
+  fi
+done

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "dependencyDashboard": true,
+  "includeForks": true,
+  "logFileLevel": "trace",
+  "enabledManagers": ["gomod"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["go"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["github.com/openstack-k8s-operators"],
+      "enabled": true
+    },
+    {
+      "excludePackagePatterns": [
+        "^github.com/openstack-k8s-operators"
+      ],
+      "extends": ["schedule:monthly"],
+      "groupName": "deps"
+    }
+  ]
+}


### PR DESCRIPTION
This adds a workflow to run the renovate github action periodically (every 30 minutes).

The renovate config file is configured to update
openstack-k8s-operators as soon as an update is detected. And once a month it will attempt a general dependency update for the go.mod.

Additionally, a new pin-custom-bundle-dockerfile.sh is wired into the Makefiles 'bundle' target to pin
the respective openstack bundle images to the
commit tag referenced in go.mod for that operator.

This should help prevent our artifacts from getting out of sync with the :latest tagged bundles.

NOTE: Renovate supports a postUpgradeTasks but I choose note to use them as they require "self hosting".