### PR TITLE
Bump operator-lint to 0.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ gowork: ## Generate go.work file to support our multi module repository
 
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.3.0
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./apis/...
 
 # Used for webhook testing


### PR DESCRIPTION
It has a new check
https://github.com/gibizer/operator-lint/blob/main/linters/crd/C003 that prevents the issue with omitempty + defaulted fields.