### PR TITLE
Mark dataplane role/nodes as visible in CSV

### DIFF
--- a/cmd/csv-merger/csv-merger.go
+++ b/cmd/csv-merger/csv-merger.go
@@ -74,7 +74,7 @@ var (
 	ovsCsv         = flag.String("ovs-csv", "", "OVS CSV filename")
 	cinderCsv      = flag.String("cinder-csv", "", "Cinder CSV filename")
 	csvOverrides   = flag.String("csv-overrides", "", "CSV like string with punctual changes that will be recursively applied (if possible)")
-	visibleCRDList = flag.String("visible-crds-list", "openstackcontrolplanes.core.openstack.org,openstackdataplanes.dataplane.openstack.org",
+	visibleCRDList = flag.String("visible-crds-list", "openstackcontrolplanes.core.openstack.org,openstackdataplanes.dataplane.openstack.org,openstackdataplaneroles.dataplane.openstack.org,openstackdataplanenodes.dataplane.openstack.org",
 		"Comma separated list of all the CRDs that should be visible in OLM console")
 )
 


### PR DESCRIPTION
This addes openstackdataplanenodes, and openstackdataplaneroles to the CSV's visible CRD list