### PR TITLE
Bump nova-operator to latest to get nova-scheduler

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -20532,7 +20532,7 @@ spec:
                         type: string
                       apiServiceTemplate:
                         default:
-                          containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+                          replicas: 1
                         description: APIServiceTemplate - define the nova-api service
                         properties:
                           containerImage:
@@ -20973,6 +20973,8 @@ spec:
                             type: string
                         type: object
                       schedulerServiceTemplate:
+                        default:
+                          replicas: 1
                         description: SchedulerServiceTemplate- define the nova-scheduler
                           service
                         properties:

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230110110231-28368fe6a6a9
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20221122141723-fb7400f56094
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20221130112258-2d20ea7691aa
-	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961
+	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230113165055-b0e3f90e8b15
 	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c
 	github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20221202142822-366b98894af3
 	github.com/rabbitmq/cluster-operator v1.14.0

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -240,8 +240,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20221122141723-fb
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20221122141723-fb7400f56094/go.mod h1:HiEKXmDSJ6Gl+pN7kK5CX1sgOjrxybux4Ob5pdUim1M=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20221130112258-2d20ea7691aa h1:FnxmhZiGNe4DI1hCuNkmZRZnREfn+bGLg9gcSkvjkzM=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20221130112258-2d20ea7691aa/go.mod h1:/xWUdBibmicmdVia5K+WsEK6thKB6ql+cUy3xXnZvvQ=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961 h1:91Zb8hc4UD+1CQDKK6we2LTGysrJBQk7peT1jVjLbC8=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961/go.mod h1:qEa87SbpolzOQFfHv8hozFkSrJ8GGL8o2HTJjn3tZzg=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230113165055-b0e3f90e8b15 h1:esUc5a/6m5KzLqrY3eVnOugeDUqCclqw3i2rQpeGDxk=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230113165055-b0e3f90e8b15/go.mod h1:dX6U4Fzwm+tsCgfzDf9bvh3BJDs//RiWKFu2WNSnwdY=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c h1:ULUSB+ps6BRCeoZzUTcFFEeYQEKMUlKenhEpRZQ81Lg=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c/go.mod h1:w9jM6WK5YUPSHgChU/mYjlf83ae+ZP7GGI888ToureE=
 github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221221132409-30464f27d7d5 h1:0iyz7m9hHk4Sr7Li2zxUXQiPJaqW9CmcQYyhDT2SzrM=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -20532,7 +20532,7 @@ spec:
                         type: string
                       apiServiceTemplate:
                         default:
-                          containerImage: quay.io/tripleozedcentos9/openstack-nova-api:current-tripleo
+                          replicas: 1
                         description: APIServiceTemplate - define the nova-api service
                         properties:
                           containerImage:
@@ -20973,6 +20973,8 @@ spec:
                             type: string
                         type: object
                       schedulerServiceTemplate:
+                        default:
+                          replicas: 1
                         description: SchedulerServiceTemplate- define the nova-scheduler
                           service
                         properties:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230110110231-28368fe6a6a9
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20221122141723-fb7400f56094
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20221130112258-2d20ea7691aa
-	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961
+	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230113165055-b0e3f90e8b15
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20221107090218-8d63dba1ec13
 	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c
 	github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221221132409-30464f27d7d5

--- a/go.sum
+++ b/go.sum
@@ -302,8 +302,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20221122141723-fb
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20221122141723-fb7400f56094/go.mod h1:HiEKXmDSJ6Gl+pN7kK5CX1sgOjrxybux4Ob5pdUim1M=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20221130112258-2d20ea7691aa h1:FnxmhZiGNe4DI1hCuNkmZRZnREfn+bGLg9gcSkvjkzM=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20221130112258-2d20ea7691aa/go.mod h1:/xWUdBibmicmdVia5K+WsEK6thKB6ql+cUy3xXnZvvQ=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961 h1:91Zb8hc4UD+1CQDKK6we2LTGysrJBQk7peT1jVjLbC8=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20221209164002-f9e6b9363961/go.mod h1:qEa87SbpolzOQFfHv8hozFkSrJ8GGL8o2HTJjn3tZzg=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230113165055-b0e3f90e8b15 h1:esUc5a/6m5KzLqrY3eVnOugeDUqCclqw3i2rQpeGDxk=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230113165055-b0e3f90e8b15/go.mod h1:dX6U4Fzwm+tsCgfzDf9bvh3BJDs//RiWKFu2WNSnwdY=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c h1:ULUSB+ps6BRCeoZzUTcFFEeYQEKMUlKenhEpRZQ81Lg=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221130085454-49cd8b9c841c/go.mod h1:w9jM6WK5YUPSHgChU/mYjlf83ae+ZP7GGI888ToureE=
 github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20221221132409-30464f27d7d5 h1:0iyz7m9hHk4Sr7Li2zxUXQiPJaqW9CmcQYyhDT2SzrM=


### PR DESCRIPTION
The nova-operator now merged support for deploying the nova-scheduler service. This patch bumps the nova-operator version embedded in the openstack-operator to get the nova-scheduler support.