### PR TITLE
Return immediately after status initialization

### DIFF
--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -126,9 +126,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 		instance.Status.Conditions.Init(&cl)
 
 		// Register overall status immediately to have an early feedback e.g. in the cli
-		if err := r.Status().Update(ctx, instance); err != nil {
-			return ctrl.Result{}, err
-		}
+		return ctrl.Result{}, r.Status().Update(ctx, instance)
 	}
 
 	helper, err := helper.NewHelper(


### PR DESCRIPTION
Whenever we call `Update` for a CR, we should end the current reconciliation and return immediately to avoid potentially losing the change in the next reconcile loop due to a race condition described in [1].  This pattern should be repeated across all our operators.

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/1#discussion_r997014701