### PR TITLE
[sample]Deploy nova with collapsed cells

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_cell_separation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_cell_separation.yaml
@@ -1,7 +1,7 @@
 apiVersion: core.openstack.org/v1beta1
 kind: OpenStackControlPlane
 metadata:
-  name: openstack
+  name: openstack-cell-separation
 spec:
   secret: osp-secret
   storageClass: local-storage
@@ -25,6 +25,8 @@ spec:
         #  limits:
         #    cpu: 800m
         #    memory: 1Gi
+      rabbitmq-cell1:
+        replicas: 1
   placement:
     template:
       databaseInstance: openstack
@@ -87,20 +89,11 @@ spec:
   nova:
     template:
       secret: osp-secret
-      # This creates a collapsed cell deployment same as what OSP17 does by
-      # default. The conductor in cell1 acts as both the cell conductor and the
-      # super conductor hence cell0 conductor is disabled. Also in this
-      # deployment both the top level services and cell1 service will share the
-      # same message bus and database service instance so there is no cell
-      # separation implemented.
       cellTemplates:
           cell0:
             cellDatabaseUser: nova_cell0
-            conductorServiceTemplate:
-              replicas: 0
             hasAPIAccess: true
           cell1:
             cellDatabaseUser: nova_cell1
-            conductorServiceTemplate:
-              replicas: 1
+            cellMessageBusInstance: rabbitmq-cell1
             hasAPIAccess: true

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,6 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - core_v1beta1_openstackcontrolplane.yaml
+- core_v1beta1_openstackcontrolplane_cell_separation.yaml
 - rabbitmq_v1beta1_transporturl.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
In preparation to switch nova to deploy a proper cell setup by default this patch changes the default OpenStackControlPlane sample in this repo to use a collapsed cell setup. The collapsed cell setup uses a single RabbitMQCluster for both the top level nova services and the cell1 services and disables the nova-conductor service in cell0. The cell1 conductor will have access to the API DB and use the common RabbitMQ so it will act both as a super-conductor and as the cell1 conductor. This is the same how tripleoo deploys nova by default. However this means no real cell separation.

To allow NovaConductor to reach Ready in cell0 with the collapsed cell setup we need the fix https://github.com/openstack-k8s-operators/nova-operator/pull/241 so this patch bump the nova-operator/api dependency version to the latest one that has that fix.

This patch also adds a new sample that configures OpenStackControlPlane with two RabbitMQClusters and configure nova that the top level services uses the common message bus while cell1 use a dedicated message bus to achieve cell separation.

Depends-On: https://github.com/openstack-k8s-operators/nova-operator/pull/241 (merged)
Depends-On: #157 (merged)