### PR TITLE
Fix network isolation CR by adding manila

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ custom-bundle.Dockerfile.pinned
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -87,6 +87,29 @@ spec:
           loadBalancerIPs:
           - 172.17.0.80
       secret: osp-secret
+  manila:
+    template:
+      manilaAPI:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-manila-api:current-tripleo
+        externalEndpoints:
+        - endpoint: internal
+          ipAddressPool: internalapi
+          loadBalancerIPs:
+          - 172.17.0.80
+        networkAttachments:
+        - internalapi
+      manilaScheduler:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-manila-scheduler:current-tripleo
+        networkAttachments:
+        - internalapi
+      manilaShares:
+        share1:
+          containerImage: quay.io/tripleozedcentos9/openstack-manila-share:current-tripleo
+          replicas: 1
+          networkAttachments:
+          - internalapi
   ovn:
     template:
       ovnDBCluster:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -132,6 +132,29 @@ spec:
           loadBalancerIPs:
           - 172.17.0.80
       secret: osp-secret
+  manila:
+    template:
+      manilaAPI:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-manila-api:current-tripleo
+        externalEndpoints:
+        - endpoint: internal
+          ipAddressPool: internalapi
+          loadBalancerIPs:
+          - 172.17.0.80
+        networkAttachments:
+        - internalapi
+      manilaScheduler:
+        replicas: 1
+        containerImage: quay.io/tripleozedcentos9/openstack-manila-scheduler:current-tripleo
+        networkAttachments:
+        - internalapi
+      manilaShares:
+        share1:
+          containerImage: quay.io/tripleozedcentos9/openstack-manila-share:current-tripleo
+          replicas: 1
+          networkAttachments:
+          - internalapi
   ovn:
     template:
       ovnDBCluster:


### PR DESCRIPTION
```
$make openstack_deploy
oc kustomize /home/faguiard/project/install_yamls/out/openstack/openstack/cr | oc apply -f -
The OpenStackControlPlane "openstack-network-isolation" is invalid: spec.manila.template.manilaShares: Invalid value: "null": spec.manila.template.manilaShares in body must be of type object: "null"
make: *** [Makefile:338: openstack_deploy] Error 1
```