### PR TITLE
Add revive to golanci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,16 @@ linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
-    errorlint
+    - errorlint
+    - revive
+    - gofmt
+    - govet
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: true
 run:
   timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,6 @@
 repos:
 - repo: local
   hooks:
-    - id: golangci-lint
-      name: golangci-lint
-      language: golang
-      types: [go]
-      entry: make
-      args: ["golangci-lint"]
-      pass_filenames: false
-    - id: gofmt
-      name: gofmt
-      language: system
-      entry: make
-      args: ["fmt"]
-      pass_filenames: false
-    - id: golint
-      name: golint
-      language: system
-      entry: make
-      args: ["golint"]
-      pass_filenames: false
-    - id: govet
-      name: govet
-      language: system
-      entry: make
-      args: ["vet"]
-      pass_filenames: false
     - id: gotidy
       name: gotidy
       language: system
@@ -79,3 +54,9 @@ repos:
   hooks:
     - id: bashate
       entry: bashate --error . --ignore=E006,E040,E011,E020,E012
+
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.52.2
+  hooks:
+    - id: golangci-lint
+      args: ["-v"]

--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,8 @@ vet: gowork ## Run go vet against code.
 
 .PHONY: tidy
 tidy: ## Run go mod tidy on every mod file in the repo
-	go mod tidy; \
-	pushd "$(LOCALBIN)/../apis"; \
-	go mod tidy; \
-	popd
+	go mod tidy
+	cd ./apis && go mod tidy
 
 .PHONY: golangci-lint
 golangci-lint:


### PR DESCRIPTION
This PR replace deprecated go-linter using
revive (https://golangci-lint.run/usage/linters/#revive).

We will add "ginkgolinter" in follow up patch once we merged add pre-commit job in openshift/releases.

If we add "ginkgolinter" in this patch then it's causes below issue [1]

```
level=info msg="[config_reader] Config search paths: [./ /home/prow/go/src/github.com/openstack-k8s-operators/dataplane-operator /home/prow/go/src/github.com/openstack-k8s-operators /home/prow/go/src/github.com /home/prow/go/src /home/prow/go /home/prow /home /]"
level=info msg="[config_reader] Used config file .golangci.yaml"
level=error msg="Running error: unknown linters: 'ginkgolinter', run 'golangci-lint help linters' to see the list of supported linters"
```

This patch also Remove fmt dependency from make tidy as per [2]:

The fmt dependency cannot be run if the go.mod file needs an update:
```
 $ make tidy
 go fmt ./...
 go: updates to go.mod needed; to update it:
        go mod tidy
 make: *** [Makefile:103: fmt] Error 1
```

I have also made some changes as per the comment given here [3]

[1]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openstack-k8s-operators_dataplane-operator/147/pull-ci-openstack-k8s-operators-dataplane-operator-main-golangci/1643555465537261568/artifacts/test/build-log.txt 
[2]: https://github.com/openstack-k8s-operators/placement-operator/pull/153
[3]: https://github.com/openstack-k8s-operators/cinder-operator/pull/147#discussion_r1158504341