### PR TITLE
Fix the config apply when deploying on KIND

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,7 @@
 ## Append samples you want in your CSV to this file as resources ##
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - core_v1beta1_openstackcontrolplane.yaml
 - core_v1beta1_openstackcontrolplane_collapsed_cell.yaml


### PR DESCRIPTION
By following the README instructions to run a cluster over KIND I faced the following error:

```
resource mapping not found for name: "openstack" namespace: "" from "config/samples/core_v1beta1_openstackcontrolplane.yaml": no matches for kind "OpenStackControlPlane" in version "core.openstack.org/v1beta1" ensure CRDs are installed first
resource mapping not found for name: "openstack-collapsed-cell" namespace: "" from "config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml": no matches for kind "OpenStackControlPlane" in version "core.openstack.org/v1beta1"
ensure CRDs are installed first
resource mapping not found for name: "openstack" namespace: "" from "config/samples/core_v1beta1_openstackcontrolplane_galera.yaml": no matches for kind "OpenStackControlPlane" in version "core.openstack.org/v1beta1"
ensure CRDs are installed first
resource mapping not found for name: "openstack-network-isolation" namespace: "" from "config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml": no matches for kind "OpenStackControlPlane" in version "core.openstack.org/v1beta1"
ensure CRDs are installed first
resource mapping not found for name: "openstack-separate-cell-db" namespace: "" from "config/samples/core_v1beta1_openstackcontrolplane_separate_cell_db.yaml": no matches for kind "OpenStackControlPlane" in version "core.openstack.org/v1beta1"
ensure CRDs are installed first
resource mapping not found for name: "" namespace: "" from "config/samples/kustomization.yaml": no matches for kind "Kustomization" in version "kustomize.config.k8s.io/v1beta1"
ensure CRDs are installed first
error validating "config/samples/kustomization.yaml": error validating data: [apiVersion not set, kind not set]; if you choose to ignore these errors, turn validation off with --validate=false
```

This patch define a couple of keys to use with KIND when we apply the config to fix this error.

However, we should notice that the `resource mapping not found` lines remains even after fixing the kustomization error. Let me know if we can add specific changes to also fix these mapping not found.