### PR TITLE
Fix netwok isolation sample

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -130,3 +130,20 @@ spec:
           - 172.17.0.86
           ipAddressPool: internalapi
           sharedIP: false
+  ironic:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      ironicAPI:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+      ironicConductors:
+      - replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
+        pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+        storageRequest: 10G
+      ironicInspector:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
+        pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+      secret: osp-secret


### PR DESCRIPTION
The current sample fails to apply due to missing ironic pieces:
```
  The OpenStackControlPlane "openstack-network-isolation" is invalid:
  spec.ironic.template.ironicConductors: Invalid value: "null":
  spec.ironic.template.ironicConductors in body must be of type array: "null"
```
So this patch copies over the ironic part of the default sample to the network isolation sample.