### PR TITLE
Bump OVN/OVS operators

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -21069,11 +21069,19 @@ spec:
                             of OVNDBCluster
                           properties:
                             containerImage:
+                              default: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
                               type: string
                             dbType:
+                              default: NB
                               description: DBType - NB or SB
                               pattern: ^NB|SB$
                               type: string
+                            electionTimer:
+                              default: 10000
+                              description: OVN Northbound and Southbound RAFT db election
+                                timer to use on db creation (in milliseconds)
+                              format: int32
+                              type: integer
                             logLevel:
                               default: info
                               description: LogLevel - Set log level info, dbg, emer
@@ -21085,11 +21093,17 @@ spec:
                               description: NodeSelector to target subset of worker
                                 nodes running this service
                               type: object
+                            probeIntervalToActive:
+                              default: 60000
+                              description: Active probe interval from standby to active
+                                ovsdb-server remote
+                              format: int32
+                              type: integer
                             replicas:
                               default: 1
                               description: Replicas of OVN DBCluster to run
                               format: int32
-                              maximum: 1
+                              maximum: 32
                               minimum: 0
                               type: integer
                             resources:
@@ -21138,6 +21152,7 @@ spec:
                           OVNNorthd service
                         properties:
                           containerImage:
+                            default: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
                             type: string
                           logLevel:
                             default: info
@@ -21209,12 +21224,16 @@ spec:
                           ovn-bridge:
                             type: string
                           ovn-encap-type:
+                            default: geneve
+                            description: OvnEncapType - geneve or vxlan
+                            enum:
+                            - geneve
+                            - vxlan
                             type: string
                           system-id:
                             type: string
                         required:
                         - ovn-bridge
-                        - ovn-encap-type
                         - system-id
                         type: object
                       nic_mappings:

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20221122141723-fb7400f56094
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20221130112258-2d20ea7691aa
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961
-	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c
+	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221221115413-9ba4de3f172e
 	github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20221202142822-366b98894af3
 	github.com/rabbitmq/cluster-operator v1.14.0
 	k8s.io/apimachinery v0.26.0
@@ -48,7 +48,7 @@ require (
 	github.com/openshift/api v3.9.0+incompatible // indirect
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220915080953-f73a201a1da6 // indirect
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20221212162305-ec57ccd85ad5
-	github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221205134225-c415d98c0182
+	github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221221132409-30464f27d7d5
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -244,8 +244,12 @@ github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b
 github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961/go.mod h1:qEa87SbpolzOQFfHv8hozFkSrJ8GGL8o2HTJjn3tZzg=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c h1:ULUSB+ps6BRCeoZzUTcFFEeYQEKMUlKenhEpRZQ81Lg=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c/go.mod h1:w9jM6WK5YUPSHgChU/mYjlf83ae+ZP7GGI888ToureE=
+github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221221115413-9ba4de3f172e h1:RpLlXVuh8+xy2JPeRpZEoCyvqc+Q+Ss8nduitKTFgEI=
+github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221221115413-9ba4de3f172e/go.mod h1:GUQ966Lr4rg+XnIYlYO+YX+rMg7OmNzYYvDk4uSIQVU=
 github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221205134225-c415d98c0182 h1:3PsL+M7w7Ptrjk/HvI7cQEy2R79lJU6SPeiL6PBncVc=
 github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221205134225-c415d98c0182/go.mod h1:kOSfN6hCA1gQfQW4gdDPU+p/t63Oj5gEJhTnRl0LGio=
+github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221221132409-30464f27d7d5 h1:0iyz7m9hHk4Sr7Li2zxUXQiPJaqW9CmcQYyhDT2SzrM=
+github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221221132409-30464f27d7d5/go.mod h1:kOSfN6hCA1gQfQW4gdDPU+p/t63Oj5gEJhTnRl0LGio=
 github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20221202142822-366b98894af3 h1:cQswripcSiZN6J9WfN6xROxkQoVkxfLMjgsAQ9AqtsM=
 github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20221202142822-366b98894af3/go.mod h1:TCDHEsJXXK7L4U1xfT44dZh5N1YH5LR6AzoVvOS15E4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -21069,11 +21069,19 @@ spec:
                             of OVNDBCluster
                           properties:
                             containerImage:
+                              default: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
                               type: string
                             dbType:
+                              default: NB
                               description: DBType - NB or SB
                               pattern: ^NB|SB$
                               type: string
+                            electionTimer:
+                              default: 10000
+                              description: OVN Northbound and Southbound RAFT db election
+                                timer to use on db creation (in milliseconds)
+                              format: int32
+                              type: integer
                             logLevel:
                               default: info
                               description: LogLevel - Set log level info, dbg, emer
@@ -21085,11 +21093,17 @@ spec:
                               description: NodeSelector to target subset of worker
                                 nodes running this service
                               type: object
+                            probeIntervalToActive:
+                              default: 60000
+                              description: Active probe interval from standby to active
+                                ovsdb-server remote
+                              format: int32
+                              type: integer
                             replicas:
                               default: 1
                               description: Replicas of OVN DBCluster to run
                               format: int32
-                              maximum: 1
+                              maximum: 32
                               minimum: 0
                               type: integer
                             resources:
@@ -21138,6 +21152,7 @@ spec:
                           OVNNorthd service
                         properties:
                           containerImage:
+                            default: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
                             type: string
                           logLevel:
                             default: info
@@ -21209,12 +21224,16 @@ spec:
                           ovn-bridge:
                             type: string
                           ovn-encap-type:
+                            default: geneve
+                            description: OvnEncapType - geneve or vxlan
+                            enum:
+                            - geneve
+                            - vxlan
                             type: string
                           system-id:
                             type: string
                         required:
                         - ovn-bridge
-                        - ovn-encap-type
                         - system-id
                         type: object
                       nic_mappings:

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20221130112258-2d20ea7691aa
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20221107090218-8d63dba1ec13
-	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c
-	github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221205134225-c415d98c0182
+	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221221115413-9ba4de3f172e
+	github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221221132409-30464f27d7d5
 	github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20221202142822-366b98894af3
 	github.com/operator-framework/api v0.17.1
 	github.com/rabbitmq/cluster-operator v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,12 @@ github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b
 github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961/go.mod h1:qEa87SbpolzOQFfHv8hozFkSrJ8GGL8o2HTJjn3tZzg=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c h1:ULUSB+ps6BRCeoZzUTcFFEeYQEKMUlKenhEpRZQ81Lg=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c/go.mod h1:w9jM6WK5YUPSHgChU/mYjlf83ae+ZP7GGI888ToureE=
+github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221221115413-9ba4de3f172e h1:RpLlXVuh8+xy2JPeRpZEoCyvqc+Q+Ss8nduitKTFgEI=
+github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221221115413-9ba4de3f172e/go.mod h1:GUQ966Lr4rg+XnIYlYO+YX+rMg7OmNzYYvDk4uSIQVU=
 github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221205134225-c415d98c0182 h1:3PsL+M7w7Ptrjk/HvI7cQEy2R79lJU6SPeiL6PBncVc=
 github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221205134225-c415d98c0182/go.mod h1:kOSfN6hCA1gQfQW4gdDPU+p/t63Oj5gEJhTnRl0LGio=
+github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221221132409-30464f27d7d5 h1:0iyz7m9hHk4Sr7Li2zxUXQiPJaqW9CmcQYyhDT2SzrM=
+github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221221132409-30464f27d7d5/go.mod h1:kOSfN6hCA1gQfQW4gdDPU+p/t63Oj5gEJhTnRl0LGio=
 github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20221202142822-366b98894af3 h1:cQswripcSiZN6J9WfN6xROxkQoVkxfLMjgsAQ9AqtsM=
 github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20221202142822-366b98894af3/go.mod h1:TCDHEsJXXK7L4U1xfT44dZh5N1YH5LR6AzoVvOS15E4=
 github.com/operator-framework/api v0.17.1 h1:J/6+Xj4IEV8C7hcirqUFwOiZAU3PbnJhWvB0/bB51c4=


### PR DESCRIPTION
This should work around recent "Unsupported value: \"geneve,vxlan\": supported values: \"geneve\", \"vxlan\""}" issues when reconciling the OpenStackControlPlane resource.