### PR TITLE
Add IMAGEREGISTRY var to pin-custom-bundle-dockerfile

### DIFF
--- a/hack/pin-custom-bundle-dockerfile.sh
+++ b/hack/pin-custom-bundle-dockerfile.sh
@@ -2,6 +2,8 @@
 set -ex
 
 IMAGENAMESPACE=${IMAGENAMESPACE:-"openstack-k8s-operators"}
+IMAGEREGISTRY=${IMAGEREGISTRY:-"quay.io"}
+
 
 cp custom-bundle.Dockerfile custom-bundle.Dockerfile.pinned
 
@@ -11,20 +13,14 @@ for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("ope
 
   BASE=$(echo $MOD_PATH | sed -e 's|github.com/.*/\(.*\)-operator/.*|\1|')
 
-  SRC_BUNDLE=("FROM quay.io/openstack-k8s-operators/${BASE}-operator-bundle.*")
-  if [[ "$( grep -o "${SRC_BUNDLE[@]}" custom-bundle.Dockerfile.pinned | wc -l )" -eq "0" ]]; then
-    # there is nothing to be replaced on custom-bundle.Dockerfile.pinned
-    continue
-  fi
-
   REF=$(echo $MOD_VERSION | sed -e 's|v0.0.0-[0-9]*-\(.*\)$|\1|')
   GITHUB_USER=$(echo $MOD_PATH | sed -e 's|github.com/\(.*\)/.*-operator/.*$|\1|')
   REPO_CURL_URL="https://quay.io/api/v1/repository/openstack-k8s-operators"
   REPO_URL="quay.io/openstack-k8s-operators"
   if [[ "$GITHUB_USER" != "openstack-k8s-operators" ]]; then
-      if [[ "$IMAGENAMESPACE" != "openstack-k8s-operators" ]]; then
-          REPO_CURL_URL="https://quay.io/api/v1/repository/${IMAGENAMESPACE}"
-          REPO_URL="quay.io/${IMAGENAMESPACE}"
+      if [[ "$IMAGENAMESPACE" != "openstack-k8s-operators" || "${IMAGEREGISTRY}" != "quay.io" ]]; then
+          REPO_CURL_URL="https://${IMAGEREGISTRY}/api/v1/repository/${IMAGENAMESPACE}"
+          REPO_URL="${IMAGEREGISTRY}/${IMAGENAMESPACE}"
       else
           REPO_CURL_URL="https://quay.io/api/v1/repository/${GITHUB_USER}"
           REPO_URL="quay.io/${GITHUB_USER}"


### PR DESCRIPTION
This patch adds IMAGEREGISTRY var to pin-custom-bundle-dockerfile.sh to solve the issue with user's image available in a different registry and namespace. IMAGENAMESPACE already allows us to customize namespace.
With this new var we don´t need the previous workaround[1] to skip customized content added to custom-bundle.Dockerfile.

[1] https://github.com/openstack-k8s-operators/openstack-operator/commit/dff94253689ca6b3f77db8d0dbbd9d3d5eb6afbf