### PR TITLE
Add storageClass to Ironic

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -143,6 +143,7 @@ spec:
         containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
         pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
         storageRequest: 10G
+        storageClass: local-storage
       ironicInspector:
         replicas: 1
         containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo


### PR DESCRIPTION
ironic is `enabled: false` by default, but while trying to enable it ironic-conductor pvc is going to pending state:-

~~~
Normal  FailedBinding  5s (x5 over 55s)  persistentvolume-controller no persistent volumes available for this claim and no storage class is set 
~~~

With this patch, we add storageClass to Ironic so that pvc can bound to pv created using `make crc_storage` targets.