### PR TITLE
Use cell separation by default

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -25,6 +25,8 @@ spec:
         #  limits:
         #    cpu: 800m
         #    memory: 1Gi
+      rabbitmq-cell1:
+        replicas: 1
   placement:
     template:
       databaseInstance: openstack
@@ -87,20 +89,3 @@ spec:
   nova:
     template:
       secret: osp-secret
-      # This creates a collapsed cell deployment same as what OSP17 does by
-      # default. The conductor in cell1 acts as both the cell conductor and the
-      # super conductor hence cell0 conductor is disabled. Also in this
-      # deployment both the top level services and cell1 service will share the
-      # same message bus and database service instance so there is no cell
-      # separation implemented.
-      cellTemplates:
-          cell0:
-            cellDatabaseUser: nova_cell0
-            conductorServiceTemplate:
-              replicas: 0
-            hasAPIAccess: true
-          cell1:
-            cellDatabaseUser: nova_cell1
-            conductorServiceTemplate:
-              replicas: 1
-            hasAPIAccess: true

--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -1,7 +1,7 @@
 apiVersion: core.openstack.org/v1beta1
 kind: OpenStackControlPlane
 metadata:
-  name: openstack-cell-separation
+  name: openstack-collapsed-cell
 spec:
   secret: osp-secret
   storageClass: local-storage
@@ -25,8 +25,6 @@ spec:
         #  limits:
         #    cpu: 800m
         #    memory: 1Gi
-      rabbitmq-cell1:
-        replicas: 1
   placement:
     template:
       databaseInstance: openstack
@@ -89,11 +87,20 @@ spec:
   nova:
     template:
       secret: osp-secret
+      # This creates a collapsed cell deployment same as what OSP17 does by
+      # default. The conductor in cell1 acts as both the cell conductor and the
+      # super conductor hence cell0 conductor is disabled. Also in this
+      # deployment both the top level services and cell1 service will share the
+      # same message bus and database service instance so there is no cell
+      # separation implemented.
       cellTemplates:
           cell0:
             cellDatabaseUser: nova_cell0
+            conductorServiceTemplate:
+              replicas: 0
             hasAPIAccess: true
           cell1:
             cellDatabaseUser: nova_cell1
-            cellMessageBusInstance: rabbitmq-cell1
+            conductorServiceTemplate:
+              replicas: 1
             hasAPIAccess: true

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,5 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - core_v1beta1_openstackcontrolplane.yaml
-- core_v1beta1_openstackcontrolplane_cell_separation.yaml
+- core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
As the intention is to use separate rabbitmq for each nova cells by default this patch switches the default OpenStackControlPlane sample to do so.

Note that this means one extra rabbitmq service is deployed. So it increases the resource usage of the deployment. I checked with CRC
```
 $ crc version
 CRC version: 2.13.1+b839ca8
 OpenShift version: 4.12.0
 Podman version: 4.3.1
```
Deploying the default sample is possible with a CRC VM with 16G RAM. If you change the rabbitmq resource limits from 2Gi to 1Gi (or even 500Mi) then I believe it is possible to deploy the default sample with 14G RAM.