### PR TITLE
Default Galera to enabled=false

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -13969,7 +13969,7 @@ spec:
                 description: Galera - Parameters related to the Galera services
                 properties:
                   enabled:
-                    default: true
+                    default: false
                     description: Enabled - Whether Galera services should be deployed
                       and managed
                     type: boolean

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -169,7 +169,7 @@ type MariadbSection struct {
 // GaleraSection defines the desired state of Galera services
 type GaleraSection struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=true
+	// +kubebuilder:default=false
 	// Enabled - Whether Galera services should be deployed and managed
 	Enabled bool `json:"enabled,omitempty"`
 

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -13969,7 +13969,7 @@ spec:
                 description: Galera - Parameters related to the Galera services
                 properties:
                   enabled:
-                    default: true
+                    default: false
                     description: Enabled - Whether Galera services should be deployed
                       and managed
                     type: boolean


### PR DESCRIPTION
The API processing treats boolean values set to `false` as if they are empty, so it triggers the kubebuilder `default` annotation to set it to `true`.  Doing so causes both MariaDB and Galera to be enabled, which hits a validation error.