### PR TITLE
Cleanup delete code path

### DIFF
--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -90,6 +90,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers. Return and don't requeue.
+			r.Log.Info("OpenStackControlPlane instance is not found, probaby deleted. Nothing to do.")
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -131,11 +132,6 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Reset all ReadyConditons to 'Unknown'
 	instance.InitConditions()
-
-	if !instance.DeletionTimestamp.IsZero() {
-		r.Log.Info("Reconciled OpenStackControlPlane delete successfully")
-		return ctrl.Result{}, err
-	}
 
 	return r.reconcileNormal(ctx, instance, helper)
 }


### PR DESCRIPTION
The PR #205 simplified the deletion code path. Now the OpenStackControlPlane CR deletion is fully automatic as there is no Finalizer on it. So the reconciler will get an NotFound when called to reconcile a deleted instance instead of seeing the instance with delete timestamp set. So that dead code is removed and logging in moved from it to the NotFound handler so that we still log something when the resource is deleted.