### PR TITLE
[sample]Cleanup cell separation

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_cell_separation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_cell_separation.yaml
@@ -89,11 +89,3 @@ spec:
   nova:
     template:
       secret: osp-secret
-      cellTemplates:
-          cell0:
-            cellDatabaseUser: nova_cell0
-            hasAPIAccess: true
-          cell1:
-            cellDatabaseUser: nova_cell1
-            cellMessageBusInstance: rabbitmq-cell1
-            hasAPIAccess: true


### PR DESCRIPTION
Now that nova switched to cell separation by default the cell separation sample file can be cleaned up to contain only the necessary information and default the rest.

Depends-On: https://github.com/openstack-k8s-operators/nova-operator/pull/242 (merged)
Depends-On: #158 (merged)