### PR TITLE
Set k8s binary as an option in order to be overriden by OCP bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 
+# K8S binary, default to kubectl.
+K8S_BIN ?= kubectl
+
 CRDDESC_OVERRIDE ?= :maxDescLen=0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
@@ -167,20 +170,20 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | $(K8S_BIN) apply -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/crd | $(K8S_BIN) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | $(K8S_BIN) apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/default | $(K8S_BIN) delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Build Dependencies
 


### PR DESCRIPTION
While installing openstack-operator on Openshift cluster, it can be necessary to override the kubectl binary by the Openshift bin.