### PR TITLE
Add missing Cinder status considerations

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -278,6 +278,6 @@ func (instance OpenStackControlPlane) IsReady() bool {
 		instance.Status.Conditions.IsTrue(OpenStackControlPlaneMariaDBReadyCondition) &&
 		instance.Status.Conditions.IsTrue(OpenStackControlPlaneKeystoneAPIReadyCondition) &&
 		instance.Status.Conditions.IsTrue(OpenStackControlPlanePlacementAPIReadyCondition) &&
-		instance.Status.Conditions.IsTrue(OpenStackControlPlaneGlanceReadyCondition)
-	// TODO add once rabbitmq transportURL is integrated with Cinder:instance.Status.Conditions.IsTrue(OpenStackControlPlaneCinderReadyCondition)
+		instance.Status.Conditions.IsTrue(OpenStackControlPlaneGlanceReadyCondition) &&
+		instance.Status.Conditions.IsTrue(OpenStackControlPlaneCinderReadyCondition)
 }

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -148,7 +148,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 			condition.UnknownCondition(corev1beta1.OpenStackControlPlaneKeystoneAPIReadyCondition, condition.InitReason, corev1beta1.OpenStackControlPlaneKeystoneAPIReadyInitMessage),
 			condition.UnknownCondition(corev1beta1.OpenStackControlPlanePlacementAPIReadyCondition, condition.InitReason, corev1beta1.OpenStackControlPlanePlacementAPIReadyInitMessage),
 			condition.UnknownCondition(corev1beta1.OpenStackControlPlaneGlanceReadyCondition, condition.InitReason, corev1beta1.OpenStackControlPlaneGlanceReadyInitMessage),
-			// TODO add once rabbitmq transportURL is integrated with Cinder: condition.UnknownCondition(corev1beta1.OpenStackControlPlaneCinderReadyCondition, condition.InitReason, corev1beta1.OpenStackControlPlaneCinderReadyInitMessage),
+			condition.UnknownCondition(corev1beta1.OpenStackControlPlaneCinderReadyCondition, condition.InitReason, corev1beta1.OpenStackControlPlaneCinderReadyInitMessage),
 			condition.UnknownCondition(corev1beta1.OpenStackControlPlaneNovaReadyCondition, condition.InitReason, corev1beta1.OpenStackControlPlaneNovaReadyInitMessage),
 		)
 

--- a/pkg/openstack/cinder.go
+++ b/pkg/openstack/cinder.go
@@ -76,16 +76,15 @@ func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControl
 		helper.GetLogger().Info(fmt.Sprintf("Cinder %s - %s", cinder.Name, op))
 	}
 
-	// TODO add once rabbitmq transportURL is integrated with Cinder
-	// if cinder.IsReady() {
-	// 	instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneCinderReadyCondition, corev1beta1.OpenStackControlPlaneCinderReadyMessage)
-	// } else {
-	// 	instance.Status.Conditions.Set(condition.FalseCondition(
-	// 		corev1beta1.OpenStackControlPlaneCinderReadyCondition,
-	// 		condition.RequestedReason,
-	// 		condition.SeverityInfo,
-	// 		corev1beta1.OpenStackControlPlaneCinderReadyRunningMessage))
-	// }
+	if cinder.IsReady() {
+		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneCinderReadyCondition, corev1beta1.OpenStackControlPlaneCinderReadyMessage)
+	} else {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			corev1beta1.OpenStackControlPlaneCinderReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			corev1beta1.OpenStackControlPlaneCinderReadyRunningMessage))
+	}
 
 	return ctrl.Result{}, nil
 


### PR DESCRIPTION
Now that Cinder is using `TransportURL`, we can add the missing Cinder status checks to the overall `OsControlPlane` status