### PR TITLE
only exclude local ./apis module replace

### DIFF
--- a/hack/pin-custom-bundle-dockerfile.sh
+++ b/hack/pin-custom-bundle-dockerfile.sh
@@ -9,7 +9,10 @@ IMAGEBASE=${IMAGEBASE:-}
 cp custom-bundle.Dockerfile custom-bundle.Dockerfile.pinned
 
 #loop over each openstack-k8s-operators go.mod entry
-for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("openstack")) | .Replace // . |.Path' | grep -v apis | grep -v openstack-operator | grep -v lib-common); do
+for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("openstack")) | .Replace // . |.Path' | grep -v openstack-operator | grep -v lib-common); do
+  if [[ "$MOD_PATH" == "./apis" ]]; then
+    continue
+  fi
   MOD_VERSION=$(go list -m -json all | jq -r ". | select(.Path | contains(\"openstack\")) | .Replace // . | select( .Path == \"$MOD_PATH\") | .Version")
 
   BASE=$(echo $MOD_PATH | sed -e 's|github.com/.*/\(.*\)-operator/.*|\1|')


### PR DESCRIPTION
The api module in the infra-operator is named apis, which right now gets excluded. This breaks pinning the infra operator to a custom version.