### PR TITLE
Remove py3.9 env enforcement from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,3 @@
-# required for automated CI to pass
-default_language_version:
-    python: python3.9
-
 repos:
 - repo: local
   hooks:

--- a/containers/ci/Dockerfile
+++ b/containers/ci/Dockerfile
@@ -1,4 +1,4 @@
 FROM src
 RUN yum update -y && yum install -y python39 python39-pip
-RUN rm /usr/bin/python3 && ln -ns /usr/bin/python3.9 /usr/bin/python3
+RUN alternatives --set python3 /usr/bin/python3.9
 RUN pip3 install pre-commit


### PR DESCRIPTION
pre-commit works with >=python3.7 so we should not need to pin it to python 3.9 in .pre-commit-config.yaml. Instead this patch fixes the CI container to properly set python3.9 as the default interpreter in the container (instead of 3.6) so that pre-commit could work in the container.