### PR TITLE
Expose NovaMetadata to internalapi

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -88,6 +88,12 @@ spec:
           loadBalancerIPs:
           - 172.17.0.80
       secret: osp-secret
+      metadataServiceTemplate:
+        externalEndpoints:
+         - endpoint: internal
+           ipAddressPool: internalapi
+           loadBalancerIPs:
+           - 172.17.0.80
   manila:
     template:
       manilaAPI:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -132,6 +132,12 @@ spec:
           loadBalancerIPs:
           - 172.17.0.80
       secret: osp-secret
+      metadataServiceTemplate:
+        externalEndpoints:
+         - endpoint: internal
+           ipAddressPool: internalapi
+           loadBalancerIPs:
+           - 172.17.0.80
   manila:
     template:
       manilaAPI:


### PR DESCRIPTION
This PR change the network isolation sample to expose nova-metadata service automatically on the internalapi network so that the ovn-metadata agent can access it from the compute.