### PR TITLE
Add sample with multiple MariaDB service

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_separate_cell_db.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_separate_cell_db.yaml
@@ -1,0 +1,121 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack-separate-cell-db
+spec:
+  secret: osp-secret
+  storageClass: local-storage
+  keystone:
+    template:
+      containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
+      databaseInstance: openstack
+      secret: osp-secret
+  mariadb:
+    templates:
+      openstack:
+        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+        storageRequest: 500M
+      openstack-cell1:
+        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+        storageRequest: 500M
+  rabbitmq:
+    templates:
+      rabbitmq:
+        replicas: 1
+        #resources:
+        #  requests:
+        #    cpu: 500m
+        #    memory: 1Gi
+        #  limits:
+        #    cpu: 800m
+        #    memory: 1Gi
+      rabbitmq-cell1:
+        replicas: 1
+  placement:
+    template:
+      databaseInstance: openstack
+      containerImage: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo
+      secret: osp-secret
+  glance:
+    template:
+      databaseInstance: openstack
+      containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+      storageClass: ""
+      storageRequest: 10G
+      glanceAPIInternal:
+        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+      glanceAPIExternal:
+        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  cinder:
+    template:
+      cinderAPI:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
+      cinderScheduler:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
+      cinderBackup:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
+      cinderVolumes:
+        volume1:
+          containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
+          replicas: 1
+  ovn:
+    template:
+      ovnDBCluster:
+        ovndbcluster-nb:
+          replicas: 1
+          containerImage: quay.io/tripleozedcentos9/openstack-ovn-nb-db-server:current-tripleo
+          dbType: NB
+          storageRequest: 10G
+        ovndbcluster-sb:
+          replicas: 1
+          containerImage: quay.io/tripleozedcentos9/openstack-ovn-sb-db-server:current-tripleo
+          dbType: SB
+          storageRequest: 10G
+      ovnNorthd:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-ovn-northd:current-tripleo
+  ovs:
+    template:
+      ovsContainerImage: "quay.io/skaplons/ovs:latest"
+      ovnContainerImage: "quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo"
+      external-ids:
+        system-id: "random"
+        ovn-bridge: "br-int"
+        ovn-encap-type: "geneve"
+  neutron:
+    template:
+      databaseInstance: openstack
+      containerImage: quay.io/tripleozedcentos9/openstack-neutron-server:current-tripleo
+      secret: osp-secret
+  nova:
+    template:
+      secret: osp-secret
+      cellTemplates:
+        cell0:
+          cellDatabaseUser: nova_cell0
+          cellDatabaseInstance: openstack
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseUser: nova_cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          hasAPIAccess: true
+  ironic:
+    template:
+      databaseInstance: openstack
+      ironicAPI:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+      ironicConductors:
+      - replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
+        pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+        storageRequest: 10G
+      ironicInspector:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
+        pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+      secret: osp-secret

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,4 +2,5 @@
 resources:
 - core_v1beta1_openstackcontrolplane.yaml
 - core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+- core_v1beta1_openstackcontrolplane_separate_cell_db.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
Now that OpenStackControlPlane supports defining deploying MariaDB services we can also deploy nova cells to use independent MariaDB services. This PR add a sample showing how to deploy NovaCell/cell1 to a separate DB service from the rest of the control plane.