### PR TITLE
Configure renovate to run go mod tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "includeForks": true,
   "logFileLevel": "trace",
   "enabledManagers": ["gomod"],
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
       "matchPackageNames": ["go"],


### PR DESCRIPTION
This should configure renovate to run go mod tidy before updating a PR.