### PR TITLE
Fix Cinder templates in samples

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -60,6 +60,8 @@ spec:
         containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
   cinder:
     template:
+      databaseInstance: openstack
+      secret: osp-secret
       cinderAPI:
         replicas: 1
         containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo

--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -48,6 +48,8 @@ spec:
         containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
   cinder:
     template:
+      databaseInstance: openstack
+      secret: osp-secret
       cinderAPI:
         replicas: 1
         containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -61,6 +61,8 @@ spec:
         containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
   cinder:
     template:
+      databaseInstance: openstack
+      secret: osp-secret
       cinderAPI:
         replicas: 1
         containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -7,6 +7,8 @@ spec:
   storageClass: local-storage
   cinder:
     template:
+      databaseInstance: openstack
+      secret: osp-secret
       cinderAPI:
         containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
         externalEndpoints:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -26,6 +26,8 @@ spec:
             readOnly: true
   cinder:
     template:
+      databaseInstance: openstack
+      secret: osp-secret
       cinderAPI:
         containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
         externalEndpoints:

--- a/config/samples/core_v1beta1_openstackcontrolplane_separate_cell_db.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_separate_cell_db.yaml
@@ -54,6 +54,8 @@ spec:
         containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
   cinder:
     template:
+      databaseInstance: openstack
+      secret: osp-secret
       cinderAPI:
         replicas: 1
         containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo


### PR DESCRIPTION
Right now we are seeing this error in CI:

```
+ oc kustomize /alabama/install_yamls/out/openstack/openstack/cr/
+ oc apply -f -
The OpenStackControlPlane "openstack" is invalid: 
* spec.cinder.template.databaseInstance: Required value
* spec.cinder.template.secret: Required value
```

This is due to the fact that `databaseInstance` and `secret` are not included in the OpenStack operator `config/samples` `Cinder` `template` blocks.  Other service operators either have none, one or both of these fields included, depending on whether or not those fields are required in their respective CRDs.  This of course leads to a question of what the proper optional/required designation should ultimately be, such that we can properly achieve consistency across all the service operators.  But for now we're patching the samples here to fix CI.