### PR TITLE
Fix inconsistent format of reconcile log

### DIFF
--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -32,7 +32,7 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling glance", "glance.Namespace", instance.Namespace, "glance.Name", "glance")
+	helper.GetLogger().Info("Reconciling Glance", "Glance.Namespace", instance.Namespace, "Glance.Name", "glance")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), glance, func() error {
 		instance.Spec.Glance.Template.DeepCopyInto(&glance.Spec)
 		if glance.Spec.Secret == "" {

--- a/pkg/openstack/ironic.go
+++ b/pkg/openstack/ironic.go
@@ -32,7 +32,7 @@ func ReconcileIronic(ctx context.Context, instance *corev1beta1.OpenStackControl
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling ironic", "ironic.Namespace", instance.Namespace, "ironic.Name", "ironic")
+	helper.GetLogger().Info("Reconciling Ironic", "Ironic.Namespace", instance.Namespace, "Ironic.Name", "ironic")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), ironic, func() error {
 		instance.Spec.Ironic.Template.DeepCopyInto(&ironic.Spec)
 		if ironic.Spec.Secret == "" {

--- a/pkg/openstack/keystone.go
+++ b/pkg/openstack/keystone.go
@@ -32,7 +32,7 @@ func ReconcileKeystoneAPI(ctx context.Context, instance *corev1beta1.OpenStackCo
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling KeystoneAPI", "KeystoneAPI.Namespace", instance.Namespace, "keystoneAPI.Name", "keystone")
+	helper.GetLogger().Info("Reconciling KeystoneAPI", "KeystoneAPI.Namespace", instance.Namespace, "KeystoneAPI.Name", "keystone")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), keystoneAPI, func() error {
 		instance.Spec.Keystone.Template.DeepCopyInto(&keystoneAPI.Spec)
 		if keystoneAPI.Spec.Secret == "" {

--- a/pkg/openstack/mariadb.go
+++ b/pkg/openstack/mariadb.go
@@ -102,7 +102,7 @@ func reconcileMariaDB(
 		return mariadbReady, nil
 	}
 
-	helper.GetLogger().Info("Reconciling MariaDB", "MariaDB.Namespace", instance.Namespace, "mariadb.Name", name)
+	helper.GetLogger().Info("Reconciling MariaDB", "MariaDB.Namespace", instance.Namespace, "Mariadb.Name", name)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), mariadb, func() error {
 		spec.DeepCopyInto(&mariadb.Spec)
 		if mariadb.Spec.Secret == "" {

--- a/pkg/openstack/neutron.go
+++ b/pkg/openstack/neutron.go
@@ -32,7 +32,7 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling neutronAPI", "neutronAPI.Namespace", instance.Namespace, "neutronAPI.Name", "neutron")
+	helper.GetLogger().Info("Reconciling NeutronAPI", "NeutronAPI.Namespace", instance.Namespace, "NeutronAPI.Name", "neutron")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), neutronAPI, func() error {
 		instance.Spec.Neutron.Template.DeepCopyInto(&neutronAPI.Spec)
 		if neutronAPI.Spec.Secret == "" {

--- a/pkg/openstack/placement.go
+++ b/pkg/openstack/placement.go
@@ -32,7 +32,7 @@ func ReconcilePlacementAPI(ctx context.Context, instance *corev1beta1.OpenStackC
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling placementAPI", "placementAPI.Namespace", instance.Namespace, "placementAPI.Name", "placement")
+	helper.GetLogger().Info("Reconciling PlacementAPI", "PlacementAPI.Namespace", instance.Namespace, "PlacementAPI.Name", "placement")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), placementAPI, func() error {
 		instance.Spec.Placement.Template.DeepCopyInto(&placementAPI.Spec)
 		if placementAPI.Spec.Secret == "" {


### PR DESCRIPTION
Currently the log for reconcile attempts have slightly different formats for sub CRs. This change makes the log formats consistent across all CRs.