### PR TITLE
Propagate extraMounts to Neutron

### DIFF
--- a/pkg/openstack/neutron.go
+++ b/pkg/openstack/neutron.go
@@ -44,6 +44,22 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 		if neutronAPI.Spec.DatabaseInstance == "" {
 			neutronAPI.Spec.DatabaseInstance = "openstack"
 		}
+
+		// if already defined at service level (template section), we don't merge
+		// with the global defined extra volumes
+		if len(neutronAPI.Spec.ExtraMounts) == 0 {
+
+			var neutronVolumes []neutronv1.NeutronExtraVolMounts
+
+			for _, ev := range instance.Spec.ExtraMounts {
+				neutronVolumes = append(neutronVolumes, neutronv1.NeutronExtraVolMounts{
+					Name:      ev.Name,
+					Region:    ev.Region,
+					VolMounts: ev.VolMounts,
+				})
+			}
+			neutronAPI.Spec.ExtraMounts = neutronVolumes
+		}
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), neutronAPI, helper.GetScheme())
 		if err != nil {
 			return err


### PR DESCRIPTION
This patch represents a follow up of [1], where `extraVolumes` are introduced in the `Neutron` operator. 
The code here is responsible to take a top-level (meta-operaotor) definition and propagate it to the
underlying service.

[1] https://github.com/openstack-k8s-operators/neutron-operator/pull/126