### PR TITLE
Drop make-operator-lint from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,6 @@ repos:
       entry: make
       args: ['generate']
       pass_filenames: false
-    - id: make-operator-lint
-      name: make-operator-lint
-      language: system
-      entry: make
-      args: ['operator-lint']
-      pass_filenames: false
 
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1


### PR DESCRIPTION
This make target doesn't exist here