### PR TITLE
allow customize operator bundle based on go mod replace config

### DIFF
--- a/.github/workflows/build-openstack-operator.yaml
+++ b/.github/workflows/build-openstack-operator.yaml
@@ -117,6 +117,7 @@ jobs:
         REGISTRY:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
         GITHUB_SHA: ${{ github.sha }}
         BASE_IMAGE: openstack-operator
+        IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE || secrets.QUAY_USERNAME }}
 
     - name: Get branch name
       id: branch-name
@@ -134,9 +135,9 @@ jobs:
         image: openstack-operator-bundle
         tags: ${{ env.latesttag }} ${{ github.sha }}
         containerfiles: |
-          ./custom-bundle.Dockerfile
+          ./custom-bundle.Dockerfile.pinned
 
-    - name: Push openstack-operator To ${{ env.imageregistry }}
+    - name: Push openstack-operator-bundle To ${{ env.imageregistry }}
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-openstack-operator-bundle.outputs.image }}

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # openstack.org/openstack-operator-bundle:$VERSION and openstack.org/openstack-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= openstack.org/openstack-operator
+IMAGE_TAG_BASE ?= quay.io/$(USER)/openstack-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/hack/pin-custom-bundle-dockerfile.sh
+++ b/hack/pin-custom-bundle-dockerfile.sh
@@ -1,14 +1,31 @@
 #!/bin/bash
-set -e
+set -ex
+
+IMAGENAMESPACE=${IMAGENAMESPACE:-"openstack-k8s-operators"}
+
 cp custom-bundle.Dockerfile custom-bundle.Dockerfile.pinned
+
 #loop over each openstack-k8s-operators go.mod entry
-for X in $(go list -m -json all | jq -r '. | select(.Path | contains("openstack")) | "\(.Path)=\(.Version)"'); do
-  #example: github.com/openstack-k8s-operators/placement-operator/api=v0.0.0-20221007105015-13dce7450573
-  BASE=$(echo $X | sed -e 's|github.com/openstack-k8s-operators/\([^-\)]*\).*|\1|')
-  REF=$(echo $X | sed -e 's|github.com/[^\=]*=v0.0.0-[0-9]*-\(.*\)$|\1|')
-  if  ! echo "$BASE" | grep -e "lib" -e "openstack" &> /dev/null; then
-      SHA=$(curl -s https://quay.io/api/v1/repository/openstack-k8s-operators/$BASE-operator-bundle/tag/ \
-            | jq -r .tags[].name | grep $REF)
-      sed -i custom-bundle.Dockerfile.pinned -e "s|FROM quay.io/openstack-k8s-operators/${BASE}-operator-bundle.*|FROM quay.io/openstack-k8s-operators/${BASE}-operator-bundle:$SHA as ${BASE}-bundle|"
+for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("openstack")) | .Replace // . |.Path' | grep -v apis | grep -v openstack-operator | grep -v lib-common); do
+  MOD_VERSION=$(go list -m -json all | jq -r ". | select(.Path | contains(\"openstack\")) | .Replace // . | select( .Path == \"$MOD_PATH\") | .Version")
+
+  BASE=$(echo $MOD_PATH | sed -e 's|github.com/.*/\(.*\)-operator/.*|\1|')
+
+  REF=$(echo $MOD_VERSION | sed -e 's|v0.0.0-[0-9]*-\(.*\)$|\1|')
+  GITHUB_USER=$(echo $MOD_PATH | sed -e 's|github.com/\(.*\)/.*-operator/.*$|\1|')
+  REPO_CURL_URL="https://quay.io/api/v1/repository/openstack-k8s-operators"
+  REPO_URL="quay.io/openstack-k8s-operators"
+  if [[ "$GITHUB_USER" != "openstack-k8s-operators" ]]; then
+      if [[ "$IMAGENAMESPACE" != "openstack-k8s-operators" ]]; then
+          REPO_CURL_URL="https://quay.io/api/v1/repository/${IMAGENAMESPACE}"
+          REPO_URL="quay.io/${IMAGENAMESPACE}"
+      else
+          REPO_CURL_URL="https://quay.io/api/v1/repository/${GITHUB_USER}"
+          REPO_URL="quay.io/${GITHUB_USER}"
+      fi
   fi
+
+  SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/ \
+        | jq -r .tags[].name | grep $REF)
+  sed -i custom-bundle.Dockerfile.pinned -e "s|FROM quay.io/openstack-k8s-operators/${BASE}-operator-bundle.*|FROM ${REPO_URL}/${BASE}-operator-bundle:$SHA as ${BASE}-bundle|"
 done


### PR DESCRIPTION
This allows to create an openstack-operator with custom service operators using replace in the go.mod file for their api module, e.g.:

~~~
replace github.com/openstack-k8s-operators/mariadb-operator/api => github.com/stuggi/mariadb-operator/api v0.0.0-20230113120129-b3b6d6e85204
replace github.com/openstack-k8s-operators/keystone-operator/api => github.com/stuggi/keystone-operator/api v0.0.0-20230116073528-591f93f2d79b
replace github.com/openstack-k8s-operators/glance-operator/api => github.com/stuggi/glance-operator/api v0.0.0-20230116073804-451079f4080a
replace github.com/openstack-k8s-operators/placement-operator/api => github.com/stuggi/placement-operator/api v0.0.0-20230113140343-73a05604990f
replace github.com/openstack-k8s-operators/cinder-operator/api => github.com/stuggi/cinder-operator/api v0.0.0-20230113140039-6ae6be6a231c
replace github.com/openstack-k8s-operators/neutron-operator/api => github.com/stuggi/neutron-operator/api v0.0.0-20230113142342-381d8b17506a
replace github.com/openstack-k8s-operators/ovn-operator/api => github.com/stuggi/ovn-operator/api v0.0.0-20230113130937-bddfc177d566
~~~

This is helpful if you want to test changed to multiple operators and integrate them into the openstack-operator. This also works with the auto build process when the ENV vars are set correct on the repo in the fork. If the quay user does not match the github one, set IMAGENAMESPACE.