### PR TITLE
Skip already customized operator bundle images

### DIFF
--- a/hack/pin-custom-bundle-dockerfile.sh
+++ b/hack/pin-custom-bundle-dockerfile.sh
@@ -11,6 +11,12 @@ for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("ope
 
   BASE=$(echo $MOD_PATH | sed -e 's|github.com/.*/\(.*\)-operator/.*|\1|')
 
+  SRC_BUNDLE=("FROM quay.io/openstack-k8s-operators/${BASE}-operator-bundle.*")
+  if [[ "$( grep -o "${SRC_BUNDLE[@]}" custom-bundle.Dockerfile.pinned | wc -l )" -eq "0" ]]; then
+    # there is nothing to be replaced on custom-bundle.Dockerfile.pinned
+    continue
+  fi
+
   REF=$(echo $MOD_VERSION | sed -e 's|v0.0.0-[0-9]*-\(.*\)$|\1|')
   GITHUB_USER=$(echo $MOD_PATH | sed -e 's|github.com/\(.*\)/.*-operator/.*$|\1|')
   REPO_CURL_URL="https://quay.io/api/v1/repository/openstack-k8s-operators"


### PR DESCRIPTION
This patch adds a condition to verify if a operator bundle image needs to be updated or not.
The following scenario is broken in current version of the script, and is the workflow that will be used on CI:
1. A PR to *-operator is proposed
2. Job runs and build operator, bundle and catalog images.
3. Images are pushed to CI registry.
4. openstack-operator go.mod is updated with new api reference
5. custom-bundle.Dockerfile is modified to point to CI operator bundle image
6. Job builds openstack-operator images, and push to CI registry
7. Deploy steps validates openstack-operator image

When generating openstack-operator bundle, it fails to find the bundle image on user's quay.io account.

The new condition ignores bundle images that were already modified.