### PR TITLE
Connect ovs pod to the tenant network

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -143,7 +143,7 @@ spec:
         system-id: "random"
         ovn-bridge: "br-int"
         ovn-encap-type: "geneve"
-      networkAttachment: internalapi
+      networkAttachment: tenant
   placement:
     template:
       containerImage: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -187,7 +187,7 @@ spec:
         system-id: "random"
         ovn-bridge: "br-int"
         ovn-encap-type: "geneve"
-      networkAttachment: internalapi
+      networkAttachment: tenant
   placement:
     template:
       containerImage: quay.io/tripleozedcentos9/openstack-placement-api:current-tripleo


### PR DESCRIPTION
In samples with network isolation enabled, lets connect ovs pods to the tenant network, instead of the internalapi. OVS pod can communicate with OVN DBs using internal OCP network provided to the PODs and tenant network attached to the pod using multus will be then used to establish tunnels with EDPM nodes.

Related: #[OSP-20056](https://issues.redhat.com//browse/OSP-20056)