### PR TITLE
[samples]Remove defaulted containerImage fields

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -7,28 +7,23 @@ spec:
   storageClass: local-storage
   keystone:
     template:
-      containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
       databaseInstance: openstack
       secret: osp-secret
   mariadb:
     templates:
       openstack:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
       openstack-cell1:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
   galera:
     enabled: false
     templates:
       openstack:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
         replicas: 1
       openstack-cell1:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
@@ -60,29 +55,20 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
       storageClass: ""
       storageRequest: 10G
-      glanceAPIInternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
-      glanceAPIExternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
   cinder:
     template:
       databaseInstance: openstack
       secret: osp-secret
       cinderAPI:
         replicas: 1
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
       cinderScheduler:
         replicas: 1
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
       cinderBackup:
         replicas: 0 # backend needs to be configured
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
       cinderVolumes:
         volume1:
-          containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
           replicas: 0 # backend needs to be configured
   manila:
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -7,12 +7,10 @@ spec:
   storageClass: local-storage
   keystone:
     template:
-      containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
       databaseInstance: openstack
       secret: osp-secret
   mariadb:
     template:
-      containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
       storageRequest: 500M
   rabbitmq:
     templates:
@@ -39,29 +37,20 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
       storageClass: ""
       storageRequest: 10G
-      glanceAPIInternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
-      glanceAPIExternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
   cinder:
     template:
       databaseInstance: openstack
       secret: osp-secret
       cinderAPI:
         replicas: 1
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
       cinderScheduler:
         replicas: 1
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
       cinderBackup:
         replicas: 0 # backend needs to be configured
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
       cinderVolumes:
         volume1:
-          containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
           replicas: 0 # backend needs to be configured
   ovn:
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -7,29 +7,24 @@ spec:
   storageClass: local-storage
   keystone:
     template:
-      containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
       databaseInstance: openstack
       secret: osp-secret
   mariadb:
     enabled: false
     templates:
       openstack:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
       openstack-cell1:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
   galera:
     enabled: true
     templates:
       openstack:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
         replicas: 1
       openstack-cell1:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
@@ -61,29 +56,20 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
       storageClass: ""
       storageRequest: 10G
-      glanceAPIInternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
-      glanceAPIExternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
   cinder:
     template:
       databaseInstance: openstack
       secret: osp-secret
       cinderAPI:
         replicas: 1
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
       cinderScheduler:
         replicas: 1
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
       cinderBackup:
         replicas: 0 # backend needs to be configured
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
       cinderVolumes:
         volume1:
-          containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
           replicas: 0 # backend needs to be configured
   manila:
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -7,29 +7,24 @@ spec:
   storageClass: local-storage
   keystone:
     template:
-      containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
       databaseInstance: openstack
       secret: osp-secret
   mariadb:
     enabled: false
     templates:
       openstack:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
       openstack-cell1:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
   galera:
     enabled: true
     templates:
       openstack:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
         replicas: 3
       openstack-cell1:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
@@ -61,29 +56,20 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
       storageClass: ""
       storageRequest: 10G
-      glanceAPIInternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
-      glanceAPIExternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
   cinder:
     template:
       databaseInstance: openstack
       secret: osp-secret
       cinderAPI:
         replicas: 1
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
       cinderScheduler:
         replicas: 1
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
       cinderBackup:
         replicas: 0 # backend needs to be configured
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
       cinderVolumes:
         volume1:
-          containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
           replicas: 0 # backend needs to be configured
   manila:
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -10,33 +10,26 @@ spec:
       databaseInstance: openstack
       secret: osp-secret
       cinderAPI:
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
         externalEndpoints:
         - endpoint: internal
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
       cinderBackup:
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
         networkAttachments:
         - storage
         replicas: 0 # backend needs to be configured
-      cinderScheduler:
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
       cinderVolumes:
         volume1:
-          containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
           networkAttachments:
           - storage
           replicas: 0 # backend needs to be configured
   glance:
     template:
       databaseInstance: openstack
-      containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
       storageClass: ""
       storageRequest: 10G
       glanceAPIInternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
         externalEndpoints:
         - endpoint: internal
           ipAddressPool: internalapi
@@ -45,12 +38,10 @@ spec:
         networkAttachments:
         - storage
       glanceAPIExternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
         networkAttachments:
         - storage
   keystone:
     template:
-      containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
       databaseInstance: openstack
       secret: osp-secret
       externalEndpoints:
@@ -61,10 +52,8 @@ spec:
   mariadb:
     templates:
       openstack:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
       openstack-cell1:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
   memcached:
     enabled: true

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -29,14 +29,12 @@ spec:
       databaseInstance: openstack
       secret: osp-secret
       cinderAPI:
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-api:current-tripleo
         externalEndpoints:
         - endpoint: internal
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
       cinderBackup:
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-backup:current-tripleo
         customServiceConfig: |
           [DEFAULT]
           backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
@@ -45,10 +43,8 @@ spec:
         networkAttachments:
         - storage
       cinderScheduler:
-        containerImage: quay.io/tripleozedcentos9/openstack-cinder-scheduler:current-tripleo
       cinderVolumes:
         ceph:
-          containerImage: quay.io/tripleozedcentos9/openstack-cinder-volume:current-tripleo
           customServiceConfig: |
             [DEFAULT]
             enabled_backends=ceph
@@ -66,7 +62,6 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
       customServiceConfig: |
         [DEFAULT]
         enabled_backends = default_backend:rbd
@@ -80,7 +75,6 @@ spec:
       storageClass: ""
       storageRequest: 10G
       glanceAPIInternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
         externalEndpoints:
         - endpoint: internal
           ipAddressPool: internalapi
@@ -89,12 +83,10 @@ spec:
         networkAttachments:
         - storage
       glanceAPIExternal:
-        containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
         networkAttachments:
         - storage
   keystone:
     template:
-      containerImage: quay.io/tripleozedcentos9/openstack-keystone:current-tripleo
       databaseInstance: openstack
       secret: osp-secret
       externalEndpoints:
@@ -105,10 +97,8 @@ spec:
   mariadb:
     templates:
       openstack:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
       openstack-cell1:
-        containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
         storageRequest: 500M
   memcached:
     enabled: true


### PR DESCRIPTION
We have defaulting webhook to set the containerImage fields so to actually test that webhook in the e2e job this patch removes the explicit values from the containerImage fields from our samples for those services where the webhook integration is already done in openstack-operator.