### PR TITLE
Updated config samples for galera deployment

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -27,13 +27,13 @@ spec:
         storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
-        replicas: 1
+        replicas: 3
       openstack-cell1:
         containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
-        replicas: 1
+        replicas: 3
   rabbitmq:
     templates:
       rabbitmq:


### PR DESCRIPTION
Sync the galera config sample to match the default deployment. Add a deployment sample for 3-nodes galera clusters.