### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: export ENABLE_WEBHOOKS?=false
-run: export OPENSTACKCLIENT_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-tripleoclient:current-tripleo
+run: export OPENSTACKCLIENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
@@ -342,7 +342,7 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete -n openstack validatingwebhookconfiguration/vopenstackcontrolplane.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export OPENSTACKCLIENT_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-tripleoclient:current-tripleo
+run-with-webhook: export OPENSTACKCLIENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,6 +12,4 @@ spec:
       - name: manager
         env:
         - name: OPENSTACKCLIENT_IMAGE_URL_DEFAULT
-          # TODO: this image causes syslog warning messages, see upstream https://bugs.launchpad.net/tripleo/+bug/1999553
-          # NOTE: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2 seems to work (no log messages)
-          value: quay.io/tripleozedcentos9/openstack-tripleoclient:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

Note that openstack-tripleoclient container was replaced by openstack-client container during migration to TCIB.

[1] https://github.com/openstack-k8s-operators/tcib