### PR TITLE
pin-custom-bundle-dockerfile.sh: avoid dup tags

### DIFF
--- a/hack/pin-custom-bundle-dockerfile.sh
+++ b/hack/pin-custom-bundle-dockerfile.sh
@@ -27,7 +27,6 @@ for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("ope
       fi
   fi
 
-  SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/ \
-        | jq -r .tags[].name | grep $REF)
+  SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/ | jq -r .tags[].name | sort -u | grep $REF)
   sed -i custom-bundle.Dockerfile.pinned -e "s|quay.io/openstack-k8s-operators/${BASE}-operator-bundle.*|${REPO_URL}/${BASE}-operator-bundle:$SHA|"
 done


### PR DESCRIPTION
This updates the hack/pin-custom-bundle-dockerfile.sh so it avoids duplicate tags which can get returned from quay.io in some situations.