### PR TITLE
Split out openstack-storage-bundle

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -23,7 +23,10 @@ echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
+BUNDLE_STORAGE_IMG=${REGISTRY}/openstack-operator-storage-bundle:${GITHUB_SHA} VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
+
+# custom storage bundle pinning
+DOCKERFILE=storage-bundle.Dockerfile /bin/bash hack/pin-custom-bundle-dockerfile.sh
 
 echo "Bundle file images:"
 cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"

--- a/.github/create_opm_index.sh
+++ b/.github/create_opm_index.sh
@@ -7,10 +7,10 @@ echo "${GITHUB_SHA}"
 echo "${INDEX_IMAGE}"
 echo "${INDEX_IMAGE_TAG}"
 echo "${BUNDLE_IMAGE}"
+echo "${STORAGE_BUNDLE_IMAGE}"
 
-echo "opm index add --bundles ${REGISTRY}/${BUNDLE_IMAGE}:${GITHUB_SHA} --tag ${REGISTRY}/${INDEX_IMAGE}:${GITHUB_SHA} -u podman --pull-tool podman"
-#opm index add --bundles "${REGISTRY}/${BUNDLE_IMAGE}:${GITHUB_SHA}" --tag "${REGISTRY}/${INDEX_IMAGE}:${GITHUB_SHA}" -u podman --pull-tool podman
-opm index add --bundles "${REGISTRY}/${BUNDLE_IMAGE}:${GITHUB_SHA}",quay.io/openstack-k8s-operators/manila-operator-bundle:latest --tag "${REGISTRY}/${INDEX_IMAGE}:${GITHUB_SHA}" -u podman --pull-tool podman
+echo "opm index add --bundles "${REGISTRY}/${BUNDLE_IMAGE}:${GITHUB_SHA}","${REGISTRY}/${STORAGE_BUNDLE_IMAGE}:${GITHUB_SHA}" --tag "${REGISTRY}/${INDEX_IMAGE}:${GITHUB_SHA}" -u podman --pull-tool podman"
+opm index add --bundles "${REGISTRY}/${BUNDLE_IMAGE}:${GITHUB_SHA}","${REGISTRY}/${STORAGE_BUNDLE_IMAGE}:${GITHUB_SHA}" --tag "${REGISTRY}/${INDEX_IMAGE}:${GITHUB_SHA}" -u podman --pull-tool podman
 
 echo "podman tag ${REGISTRY}/${INDEX_IMAGE}:${GITHUB_SHA} ${REGISTRY}/${INDEX_IMAGE}:${INDEX_IMAGE_TAG}"
 podman tag "${REGISTRY}/${INDEX_IMAGE}:${GITHUB_SHA}" "${REGISTRY}/${INDEX_IMAGE}:${INDEX_IMAGE_TAG}"

--- a/.github/workflows/build-openstack-operator.yaml
+++ b/.github/workflows/build-openstack-operator.yaml
@@ -115,6 +115,24 @@ jobs:
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
+    - name: Build openstack-operator-storage-bundle using buildah
+      id: build-openstack-operator-storage-bundle
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: openstack-operator-storage-bundle
+        tags: ${{ env.latesttag }} ${{ github.sha }}
+        containerfiles: |
+          ./storage-bundle.Dockerfile.pinned
+
+    - name: Push openstack-operator-storage-bundle To ${{ env.imageregistry }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-openstack-operator-storage-bundle.outputs.image }}
+        tags: ${{ steps.build-openstack-operator-storage-bundle.outputs.tags }}
+        registry:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
     - name: Build openstack-operator-bundle using buildah
       id: build-openstack-operator-bundle
       uses: redhat-actions/buildah-build@v2
@@ -175,6 +193,7 @@ jobs:
         REGISTRY:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
         GITHUB_SHA: ${{ github.sha }}
         BUNDLE_IMAGE: openstack-operator-bundle
+        STORAGE_BUNDLE_IMAGE: openstack-operator-storage-bundle
         INDEX_IMAGE_TAG: ${{ env.latesttag }}
         INDEX_IMAGE: openstack-operator-index
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ testbin/*
 bundle/*
 bundle.Dockerfile
 custom-bundle.Dockerfile.pinned
+storage-bundle.Dockerfile.pinned
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ IMAGE_TAG_BASE ?= quay.io/$(USER)/openstack-operator
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
+BUNDLE_STORAGE_IMG ?= $(IMAGE_TAG_BASE)-storage-bundle:v$(VERSION)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
@@ -223,15 +224,23 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 	cp dependencies.yaml ./bundle/metadata
 	operator-sdk bundle validate ./bundle
 	/bin/bash hack/pin-custom-bundle-dockerfile.sh
+	sed -i custom-bundle.Dockerfile.pinned -e "s|quay.io/openstack-k8s-operators/openstack-operator-storage-bundle.*|$(BUNDLE_STORAGE_IMG)|"
+
 
 .PHONY: bundle-build
 bundle-build: bundle ## Build the bundle image.
 	podman build -f custom-bundle.Dockerfile.pinned -t $(BUNDLE_IMG) .
 
-
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+
+.PHONY: dep-bundle-build-push
+dep-bundle-build-push: bundle ## Build and push dependency bundle images (storage, etc). When building bundles locally correct make order is: bundle, dep-bundle-build-push, bundle-build, bundle-push
+	DOCKERFILE=storage-bundle.Dockerfile /bin/bash hack/pin-custom-bundle-dockerfile.sh
+	podman build -f storage-bundle.Dockerfile.pinned -t $(BUNDLE_STORAGE_IMG) --env CSV_VERSION=$(VERSION) .
+	$(MAKE) docker-push IMG=$(BUNDLE_STORAGE_IMG)
+	#TODO in the future add new operator builds here
 
 .PHONY: opm
 OPM = ./bin/opm
@@ -252,7 +261,7 @@ endif
 
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
+BUNDLE_IMGS ?= $(BUNDLE_IMG),$(BUNDLE_STORAGE_IMG)
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-index:v$(VERSION)
@@ -268,7 +277,7 @@ endif
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
 	# FIXME: hardcoded bundle below should use go.mod pinned version for manila bundle
-	$(OPM) index add --container-tool podman --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS),quay.io/openstack-k8s-operators/manila-operator-bundle:latest $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool podman --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/README.md
+++ b/README.md
@@ -46,6 +46,68 @@ UnDeploy the controller to the cluster:
 make undeploy
 ```
 
+### Building your own bundle, index images
+The OpenStack operator uses multiple bundles to minimize the number of
+deployment artifacts we have in the OLM catalog while also providing enough
+space for our CRs (this is a big project). As such the build order for local
+bundles is a bit different than normal.
+
+1. Run make:bundle. This pins down dependencies to version used in the go.mod and
+ and also string replaces the URL for any dependant bundles (storage, etc) that
+ we will build below. Additionally a dependency.yaml is added to the generated bundle
+ so that we require any dependencies. This sets the stage for everything below.
+
+```sh
+make bundle
+```
+
+2. Run dep-bundle-build-push. This creates any *dependency* bundles required by this project.
+It builds and pushes them to a registry as this is required to be able to build the main
+bundle.
+
+```sh
+make dep-bundle-build-push
+```
+
+3. Run bundle-build. This will execute podman to build the custom-bundle.Dockerfile.pinned.
+
+```sh
+make bundle-build
+```
+
+4. Run bundle-push. This pushes the resulting bundle image to the registry.
+
+```sh
+make bundle-push
+```
+
+5. Run catalog-build.  At this point you can generate your index image so that it contains both of the above bundle images. Because we use dependencies in the openstack-operator's main bundle it will
+ automatically install the CSV contained in the dependant (storage, etc) bundle.
+
+```sh
+make catalog-build
+```
+
+6. Run catalog-push. Push the catalog to your registry.
+
+```sh
+make catalog-push
+```
+
+### Uninstall CRDs
+To delete the CRDs from the cluster:
+
+```sh
+make uninstall
+```
+
+### Undeploy controller
+UnDeploy the controller to the cluster:
+
+```sh
+make undeploy
+```
+
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 

--- a/cmd/csv-merger/csv-merger.go
+++ b/cmd/csv-merger/csv-merger.go
@@ -21,21 +21,20 @@ import (
 	"encoding/json"
 	"flag"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
 	"github.com/openstack-k8s-operators/openstack-operator/pkg/util"
 
+	semver "github.com/blang/semver/v4"
+	"github.com/operator-framework/api/pkg/lib/version"
 	csvv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const csvMode = "CSV"
-
-var validOutputModes = []string{csvMode}
 
 // TODO: get rid of this if/when RelatedImages officially appears in github.com/operator-framework/api/pkg/operators/v1alpha1/
 type relatedImage struct {
@@ -56,9 +55,45 @@ type clusterServiceVersionExtended struct {
 	Status csvv1alpha1.ClusterServiceVersionStatus `json:"status"`
 }
 
+func getEnvsFromFile(filename string) []v1.EnvVar {
+	csvBytes, err := os.ReadFile(filename)
+	if err != nil {
+		exitWithError(err.Error())
+	}
+	envVarList := &[]v1.EnvVar{}
+
+	err = yaml.Unmarshal(csvBytes, envVarList)
+	if err != nil {
+		exitWithError(err.Error())
+	}
+	return *envVarList
+}
+
+func writeEnvToYaml(filename string, data interface{}) {
+	yamlBytes, err := yaml.Marshal(data)
+	if err != nil {
+		exitWithError(err.Error())
+	}
+
+	file, err := os.Create(filename)
+	if err != nil {
+		exitWithError(err.Error())
+	}
+	defer file.Close()
+	_, err = file.Write(yamlBytes)
+	if err != nil {
+		exitWithError(err.Error())
+	}
+}
+
+func exitWithError(msg string) {
+	os.Stderr.WriteString(msg)
+	debug.PrintStack()
+	os.Exit(1)
+}
+
 var (
-	outputMode     = flag.String("output-mode", csvMode, "Working mode: "+strings.Join(validOutputModes, "|"))
-	openstackCsv   = flag.String("openstack-csv", "", "OpenStack CSV filename")
+	baseCsv        = flag.String("base-csv", "", "Base CSV filename")
 	keystoneCsv    = flag.String("keystone-csv", "", "Keystone CSV filename")
 	mariadbCsv     = flag.String("mariadb-csv", "", "Mariadb CSV filename")
 	rabbitmqCsv    = flag.String("rabbitmq-csv", "", "RabbitMQ CSV filename")
@@ -75,6 +110,9 @@ var (
 	ovsCsv         = flag.String("ovs-csv", "", "OVS CSV filename")
 	cinderCsv      = flag.String("cinder-csv", "", "Cinder CSV filename")
 	csvOverrides   = flag.String("csv-overrides", "", "CSV like string with punctual changes that will be recursively applied (if possible)")
+	importEnvFiles = flag.String("import-env-files", "", "Comma separated list of file names to read default operator ENVs from. Used for inter-bundle ENV merging.")
+	exportEnvFile  = flag.String("export-env-file", "", "Name the external file to write operator ENVs to. Used for inter-bundle ENV merging.")
+	almExamples    = flag.Bool("alm-examples", false, "Merge almExamples into the CSV")
 	visibleCRDList = flag.String("visible-crds-list", "openstackcontrolplanes.core.openstack.org,openstackdataplanes.dataplane.openstack.org,openstackdataplaneroles.dataplane.openstack.org,openstackdataplanenodes.dataplane.openstack.org",
 		"Comma separated list of all the CRDs that should be visible in OLM console")
 )
@@ -82,13 +120,13 @@ var (
 func getCSVBase(filename string) *csvv1alpha1.ClusterServiceVersion {
 	csvBytes, err := os.ReadFile(filename)
 	if err != nil {
-		panic(err)
+		exitWithError(err.Error())
 	}
 	csvStruct := &csvv1alpha1.ClusterServiceVersion{}
 
 	err = yaml.Unmarshal(csvBytes, csvStruct)
 	if err != nil {
-		panic(err)
+		exitWithError(err.Error())
 	}
 	return csvStruct
 }
@@ -96,129 +134,131 @@ func getCSVBase(filename string) *csvv1alpha1.ClusterServiceVersion {
 func main() {
 	flag.Parse()
 
-	switch *outputMode {
-	case csvMode:
+	csvs := []string{
+		*keystoneCsv,
+		*mariadbCsv,
+		*rabbitmqCsv,
+		*infraCsv,
+		*ansibleEECsv,
+		*dataplaneCsv,
+		*novaCsv,
+		*neutronCsv,
+		*manilaCsv,
+		*glanceCsv,
+		*ironicCsv,
+		*placementCsv,
+		*ovnCsv,
+		*ovsCsv,
+		*cinderCsv,
+	}
 
-		csvs := []string{
-			*keystoneCsv,
-			*mariadbCsv,
-			*rabbitmqCsv,
-			*infraCsv,
-			*ansibleEECsv,
-			*dataplaneCsv,
-			*novaCsv,
-			*neutronCsv,
-			*manilaCsv,
-			*glanceCsv,
-			*ironicCsv,
-			*placementCsv,
-			*ovnCsv,
-			*ovsCsv,
-			*cinderCsv,
+	csvVersion := os.Getenv("CSV_VERSION")
+
+	// BaseCSV is built on the bundle/manifests/openstack-operator.clusterserviceversion.yaml from this repo
+	csvBase := getCSVBase(*baseCsv)
+	csvExtended := clusterServiceVersionExtended{
+		TypeMeta:   csvBase.TypeMeta,
+		ObjectMeta: csvBase.ObjectMeta,
+		Spec:       clusterServiceVersionSpecExtended{ClusterServiceVersionSpec: csvBase.Spec},
+		Status:     csvBase.Status}
+
+	installStrategyBase := csvBase.Spec.InstallStrategy.StrategySpec
+
+	envVarList := []v1.EnvVar{}
+	if len(*importEnvFiles) > 0 {
+		for _, filename := range strings.Split(*importEnvFiles, ",") {
+			envVarList = append(envVarList, getEnvsFromFile(filename)...)
 		}
+	}
+	for _, csvFile := range csvs {
+		if csvFile != "" {
+			csvBytes, err := os.ReadFile(csvFile)
+			if err != nil {
+				exitWithError(err.Error())
+			}
 
-		// BaseCSV is built on the bundle/manifests/openstack-operator.clusterserviceversion.yaml from this repo
-		csvBase := getCSVBase(*openstackCsv)
-		csvExtended := clusterServiceVersionExtended{
-			TypeMeta:   csvBase.TypeMeta,
-			ObjectMeta: csvBase.ObjectMeta,
-			Spec:       clusterServiceVersionSpecExtended{ClusterServiceVersionSpec: csvBase.Spec},
-			Status:     csvBase.Status}
+			csvStruct := &csvv1alpha1.ClusterServiceVersion{}
 
-		installStrategyBase := csvBase.Spec.InstallStrategy.StrategySpec
+			err = yaml.Unmarshal(csvBytes, csvStruct)
+			if err != nil {
+				exitWithError(err.Error())
+			}
 
-		for _, csvFile := range csvs {
-			if csvFile != "" {
-				csvBytes, err := os.ReadFile(csvFile)
-				if err != nil {
-					panic(err)
-				}
+			// 1. We need to add the "env" section from this Service Operator deployment in case there
+			// are default values configured there that are needed for use with defaulting webhooks
+			//
+			// - DeploymentSpecs[0] is always the base deployment for OpenStack Operator
+			// - Container at index 1 in DeploymentSpecs[0].Spec.Template.Spec.Containers list is
+			//   always the OpenStack Operator controller-manager
+			// - We need to find the Service Operator's controller-manager container in
+			//   csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers
+			//
+			// TODO: What about "env" list keys that overlap between Service Operators (i.e. non-unique
+			//       names)?
+			//
+			// 2. We also need to inject "ENABLE_WEBHOOKS=false" into the env vars for the Service Operators'
+			//    deployments, and then remove their webhook server's cert's volume mount
 
-				csvStruct := &csvv1alpha1.ClusterServiceVersion{}
+			for index, container := range csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers {
+				// Copy env vars from the Service Operator into the OpenStack Operator
+				if container.Name == "manager" {
+					envVarList = append(envVarList, container.Env...)
 
-				err = yaml.Unmarshal(csvBytes, csvStruct)
-				if err != nil {
-					panic(err)
-				}
-
-				// 1. We need to add the "env" section from this Service Operator deployment in case there
-				// are default values configured there that are needed for use with defaulting webhooks
-				//
-				// - DeploymentSpecs[0] is always the base deployment for OpenStack Operator
-				// - Container at index 1 in DeploymentSpecs[0].Spec.Template.Spec.Containers list is
-				//   always the OpenStack Operator controller-manager
-				// - We need to find the Service Operator's controller-manager container in
-				//   csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers
-				//
-				// TODO: What about "env" list keys that overlap between Service Operators (i.e. non-unique
-				//       names)?
-				//
-				// 2. We also need to inject "ENABLE_WEBHOOKS=false" into the env vars for the Service Operators'
-				//    deployments, and then remove their webhook server's cert's volume mount
-
-				for index, container := range csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers {
-					// Copy env vars from the Service Operator into the OpenStack Operator
-					if container.Name == "manager" {
-						installStrategyBase.DeploymentSpecs[0].Spec.Template.Spec.Containers[1].Env = append(
-							// OpenStack Operator controller-manager container env vars
-							installStrategyBase.DeploymentSpecs[0].Spec.Template.Spec.Containers[1].Env,
-							// Service Operator controller-manager container env vars
-							container.Env...,
-						)
-
-						// Now we also need to turn off any "internal" webhooks that belong to the service
-						// operator, as we are now using "external" webhooks that live in the OpenStack
-						// operator.  These "external" webhooks will eventually call the mutating/validating
-						// logic that was previously housed within the "internal" Service Operator webhook
-						// logic.
-						container.Env = append(container.Env,
-							v1.EnvVar{
-								Name:  "ENABLE_WEBHOOKS",
-								Value: "false",
-							},
-						)
-
-						// And finally we need to remove the webhook server's cert volume mount
-						for volMountIndex, volMount := range container.VolumeMounts {
-							if volMount.Name == "cert" {
-								container.VolumeMounts[volMountIndex] = container.VolumeMounts[len(container.VolumeMounts)-1]
-								container.VolumeMounts = container.VolumeMounts[:len(container.VolumeMounts)-1]
-								// Found the target mount, so stop iterating
-								break
-							}
-						}
-
-						// Need to replace the container in the Deployment since this local variable is a copy
-						csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[index] = container
-
-						// We found the controller-manager container, so no need to continue iterating
-						break
-					}
-				}
-
-				installStrategyBase.DeploymentSpecs = append(installStrategyBase.DeploymentSpecs, csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs...)
-				installStrategyBase.ClusterPermissions = append(installStrategyBase.ClusterPermissions, csvStruct.Spec.InstallStrategy.StrategySpec.ClusterPermissions...)
-				installStrategyBase.Permissions = append(installStrategyBase.Permissions, csvStruct.Spec.InstallStrategy.StrategySpec.Permissions...)
-
-				for _, owned := range csvStruct.Spec.CustomResourceDefinitions.Owned {
-					csvExtended.Spec.CustomResourceDefinitions.Owned = append(
-						csvExtended.Spec.CustomResourceDefinitions.Owned,
-						csvv1alpha1.CRDDescription{
-							Name:        owned.Name,
-							Version:     owned.Version,
-							Kind:        owned.Kind,
-							Description: owned.Description,
-							DisplayName: owned.DisplayName,
+					// Now we also need to turn off any "internal" webhooks that belong to the service
+					// operator, as we are now using "external" webhooks that live in the OpenStack
+					// operator.  These "external" webhooks will eventually call the mutating/validating
+					// logic that was previously housed within the "internal" Service Operator webhook
+					// logic.
+					container.Env = append(container.Env,
+						v1.EnvVar{
+							Name:  "ENABLE_WEBHOOKS",
+							Value: "false",
 						},
 					)
-				}
 
+					// And finally we need to remove the webhook server's cert volume mount
+					for volMountIndex, volMount := range container.VolumeMounts {
+						if volMount.Name == "cert" {
+							container.VolumeMounts[volMountIndex] = container.VolumeMounts[len(container.VolumeMounts)-1]
+							container.VolumeMounts = container.VolumeMounts[:len(container.VolumeMounts)-1]
+							// Found the target mount, so stop iterating
+							break
+						}
+					}
+
+					// Need to replace the container in the Deployment since this local variable is a copy
+					csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers[index] = container
+
+					// We found the controller-manager container, so no need to continue iterating
+					break
+				}
+			}
+
+			installStrategyBase.DeploymentSpecs = append(installStrategyBase.DeploymentSpecs, csvStruct.Spec.InstallStrategy.StrategySpec.DeploymentSpecs...)
+			installStrategyBase.ClusterPermissions = append(installStrategyBase.ClusterPermissions, csvStruct.Spec.InstallStrategy.StrategySpec.ClusterPermissions...)
+			installStrategyBase.Permissions = append(installStrategyBase.Permissions, csvStruct.Spec.InstallStrategy.StrategySpec.Permissions...)
+
+			for _, owned := range csvStruct.Spec.CustomResourceDefinitions.Owned {
+				csvExtended.Spec.CustomResourceDefinitions.Owned = append(
+					csvExtended.Spec.CustomResourceDefinitions.Owned,
+					csvv1alpha1.CRDDescription{
+						Name:        owned.Name,
+						Version:     owned.Version,
+						Kind:        owned.Kind,
+						Description: owned.Description,
+						DisplayName: owned.DisplayName,
+					},
+				)
+			}
+
+			if *almExamples {
 				csvBaseAlmString := csvExtended.Annotations["alm-examples"]
 				csvStructAlmString := csvStruct.Annotations["alm-examples"]
 				var baseAlmCrs []interface{}
 				var structAlmCrs []interface{}
 				if err = json.Unmarshal([]byte(csvBaseAlmString), &baseAlmCrs); err != nil {
-					panic(err)
+					print(csvBaseAlmString)
+					exitWithError(err.Error())
 				}
 				if err = json.Unmarshal([]byte(csvStructAlmString), &structAlmCrs); err == nil {
 					//panic(err)
@@ -226,66 +266,80 @@ func main() {
 				}
 				almB, err := json.Marshal(baseAlmCrs)
 				if err != nil {
-					panic(err)
+					exitWithError(err.Error())
 				}
 				csvExtended.Annotations["alm-examples"] = string(almB)
+			}
 
+		}
+	}
+	if len(*exportEnvFile) > 0 {
+		writeEnvToYaml(*exportEnvFile, envVarList)
+	} else {
+		installStrategyBase.DeploymentSpecs[0].Spec.Template.Spec.Containers[1].Env = append(
+			// OpenStack Operator controller-manager container env vars
+			installStrategyBase.DeploymentSpecs[0].Spec.Template.Spec.Containers[1].Env,
+			// Service Operator controller-manager container env vars
+			envVarList...,
+		)
+	}
+
+	// by default we hide all CRDs in the Console
+	hiddenCrds := []string{}
+	visibleCrds := strings.Split(*visibleCRDList, ",")
+	for _, owned := range csvExtended.Spec.CustomResourceDefinitions.Owned {
+		found := false
+		for _, name := range visibleCrds {
+			if owned.Name == name {
+				found = true
 			}
 		}
-
-		// by default we hide all CRDs in the Console
-		hiddenCrds := []string{}
-		visibleCrds := strings.Split(*visibleCRDList, ",")
-		for _, owned := range csvExtended.Spec.CustomResourceDefinitions.Owned {
-			found := false
-			for _, name := range visibleCrds {
-				if owned.Name == name {
-					found = true
-				}
-			}
-			if !found {
-				hiddenCrds = append(
-					hiddenCrds,
-					owned.Name,
-				)
-			}
+		if !found {
+			hiddenCrds = append(
+				hiddenCrds,
+				owned.Name,
+			)
 		}
-		hiddenCrdsJ, err := json.Marshal(hiddenCrds)
+	}
+	hiddenCrdsJ, err := json.Marshal(hiddenCrds)
+	if err != nil {
+		exitWithError(err.Error())
+	}
+	csvExtended.Annotations["operators.operatorframework.io/internal-objects"] = string(hiddenCrdsJ)
+
+	csvExtended.Spec.InstallStrategy.StrategyName = "deployment"
+	csvExtended.Spec.InstallStrategy = csvv1alpha1.NamedInstallStrategy{
+		StrategyName: "deployment",
+		StrategySpec: installStrategyBase,
+	}
+
+	if csvVersion != "" {
+		csvExtended.Spec.Version = version.OperatorVersion{
+			Version: semver.MustParse(csvVersion),
+		}
+		csvExtended.Name = strings.Replace(csvExtended.Name, "0.0.1", csvVersion, 1)
+	}
+
+	if *csvOverrides != "" {
+		csvOBytes := []byte(*csvOverrides)
+
+		csvO := &clusterServiceVersionExtended{}
+
+		err := yaml.Unmarshal(csvOBytes, csvO)
 		if err != nil {
-			panic(err)
-		}
-		csvExtended.Annotations["operators.operatorframework.io/internal-objects"] = string(hiddenCrdsJ)
-
-		csvExtended.Spec.InstallStrategy.StrategyName = "deployment"
-		csvExtended.Spec.InstallStrategy = csvv1alpha1.NamedInstallStrategy{
-			StrategyName: "deployment",
-			StrategySpec: installStrategyBase,
+			exitWithError(err.Error())
 		}
 
-		if *csvOverrides != "" {
-			csvOBytes := []byte(*csvOverrides)
-
-			csvO := &clusterServiceVersionExtended{}
-
-			err := yaml.Unmarshal(csvOBytes, csvO)
-			if err != nil {
-				panic(err)
-			}
-
-			err = mergo.Merge(&csvExtended, csvO, mergo.WithOverride)
-			if err != nil {
-				panic(err)
-			}
-
-		}
-
-		err = util.MarshallObject(csvExtended, os.Stdout)
+		err = mergo.Merge(&csvExtended, csvO, mergo.WithOverride)
 		if err != nil {
-			panic(err)
+			exitWithError(err.Error())
 		}
 
-	default:
-		panic("Unsupported output mode: " + *outputMode)
+	}
+
+	err = util.MarshallObject(csvExtended, os.Stdout)
+	if err != nil {
+		exitWithError(err.Error())
 	}
 
 }

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - type: olm.package
     value:
-      packageName: manila-operator
+      packageName: openstack-storage-operators
       version: ">0.0.0"

--- a/hack/pin-custom-bundle-dockerfile.sh
+++ b/hack/pin-custom-bundle-dockerfile.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -ex
 
+DOCKERFILE=${DOCKERFILE:-"custom-bundle.Dockerfile"}
 IMAGENAMESPACE=${IMAGENAMESPACE:-"openstack-k8s-operators"}
 IMAGEREGISTRY=${IMAGEREGISTRY:-"quay.io"}
 IMAGEBASE=${IMAGEBASE:-}
 
-
-cp custom-bundle.Dockerfile custom-bundle.Dockerfile.pinned
+cp "$DOCKERFILE" "${DOCKERFILE}.pinned"
 
 #loop over each openstack-k8s-operators go.mod entry
 for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("openstack")) | .Replace // . |.Path' | grep -v openstack-operator | grep -v lib-common); do
@@ -32,5 +32,5 @@ for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("ope
     fi
 
     SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/ | jq -r .tags[].name | sort -u | grep $REF)
-    sed -i custom-bundle.Dockerfile.pinned -e "s|quay.io/openstack-k8s-operators/${BASE}-operator-bundle.*|${REPO_URL}/${BASE}-operator-bundle:$SHA|"
+    sed -i "${DOCKERFILE}.pinned" -e "s|quay.io/openstack-k8s-operators/${BASE}-operator-bundle.*|${REPO_URL}/${BASE}-operator-bundle:$SHA|"
 done

--- a/storage-bundle.Dockerfile
+++ b/storage-bundle.Dockerfile
@@ -1,0 +1,78 @@
+ARG GOLANG_CTX=golang:1.19
+ARG GLANCE_BUNDLE=quay.io/openstack-k8s-operators/glance-operator-bundle:latest
+ARG CINDER_BUNDLE=quay.io/openstack-k8s-operators/cinder-operator-bundle:latest
+ARG MANILA_BUNDLE=quay.io/openstack-k8s-operators/manila-operator-bundle:latest
+
+# Build the manager binary
+FROM $GOLANG_CTX as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+COPY apis/ apis/
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/csv-merger/csv-merger.go csv-merger.go
+COPY pkg/ pkg/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o csv-merger csv-merger.go
+
+FROM $GLANCE_BUNDLE as glance-bundle
+FROM $CINDER_BUNDLE as cinder-bundle
+FROM $MANILA_BUNDLE as manila-bundle
+
+FROM $GOLANG_CTX as merger
+# this provides CSV_VERSION to the csv-merger
+WORKDIR /workspace
+COPY --from=builder /workspace/csv-merger .
+
+# this makes creates the base /manifests dir
+COPY --from=glance-bundle /manifests /manifests/
+# copy in the rest
+COPY --from=cinder-bundle /manifests/* /manifests/
+COPY --from=manila-bundle /manifests/* /manifests/
+COPY storage-operators.clusterserviceversion.yaml /manifests/
+
+RUN /workspace/csv-merger \
+  --export-env-file=/env-vars.yaml \
+  --glance-csv=/manifests/glance-operator.clusterserviceversion.yaml \
+  --cinder-csv=/manifests/cinder-operator.clusterserviceversion.yaml \
+  --manila-csv=/manifests/manila-operator.clusterserviceversion.yaml \
+  --base-csv=/manifests/storage-operators.clusterserviceversion.yaml | tee /openstack-operator-storage.clusterserviceversion.yaml.new
+
+# remove all individual operator CSV's
+RUN rm /manifests/*clusterserviceversion.yaml
+
+RUN mkdir /metadata/
+COPY bundle/metadata/annotations.yaml /metadata/
+RUN sed -e "s|operators.operatorframework.io.bundle.package.v1.*|operators.operatorframework.io.bundle.package.v1: openstack-storage-operators|" -i /metadata/annotations.yaml
+
+### Put everything together
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=openstack-storage-operators
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.1
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# Copy files to locations specified by labels.
+
+# copy in manifests from operators
+COPY --from=merger /manifests /manifests/
+COPY --from=merger /metadata /metadata/
+
+# overwrite with the final merged CSV
+COPY --from=merger /openstack-operator-storage.clusterserviceversion.yaml.new /manifests/openstack-operator-storage.clusterserviceversion.yaml
+COPY --from=merger /env-vars.yaml /env-vars.yaml

--- a/storage-operators.clusterserviceversion.yaml
+++ b/storage-operators.clusterserviceversion.yaml
@@ -2,233 +2,20 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[]'
+    alm-examples: ''
     capabilities: Basic Install
-    operatorframework.io/suggested-namespace: openstack
-    operators.operatorframework.io/builder: operator-sdk-v1.26.0
+    operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: openstack-operator.v0.0.0
+  name: openstack-storage-operators.v0.0.1
   namespace: placeholder
+
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions:
-    owned:
-    - description: OpenStackControlPlane is the Schema for the openstackcontrolplanes
-        API
-      displayName: OpenStack ControlPlane
-      kind: OpenStackControlPlane
-      name: openstackcontrolplanes.core.openstack.org
-      specDescriptors:
-      - description: Cinder - Parameters related to the Cinder service
-        displayName: Cinder
-        path: cinder
-      - description: Enabled - Whether Cinder service should be deployed and managed
-        displayName: Enabled
-        path: cinder.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Template - Overrides to use when creating Cinder Resources
-        displayName: Template
-        path: cinder.template
-      - description: ExtraMounts containing conf files and credentials that should
-          be provided to the underlying operators. This struct can be defined in the
-          top level CR and propagated to the underlying operators that accept it in
-          their API (e.g., cinder/glance). However, if extraVolumes are specified
-          within the single operator template Section, the globally defined ExtraMounts
-          are ignored and overridden for the operator which has this section already.
-        displayName: Extra Mounts
-        path: extraMounts
-      - displayName: Vol Mounts
-        path: extraMounts[0].extraVol
-      - displayName: Name
-        path: extraMounts[0].name
-      - displayName: Region
-        path: extraMounts[0].region
-      - description: Galera - Parameters related to the Galera services
-        displayName: Galera
-        path: galera
-      - description: Enabled - Whether Galera services should be deployed and managed
-        displayName: Enabled
-        path: galera.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Templates - Overrides to use when creating the Galera databases
-        displayName: Templates
-        path: galera.templates
-      - description: Glance - Parameters related to the Glance service
-        displayName: Glance
-        path: glance
-      - description: Enabled - Whether Glance service should be deployed and managed
-        displayName: Enabled
-        path: glance.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Template - Overrides to use when creating the Glance Service
-        displayName: Template
-        path: glance.template
-      - description: Ironic - Parameters related to the Ironic services
-        displayName: Ironic
-        path: ironic
-      - description: Enabled - Whether Ironic services should be deployed and managed
-        displayName: Enabled
-        path: ironic.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Template - Overrides to use when creating the Ironic services
-        displayName: Template
-        path: ironic.template
-      - description: Keystone - Parameters related to the Keystone service
-        displayName: Keystone
-        path: keystone
-      - description: Enabled - Whether Keystone service should be deployed and managed
-        displayName: Enabled
-        path: keystone.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Template - Overrides to use when creating the Keystone service
-        displayName: Template
-        path: keystone.template
-      - description: Enabled - Whether Manila service should be deployed and managed
-        displayName: Enabled
-        path: manila.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Mariadb - Parameters related to the Mariadb service
-        displayName: Mariadb
-        path: mariadb
-      - description: Enabled - Whether MariaDB service should be deployed and managed
-        displayName: Enabled
-        path: mariadb.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Templates - Overrides to use when creating the MariaDB databases
-        displayName: Templates
-        path: mariadb.templates
-      - description: Neutron - Overrides to use when creating the Neutron Service
-        displayName: Neutron
-        path: neutron
-      - description: Enabled - Whether Neutron service should be deployed and managed
-        displayName: Enabled
-        path: neutron.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Template - Overrides to use when creating the Neutron service
-        displayName: Template
-        path: neutron.template
-      - description: NodeSelector to target subset of worker nodes running control
-          plane services (currently only applies to KeystoneAPI and PlacementAPI)
-        displayName: Node Selector
-        path: nodeSelector
-      - description: Nova - Parameters related to the Nova services
-        displayName: Nova
-        path: nova
-      - description: Enabled - Whether Nova services should be deployed and managed
-        displayName: Enabled
-        path: nova.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Template - Overrides to use when creating the Nova services
-        displayName: Template
-        path: nova.template
-      - description: Ovn - Overrides to use when creating the OVN Services
-        displayName: Ovn
-        path: ovn
-      - description: Enabled - Whether OVN services should be deployed and managed
-        displayName: Enabled
-        path: ovn.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Template - Overrides to use when creating the OVN services
-        displayName: Template
-        path: ovn.template
-      - description: OVNDBCluster - Overrides to use when creating the OVNDBCluster
-          services
-        displayName: OVNDBCluster
-        path: ovn.template.ovnDBCluster
-      - description: OVNNorthd - Overrides to use when creating the OVNNorthd service
-        displayName: OVNNorthd
-        path: ovn.template.ovnNorthd
-      - description: Ovs - Overrides to use when creating the OVS Services
-        displayName: Ovs
-        path: ovs
-      - description: Enabled - Whether OVS services should be deployed and managed
-        displayName: Enabled
-        path: ovs.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Template - Overrides to use when creating the OVS services
-        displayName: Template
-        path: ovs.template
-      - description: Placement - Parameters related to the Placement service
-        displayName: Placement
-        path: placement
-      - description: Enabled - Whether Placement service should be deployed and managed
-        displayName: Enabled
-        path: placement.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Template - Overrides to use when creating the Placement API
-        displayName: Template
-        path: placement.template
-      - description: Rabbitmq - Parameters related to the Rabbitmq service
-        displayName: Rabbitmq
-        path: rabbitmq
-      - description: Enabled - Whether RabbitMQ services should be deployed and managed
-        displayName: Enabled
-        path: rabbitmq.enabled
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Templates - Overrides to use when creating the Rabbitmq clusters
-        displayName: Templates
-        path: rabbitmq.templates
-      - description: ExternalEndpoint, expose a VIP via MetalLB on the pre-created
-          address pool
-        displayName: External Endpoint
-        path: rabbitmq.templates.externalEndpoint
-      - description: IPAddressPool expose VIP via MetalLB on the IPAddressPool
-        displayName: IPAddress Pool
-        path: rabbitmq.templates.externalEndpoint.ipAddressPool
-      - description: LoadBalancerIPs, request given IPs from the pool if available.
-          Using a list to allow dual stack (IPv4/IPv6) support
-        displayName: Load Balancer IPs
-        path: rabbitmq.templates.externalEndpoint.loadBalancerIPs
-      - description: SharedIP if true, VIP/VIPs get shared with multiple services
-        displayName: Shared IP
-        path: rabbitmq.templates.externalEndpoint.sharedIP
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: SharedIPKey specifies the sharing key which gets set as the annotation
-          on the LoadBalancer service. Services which share the same VIP must have
-          the same SharedIPKey. Defaults to the IPAddressPool if SharedIP is true,
-          but no SharedIPKey specified.
-        displayName: Shared IPKey
-        path: rabbitmq.templates.externalEndpoint.sharedIPKey
-      - description: 'Secret - FIXME: make this optional'
-        displayName: Secret
-        path: secret
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:Secret
-      - description: StorageClass -
-        displayName: Storage Class
-        path: storageClass
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:StorageClass
-      statusDescriptors:
-      - description: Conditions
-        displayName: Conditions
-        path: conditions
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes.conditions
-      version: v1beta1
-  description: Install and configure OpenStack
-  displayName: OpenStack
+  description: OpenStack Storage Operators
+  displayName: OpenStack Storage
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAA2sAAALxCAYAAADCPz4BAAAgZElEQVR42u3dP2xcV2Lv8Z8I9SSmyxSiUqQVGWDTinyAp7QkIG4tC9C2lrVRWtvyso13tVJr4Ulym4foT3kNrKh6gUeqzQNCupguA7J9DVPk0KG1IjkznD/33vl8AEK2NRzeOTM058tz7rmXjo6Own8bdHtrSVaMBABA+3T61bZRoEkuLVKslRhbTbKWZD3JcpKrSa54KQAALJR35c/tJIdJdpPsdvrVgaFBrE0/zI6jbKP8ed3TDQDAOX4u4badZLvTr3YNCWJtMoG2keRGCbRrnl4AAC7osMzCvUry2swbYm20QLuR5GaJtGVPKQAAU/QuyQvhhlg7PdBWk9wrkeZ8MwAA5uFNkuedfvXaULDwsVZm0e45/wwAgBr5OcnzJE/MtrFwsTbo9m4n+cYsGgAANXaY5HWS33f61b7hoNWxJtIAAGioH0UbrYy1stzxDyINAICG27I8klbEWrlo9ffOSQMAoEUOkzzo9KsXhoLGxdqg21tJ8nWSLz0lAAC01LsSbS60TTNirVzI+qkljwAALIitTr/aMgzUNtbMpgEAsMDeJ7lrlo3axVo5N+1pkmueAgAAFtg/d/rVY8NALWKtbMf/fZJlww8AAHlTZtnsGMn8Ym3Q7T1N8rlhBwCAX7EskvnEWjk/7SfLHgEA4FSHST7r9KttQ0GSLM0g1NaEGgAAnGs5SVVOG4LpzqydCDXnpwEAwPBs78/0Yk2oAQDAhfzY6Vd3DcPimsoySKEGAAAX9nnZoA+xJtQAAECw0cpYE2oAACDYqFmsCTUAAJhqsNklUqyNFWorSZ4KNQAAmJofBJtYG4frqAEAwPR9X1a0IdbOV9bPCjUAAJi+5SQ/lZVtiLUzQ+12ks8NIwAAzDbYDINYOyvU1pL8YAgBAGDmrg26ve8NQ7tdOjo6GifUVpL8JckVQwgAAHPT6/SrbcPQTuPOrH0t1AAAYO7+1flrYu0Xg27vRpIvDR0AAMzdcrmEFi000jJIyx8BAKCWPuv0q9eGoV1GnVmz/BEAAOrnqeWQCxxrZfdHyx8BAKB+lsvECosYa0lsDQoAAPX1ZZlgYZFirVz8+rrhAgCAWjPBsmixluQbQwUAALV3fdDtbRiGBYm1Qbd3z6YiAADQGGbXWuLMrfvLjjL/Xk5YBAAAmuG3nX71wjA023kzazeEGgAANM49Q9D+WHOuGgAANM815661ONbKDpDOVQMAgGZy3bW2xlqS24YHAAAa6/qg21s1DC2LtXIxPddVAwCAZnPuWttizZMKAACtYLVcC2PthqEBAIDGWy57UdCGWBt0e7brBwCA9rhpCFoSa0m+MCwAANAanw66vRXD0I5Y+9SwAABAqzjNqemxVpZAAgAA7WIpZNNjzZMIAACtZPVcC2Jtw5AAAED7DLo97/WbGmvl6uZXDAkAALTSdUPQ0FgzqwYAAK3m/b5YAwAAasjMWoNjbc1wAABAezlvrbmxds1wAABAq5mgaVqsKWwAABBr1DDWPGkAALAQVg1B82Jt2VAAAEDr2WSkgbFmGSQAACyAQbe3YhSaFWueMAAAWAxOgWpYrNkJEgAAoIaxBgAALAbnrTUl1gbdnh1hAAAA6hZrSa4aBgAAgPrFGgAAsDjWDYFYAwAA6sc1lsUaAAAAYg0AAECsAQAAINYAAADEGgAAAGINAAAAsQYAACDWAAAAEGsAAABiDQAAALEGAAAg1gAAABBrAAAAiDUAAACxBgAAgFgDAAAQawAAAIg1AAAAsQYAAIBYAwAAQKwBAACINQAAAMQaAACAWAMAAECsAQAAiDUAAADEGgAAAGINAABArAEAACDWAAAAxBoAAABiDQAAQKwBAAAg1gAAABBrAAAAYg0AAACxBgAAINYAAAAQawAAAGINAAAAsQYAAIBYAwAAEGsAAACINQAAALEGAACAWAMAABBrAAAAiDUAAACxZggAAADEGgAAAGINAABArAEAACDWAAAAxBoAAABiDQAAQKwBAAAg1gAAABBrAAAAYg0AAACxBgAAINYAAAAQawAAAGINAAAAsQYAAIBYAwAAEGsAAACINQAAALEGAACAWAMAABBrAAAAiDUAAADEGgAAgFgDAABArAEAAIg1AAAAxBoAAIBYAwAAQKwBAAAg1gAAAMQaAAAAYg0AAECsAQAAINYAAADEGgAAAGINAAAAsQYAACDWAAAAEGsAAABiDQAAALEGAAAg1gAAABBrAAAAiDUAAACxBgAAgFgDAAAQawAAAIg1AAAAsQYAAIBYAwAAQKwBAACINQAAAMQaAACAWAMAAECsAQAALIzLhgDG8nOSvST75c9j7wwNwNSsJVk+8e8bSVaSXDM0gFiDxfU+yasSY7udfnVgSABmbvuDf986/odBt7dW4m0jyfUPog5ArEHLvEvyIslrcQZQb51+tZtkN8njEm83ktxMckO4AWIN2uGwBNrjTr/aNxwAjY2310leD7q9lRJs3yS5YmQAsQbNjLTHSZ6YRQNoVbQdlF/CvSizbd84xw0Qa9AcT5JsiTSA1ofb8Wzb7STfWx4J1J2t+1lk75P8Q6dfPRBqAAsVbS+S/F35ZR2AWIOa2er0q9+UE9IBWLxgO+j0qwdJemUpPIBYgzk7TNLr9KstQwFAp19tl1k218kExBrM0fskvyk/mAHgONgOOv3qkyQ/Gg1ArMF8Qu0T2/EDcEa03U3yWyMBiDWYfajZRASA84LthWADxBoINQAEG4BYQ6gBwIjBZjMqQKzBFBwm+UehBsAFgm3LpiOAWIPJ+8xmIgBMwIOyUgNArMEEbNmeH4BJKCs07rpwNiDW4OLeu+A1ABMOtl3nrwFiDS7uriEAYArB9jjJOyMBiDUYz5Py208AmIYHhgAQazC6Q0tUAJim8gtBu0MCYg1G9Ng2/QDMwO8NASDWYHiHSZ4YBgCmrVwWxuwaINZgSGbVAJgls2uAWIMhvTAEAMxKmV17YyQAsQZne1N+aALALD03BIBYg7O9MgQAzFqnX70u50wDiDU4xWtDAICfQYBYg3p5Z2MRAOZo2xAAYg38kASgfsysAWINTvHOEAAwL2V1x3sjAYg1+OsfkmbWAJi3XUMAiDX4Nb/JBKAO9gwBINbg12wsAkAdWJIPiDX4gCWQAACINQAA/przpwGxBn9t3xAAACDWQKwBAIBYAwAAEGsAAACINQAAAMQaAACAWAMAAECsAQAAiDUAAADEGgAAgFgDAABArAEAACDWAAAAxBoAAABiDQAAQKwBAAAg1gAAAMQaAAAAYg0AAACxBgAAINYAAAAQawAAAGINAAAAsQYAACDWAAAAEGsAAACINQAAALEGAACAWAMAABBrAAAATN3lJHtJtgwFDbNnCACoCe+jaJp9Q9AMl46OjowCAABAzVgGCQAAINYAAAAQawAAAGINAAAAsQYAACDWAAAAEGsAAABiDQAAALEGAACAWAMAABBrAAAAiDUAAACxBgAAgFgDAAAQawAAAIg1AAAAxBoAAIBYAwAAQKwBAACINQAAAMQaAACAWAMAAECsAQAAINYAAADEGgAAAGINAABArAEAACDWAAAAxBoAAABiDQAAALEGAAAg1gAAABBrAAAAYg0AAACxBgAAINYAAAAQawAAAIg1AAAAsQYAAIBYAwAAEGsAAACINQAAALEGAACAWAMAAECsAQAAiDUAAADEGgAAQGtc+s+/+WQlyZqhoGF2O/3qwDAAMG+Dbm/DKNAwB51+tWsY6u9yCbXKUNAwvSTbhgGAGvA+iqZ5l+QTw1B/lkECAACINQAAAMQaAACAWAMAAECsAQAAiDUAAADEGgAAgFgDAABArAEAACDWAAAAxBoAAABiDQAAQKwBAAAg1gAAAMQaAAAAYg0AAACxBgAAINYAAAAQawAAAGINAAAAsQYAACDWAAAAEGsAAACINQAAALEGAACAWAMAABBrAAAAiDUAAACxBgAAgFgDAABArAEAAIg1AAAAxBoAAIBYAwAAQKwBAACINQAAAMQaAAAAYg0AAECsAQAAINYAAADEGgAAAGINAABArAEAACDWAAAAEGsAAABiDQAAALEGAAAg1gAAABBrAAAAYg0AAACxBgAAgFgDAAAQawAAAIg1AAAAsQYAAIBYAwAAEGsAAACINQAAAMQaAACAWAMAAECsAQAAiDUAAADEGgAAgFgDAABArAEAACDWAAAAxBoAAABiDQAAQKwBAAAg1gAAAMQaAAAAYg0AAACxBgAAINYAAAAQawAAAGINAAAAsQYAACDWAAAAEGsAAACINQAAALEGAACAWAMAABBrAAAAiDUAAACxBgAAgFgDAABArAEAAIg1AAAAxBoAAIBYAwAAQKwBAACINQAAAMQaAACAWAMAAECsAQAAINYAAADEGgAAAGINAABArAEAACDWAAAAxBoAAABiDQAAALEGAAAg1gAAABBrAAAAYg0AAACxBgAAINYAAAAQawAAAIg1AAAAsQYAAIBYAwAAEGsAAACINQAAALEGAACAWAMAAECsAQAAiDUAAADEGgAAgFgDAABArAEAAIg1AAAAxBoAAABiDQAAQKwBAAAg1gAAAMQaAAAAYg0AAECsAQAAINYAAAAQawAAAGINAAAAsQYAACDWAAAAEGsAAABiDQAAALEGAACAWAMAABBrAAAAiDUAAACxBgAAgFgDAAAQawAAAIg1AAAAxBoAAIBYAwAAQKwBAACINQAAAMQaAACAWAMAAECsAQAAINYAAADEGgAAAGINAABArAEAACDWAAAAxBoAAABiDQAAALEGAAAg1gAAABBrAAAAYg0AAACxBgAAINYAAAAQawAAAIg1AAAAsQYAAIBYAwAAEGsAAACINQAAALEGAACAWAMAAOBykr0kW4aChtkzBADUhPdRNM2+IWiGS0dHR0YBAACgZiyDBAAAEGsAAACINQAAALEGAACAWAMAABBrAAAAiDUAAACxBgAAgFgDAABArAEAAIg1AAAAxBoAAIBYAwAAQKwBAACINQAAAMQaAAAAYg0AAECsAQAAINYAAADEGgAAAGINAABArAEAACDWAAAAEGsAAABiDQAAALEGAAAg1gAAABBrAAAAYg0AAACxBgAAgFgDAAAQawAAAIg1AAAAsQYAAIBYAwAAEGsAAACINQAAAMQaAACAWAMAAECsAQAAiDUAAADEGgAAgFgDAABArAEAACDWAAAAxBoAAABiDQAAoDUu/efffLKSZM1Q0DC7nX51YBgAmLdBt7dhFGiYg06/2jUM9Xe5hFplKGiYXpJtwwBADXgfRdO8S/KJYag/yyABAADEGgAAAGINAABArAEAACDWAAAAxBoAAABiDQAAQKwBAAAg1gAAABBrAAAAYg0AAACxBgAAINYAAAAQawAAAGINAAAAsQYAAIBYAwAAEGsAAACINQAAALEGAACAWAMAABBrAAAAiDUAAADEGgAAgFgDAABArAEAAIg1AAAAxBoAAIBYgyZZNQQAAIg1EGsAACDWAACaYNDtrRkFQKzBr60bAgBqYMUQAGINfs0ySADqwMwaINbgA9cMAQBiDRBrUEPOEwBArAFiDeppwxAAMC+Dbm/FSg9ArIFYA6B+rhsCQKyBH5IA1M9NQwCINfi45UG3d8MwADAnfgYBYg3O4LeaAMxc+WXhspEAxBqc7vNygjcAzJJfFgJiDYZw2xAAMCvll4SfGwlArMH57hkCAGboS0MAiDUYzpVBt2d2DYCpK7NqfkkIiDUYwTeGAIAZ+NLGIoBYg9FcGXR7XxsGAKZl0O2tmlUDxBqM5175QQoA0/AHs2qAWIPxLJcfpAAwUeW6ap8aCUCswfg+HXR7lqgAMMlQW0ny1EgAYg0u7utBt7dmGACYkH+1/BEQazAZy0melt+EAsDYBt3e90muGwlArMHkXCu/CQWAcUPttgtgA2INpuP6oNtzjgEA44TajSQ/GAlArMH0fC7YABgx1NZsKAKINRBsANQr1G4n+cmGIoBYg9kG2082HQHgnFD7QagBYg1m73qSn2zrD8BHQu2pc9QAsQbzda0E221DAcCg21sddHt/SfK50QDEGszfcpIfBt3e/7EsEmChQ+1ekr+UX+QBiDWokU+T/Hv5YQ3A4kTaxqDb+ynJvzg/DRBrUF/LSf5l0O39P0sjAVofaavl3LSqnMcMUGuXDQEkSa6UpZHfJPl9ktedfnVgWABaEWkbSW47Lw0Qa9CCaEtyOOj2Xid53OlXu4YFoHGBtprkZpJ75f/tAGINWmK5/Ab280G3d5jkdZLtJNudfrVveABqGWgbZXnjTZuGAGINFizcypuBwyS75eOg/HlomABmaq38/3k9yao4A8QacBxv152cDgDANNkNEgAAQKwBAAAg1gAAAMQaAAAAYg0AAECsAQAAINYAAADEGgAAAGINAAAAsQYAACDWAAAAEGsAAABiDQAAALEGAAAg1gAAABBrAAAAiDUAAACxBgAAgFgDAAAQawAAAIg1AAAAsQYAAIBYAwAAQKwBAACINQAAAMQaAACAWAMAAECsAQAAiDUAAADEGgAAAGINAABArAEAACDWAAAAxBoAAABiDQAAQKwBAAAg1gAAABBrAAAAYg0AAACxBgAAINYAAAAQawAAAGINAAAAsQYAAIBYAwAAEGsAAACINQAAALEGAACAWAMAABBrAAAAiDUAAADEGgAAgFgDAABArAEAAIg1AAAAxBoAAIBYAwAAQKwBAAAg1gAAAMQaAAAAYg0AAECsAQAAINYAAADEGgAAAGINAAAAsQYAACDWAAAAEGsAAABiDQAAALEGAAAg1gAAABBrAAAAiDUAAACxBgAAgFgDAAAQawAAAIg1AAAAsQYAAIBYAwAAQKwBAACINQAAAMQaAACAWAMAAECsAQAAiDUAAADEGgAAAGINAABArAEAACDWAAAAxBoAAABiDQAAQKwBAAAg1gAAAMQaAAAAYg0AAIBzXTYEAABA2w26vatJriZZSbJ+ys12khwk2ev0qz2xBgAAMNkwW0myWT7Wk2yMcR9Jsl0CbifJy06/OhBrAAAAo8XV1SS3ktxJsjahu904EXr/e9Dt7SZ5VsJt6jNvYg0AAGhypG0muZ/k5gy+3FqSPyb546Dbe5XkWadfvRRrAAAA/xNpt5I8nOAs2qhuJrk56Pb2kzzs9Ktnk/4CdoMEAACaFGmbg27vbZJ/m2OonbRalkjulFm+iTGzBgAANCHSVspM2lc1PcS1JH8uyyPvTGIzEjNrAABA3UNts+zI+FUDDvdmkr2yTFOsAQAArQ21h0n+XJYbNsVykn8bdHuPLnInlkECAAB1jLSVsk3+zQY/jK8G3d56klvjLIsUawAAsFi2GxJqbye4gchhWUb5NslB+eePuVo+ji+mvTyBr72R5O2g29scNdgul4MFAABoU6jtJnlZLmC9M+axrJdwu+iFttfKeWyboxzLpaOjowy6vf/vZQEAAAthq9Ovtlocas+TPBo30M44tqtlN8pbF5hxO0yy3ulXe8Pc2AYjAACwWHZbGmrPk/xtp1/dmXSoJUmnX+11+tWdskzyT2PezXKSl+WxDh1r771mAQBgIRzW9LiejRlq20n+vkTa3rQPstOvDjr96n6Svx3z/L+1EqVDx5rz1gAAYDHs1e2Ayvb84+z6+F2nX21OYyZtiGjb6/SrzSS/GyOA14bZ1v841na9ZgEAoP06/Wq/ZqG2meTbET/tsMymPazBeD4qm5CMOq5fnXfh7ONY2/eyBQCA1ntXs1A7vpbaKHaTXJ3HbNoZwbZTtvofdRLs2Vnnr5lZAwCAxVG3SZqHSVZHDLXNcS4wPYNgOygzbKO01fJZsXpZrAEAwMKozflq5RpmX00q1MrW+ncmcGg7SXbG2ayk068OyrLOUXa1vFmuv/b2o7FW7vTnJFe8fgEAoLXqtAzy0Qi3PUxy65wZtatjnPt2Vkzul1mvZ6OE24lg2xlh1vBZOf5fWfqgVAEAgPaqxXv+EjMbI3zKrVlsy/+B1RJ//1F2qxxaicpbI+wSuTro9u6cFWvbXrsAANBa72t0rtco8fPdx5YIzti3g25vZ9iLWed/Nh15eJExEWsAALAYavF+f8RZtd06bM9frCV5O2KwPRph3Fc/3Mp/6cQd7db4auYAAEALYm3ETUDu12wM10acLbvQ41364C9few0DAEArzX1zkTIr9cWQN39eg+WPH/NVmR0cSjnX7rshb75RdrX8aKxZCgkAAC0MtZqcr3ZrhNtOevnjYemd0z5GWWU46iUCHo1w/7+M0eUP/sLMGgAAtE9d3ucPG2vPp7D7406nX505I1ZmzB4NcY20L0YJtrKd/8shZxXvHF/WYOnDO0nyxmsZAABa5VVNjuPmkLd7No+DK8suN4e5xMEoSyGLYWcK146XQi7V+IkEAAAu7n2nX+3P+yBGiJv9eZ6rduIaaedZH/F+90a4zt3mabFmKSQAALTH45ocx7Cx9nLeB1rC6rz9PFbGuOtno4zV0ikl+aPXNAAAtEJdJmMaE2vF2zne53pOmVlLkhde0wAA0Hg/1mQXyAy7bLCm2/VPRKdf7Qy5K+TaqbHW6VfbSX722gYAgEar0yTM8hC3qdOlxNandL87w9xo0O1dXTrj73/vtQ0AAI31vkzCzN0Im4vs1eR4V4ZYtjnusQ47c3hmrL0e8cJwAABAfTxu4DHv1eQ47g8xE7gz5cd4eqyVta2PvcYBAKBxfu70qzotgRx258SdeR/ooNt7mOTbc262X84/m2qsXT7nBk+S3BtyfSkAAFAPdTuladjzv6a5GcrKGcsxj5c93kqyOsR9zeSi3WfGWqdfHQy6vcdJvvZ6BwCARqjbrFpdrCX58wTu5zDJo1kc8NIQt3ni3DUAAGgMGwVO1/1ZXQ7h3Fhz7hoAADTGe7NqU/WnTr96NqsvNszMWjr9ast11wAAoPYe1PS4ht2MY6XGY/u7Tr+6P8svuDTCbe967QMAQG29qct11T5i2GWD6zU89u0kf9/pV5M6T+3qsIE7dKyVJ/6N7wEAAKidwyT/1ILHcbVmx7Pf6VebF9im/yKP8WBpxDv+J5uNAABA7Wx1+tV+XQ+u06/e1iDWDsss2cmP88ZsddDtTXrp4+aQt9tbGnGQ95Ns+V4AAIDaeNfpV03YEHCYmNyY4tffKbNkv3wMGU4PB93eJM+lG2qpZ6df7Y06s5byQnjnewIAAObusEF7S+wNc6NBt3drVgfU6Vd7SZ6fc7PlJA8n8fUG3d56ub/zbGfEDUZO+sxySAAAmLtaL3/8wLBLITdnfFz3h2ibrwbd3iSWaA772HbGjrVy7TW7QwIAwPy8acjyx1Fj7dYsD6q0zTA7PU7i+mp3ph5r5UG9TvLE9wgAAMzc+6ZNnoywycjqLJdCFo+GOKduY9DtjT3rV5ZArg1585cXirUy4A+cvwYAADN1mORumRFqmldD3u7OLA+qjOUw56VdZHZt2F0ld4+f26UJPLbPStkDAADTd7fTr3Ybeuwvh7zdzQmdIzZKsD073tjjDGNt5V8eyxdD3vyXIFyawIM6Pn/NhiMAADBd/1xOR2qqlyN0w6M5HN8ws2vjbOX/cMQxmkyslWDbTfKJYAMAgKn5sWEbinysGw5GnF3bnPHxvR1iqeZIW/mXc9WGnVV7VS4nMLlYOxFsD3wPAQDAVEKtLbuxP5rSbSdlmGWOX5UIm+rjXZrko+r0qxdJfut7CQAAhNopzbAzxLlhx9YG3d7DGR/fXpLvJhFh5fy2jSG/9P6HO2YuTeHBCTYAAJiM9y1dvTZKgH076+WQJcTOO8Vr46xLDJSZtz9eZEwuHR0dTeXRDbq920l+8P0FAABj+THJg4Zu0T9ML7wdYdbpMMlmmZU77f5Wkpy1NPHgrM8/JbbO20hk7+Q5Zh8cy145v20Y251+tTmzWBNsAAAwfqi1aenjKa1wNcl/jPApuyXYDmr+uFaSvB3hAthJ8r8+dtHwpWkeaFkS+Q92iQQAAKH2QSsMe27YsbUkb8fYNr/uofb8Y6E29VjLr7f1/9n3HQAAnOm3ixBqJzxKsj9GsK3X7YGMGWqHZ+0+uTSLAy/B9psk73z/AQDAR9+098rKtIVRljTeGvHTjoNtsy6Po8Tj3oihliS3zlrWuTTLJ6LTrz5J8sT3IgAA/OJ9kt90+tX2Ij74sunH70b8tOUkf571tv6nhNrDJP93hM1Ejn132vLHY1PdYOSMB3QjydMxHhAAALTJkyRbbd3xccRGeJbkizE+dTfJ/fPCZwrHu57k2RizaUnyqtOvzp1RnEuslQe3WoLtuu9RAAAWzGGSu51+9dpQ/KoRdsaMnyR5VaJtb8rHeLVcE+2LMe9i6F0t5xZrJx7svSRfm2UDAGBBvCmhdmAo/qoNxtmk42PR9mjSM23lHLk7F4i0jHr5gbnHWsyyAQCwGMymzS7YUnaZfJnk5bjhVgLtVvlYveDxjHyduFrE2onBuJHkD0mueJkCANAizk2bT7CdtF12bNxLspPkw+diJcn6iT83Jvi1x7qgd61i7cQT82WSe5ZGAgDQcO/KbNq+oRirDZ5dcNlhHbxKcmecUK9drH0k2r72MgUAoIGRtrWo2/FPuAvuJ/ljQw//u06/GvvyArWNtRNPzmqS22baAAAQaQsbbOvl/LPVhhzyfplNu9AmJ7WPtRNP0PFM2xfOaQMAoGZ+TPK40692DcVUe+B+km9rfqh/SvJwEucnNibWPniibpRo+9TLFgCAOfk5yeMkL2wcMtMWuFouRr1Rs0PbLpE2sUsGNDLWTjxRq0lulmWS17x0AQCYQaC9KoFmFm2+LbBZLk4972ibeKS1ItZOCbcNM24AAEzQ+/KGXKDVswPWy/LIWe8a+TzJs2lEWuti7SNP2ka5yPZGuT6DzUkAABglznaTbNt2vzHv/1dOXMD65pS+zKsTF9qe+tLX1sbaR568tbJ7zFq5yN1yiTkAABY3yg5KlO0n2bWLY6ve/28mOf5YH2Py5rBcPPvt8Z+zPjdxYWJtiJBbOfGfRBwAQHvsl48kiSBb+IBLee+//sFf75WPTHNp4yj+C6D00oJsbA//AAAAAElFTkSuQmCC
     mediatype: image/png
-  install:
-    spec:
-      deployments: null
-    strategy: ""
   installModes:
   - supported: true
     type: OwnNamespace
@@ -239,7 +26,7 @@ spec:
   - supported: false
     type: AllNamespaces
   keywords:
-  - OpenStack
+  - OpenStack Storage
   links:
   - name: Openstack Operator
     url: https://github.com/openstack-k8s-operators/
@@ -247,4 +34,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://redhat.com/
-  version: 0.1.0
+  version: 0.0.1


### PR DESCRIPTION
This patch splits out the openstack-storage-bundle. We may take a similar approach for grouping other operators to save space, but limit the number of bundle packages we maintain in the catalog.

The csv-merger gets 3 new options:
 --import-env-files Comma separated list of file names to read default operator ENVs from. Used for inter-bundle ENV merging.
 -- export-env-file: Name the external file to write operator ENVs to. Used for inter-bundle ENV merging.
 --alm-examples: a boolean to indicate whether almExamples should be
 processed for merged CSV (false by default we now only keep these in the main openstack-operator/bundle). This save space and we really only need them for top level CRDs. (TODO: are we going to move Dataplane into openstack-operator?, if not may need custom way to handle this)

With the above changes. The build process now works like this:
 -build openstack-operator-storage-bundle (--export-env-file is set
 where we write ENV vars to merge)
 -build openstack-operator-bundle (--import-env-files is used to read in
 the ENV vars from the storage bundle above)
 -a dependency.yaml now installs openstack-storage-operators when
 openstack-operator is installed

If we like this process further updates can be made to split out Rabbit, Network, and Ironic.