### PR TITLE
Container img defaults for Keystone and MariaDB

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -211,6 +211,29 @@ func (r *OpenStackControlPlane) Default() {
 
 // DefaultServices - common function for calling individual services' defaulting functions
 func (r *OpenStackControlPlane) DefaultServices() {
+	// MariaDB
+	if r.Spec.Mariadb.Enabled {
+		for index, template := range r.Spec.Mariadb.Templates {
+			template.Default()
+			// By-value copy, need to update
+			r.Spec.Mariadb.Templates[index] = template
+		}
+	}
+
+	// Galera
+	if r.Spec.Galera.Enabled {
+		for index, template := range r.Spec.Galera.Templates {
+			template.Default()
+			// By-value copy, need to update
+			r.Spec.Galera.Templates[index] = template
+		}
+	}
+
+	// Keystone
+	if r.Spec.Keystone.Enabled {
+		r.Spec.Keystone.Template.Default()
+	}
+
 	// Glance
 	if r.Spec.Glance.Enabled {
 		r.Spec.Glance.Template.Default()

--- a/main.go
+++ b/main.go
@@ -191,6 +191,20 @@ func setupServiceOperatorDefaults() {
 	// Acquire environmental defaults and initialize service operators that
 	// require each respective default
 
+	// Keystone
+	keystoneDefaults := keystonev1.KeystoneAPIDefaults{
+		ContainerImageURL: os.Getenv("KEYSTONE_API_IMAGE_URL_DEFAULT"),
+	}
+
+	keystonev1.SetupKeystoneAPIDefaults(keystoneDefaults)
+
+	// MariaDB
+	mariadbDefaults := mariadbv1.MariaDBDefaults{
+		ContainerImageURL: os.Getenv("MARIADB_IMAGE_URL_DEFAULT"),
+	}
+
+	mariadbv1.SetupMariaDBDefaults(mariadbDefaults)
+
 	// Glance
 	glanceDefaults := glancev1.GlanceDefaults{
 		ContainerImageURL: os.Getenv("GLANCE_API_IMAGE_URL_DEFAULT"),


### PR DESCRIPTION
Wire-in defaulting logic for Keystone and MariaDB now that we're using the latest versions of them (where `containerImage` is no longer defaulted via `kubebuilder` annotations, but instead is handled via defaulting webhooks).