### PR TITLE
workflow rename, disable cron

### DIFF
--- a/.github/workflows/build-openstack-operator.yaml
+++ b/.github/workflows/build-openstack-operator.yaml
@@ -1,8 +1,6 @@
 name: OpenStack Operator image builder
 
 on:
-  schedule:
-    - cron:  '55 * * * *'
   push:
     branches:
       - '*'

--- a/.github/workflows/release-openstack-operator.yaml
+++ b/.github/workflows/release-openstack-operator.yaml
@@ -1,4 +1,4 @@
-name: Release Keystone Operator
+name: Release OpenStack Operator
 
 on:
   release:


### PR DESCRIPTION
Renames the release workflow to 'OpenStack Operator'

Also, Disables cron builds on the build. Now that we are pinning this should no longer be required.