### PR TITLE
Add openstack-baremetal-operator to openstack-operator bundle

### DIFF
--- a/cmd/csv-merger/csv-merger.go
+++ b/cmd/csv-merger/csv-merger.go
@@ -104,6 +104,7 @@ var (
 	neutronCsv     = flag.String("neutron-csv", "", "Neutron CSV filename")
 	glanceCsv      = flag.String("glance-csv", "", "Glance CSV filename")
 	ironicCsv      = flag.String("ironic-csv", "", "Ironic CSV filename")
+	baremetalCsv   = flag.String("baremetal-csv", "", "Baremetal CSV filename")
 	manilaCsv      = flag.String("manila-csv", "", "Manila CSV filename")
 	placementCsv   = flag.String("placement-csv", "", "Placement CSV filename")
 	ovnCsv         = flag.String("ovn-csv", "", "OVN CSV filename")
@@ -147,6 +148,7 @@ func main() {
 		*manilaCsv,
 		*glanceCsv,
 		*ironicCsv,
+		*baremetalCsv,
 		*placementCsv,
 		*ovnCsv,
 		*ovsCsv,

--- a/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
@@ -30,14 +30,6 @@ spec:
       - description: Template - Overrides to use when creating Cinder Resources
         displayName: Template
         path: cinder.template
-      - description: ExtraMounts containing conf files and credentials that should
-          be provided to the underlying operators. This struct can be defined in the
-          top level CR and propagated to the underlying operators that accept it in
-          their API (e.g., cinder/glance). However, if extraVolumes are specified
-          within the single operator template Section, the globally defined ExtraMounts
-          are ignored and overridden for the operator which has this section already.
-        displayName: Extra Mounts
-        path: extraMounts
       - displayName: Vol Mounts
         path: extraMounts[0].extraVol
       - displayName: Name
@@ -66,6 +58,9 @@ spec:
       - description: Template - Overrides to use when creating the Glance Service
         displayName: Template
         path: glance.template
+      - description: Horizon - Parameters related to the Horizon services
+        displayName: Horizon
+        path: horizon
       - description: Ironic - Parameters related to the Ironic services
         displayName: Ironic
         path: ironic

--- a/custom-bundle.Dockerfile
+++ b/custom-bundle.Dockerfile
@@ -11,6 +11,7 @@ ARG ANSIBLEEE_BUNDLE=quay.io/openstack-k8s-operators/openstack-ansibleee-operato
 ARG DATAPLANE_BUNDLE=quay.io/openstack-k8s-operators/dataplane-operator-bundle:latest
 ARG NOVA_BUNDLE=quay.io/openstack-k8s-operators/nova-operator-bundle:latest
 ARG IRONIC_BUNDLE=quay.io/openstack-k8s-operators/ironic-operator-bundle:latest
+ARG BAREMETAL_BUNDLE=quay.io/openstack-k8s-operators/openstack-baremetal-operator-bundle:latest
 # we obtain the needed ENV vars containing defaults from storage operators
 ARG OPENSTACK_STORAGE_BUNDLE=quay.io/openstack-k8s-operators/openstack-operator-storage-bundle:latest
 ARG HORIZON_BUNDLE=quay.io/openstack-k8s-operators/horizon-operator-bundle:latest
@@ -48,6 +49,7 @@ FROM $ANSIBLEEE_BUNDLE as openstack-ansibleee-bundle
 FROM $DATAPLANE_BUNDLE as dataplane-bundle
 FROM $NOVA_BUNDLE as nova-bundle
 FROM $IRONIC_BUNDLE as ironic-bundle
+FROM $BAREMETAL_BUNDLE as baremetal-bundle
 FROM $OPENSTACK_STORAGE_BUNDLE as openstack-storage-bundle
 FROM $HORIZON_BUNDLE as horizon-bundle
 
@@ -71,6 +73,7 @@ COPY --from=openstack-ansibleee-bundle /manifests/* /manifests/
 COPY --from=dataplane-bundle /manifests/* /manifests/
 COPY --from=nova-bundle /manifests/* /manifests/
 COPY --from=ironic-bundle /manifests/* /manifests/
+COPY --from=baremetal-bundle /manifests/* /manifests/
 COPY --from=openstack-storage-bundle /env-vars.yaml /storage-env-vars.yaml
 COPY --from=horizon-bundle /manifests/* /manifests/
 
@@ -88,6 +91,7 @@ RUN /workspace/csv-merger \
   --dataplane-csv=/manifests/dataplane-operator.clusterserviceversion.yaml \
   --nova-csv=/manifests/nova-operator.clusterserviceversion.yaml \
   --ironic-csv=/manifests/ironic-operator.clusterserviceversion.yaml \
+  --baremetal-csv=/manifests/openstack-baremetal-operator.clusterserviceversion.yaml \
   --horizon-csv=/manifests/horizon-operator.clusterserviceversion.yaml \
   --base-csv=/manifests/openstack-operator.clusterserviceversion.yaml | tee /openstack-operator.clusterserviceversion.yaml.new
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230424090041-47807452e814
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230424084746-ecac2ab4efa0
 	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230419203517-e2dc6bc77bae
+	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230425095503-b6eeffe5c3c7
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20230424185627-72bfb0120cd1
 	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230424055933-51638f9e729f
 	github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20230424062457-1dd1d6c5611c
@@ -56,6 +57,8 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/metal3-io/baremetal-operator/apis v0.2.0 // indirect
+	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.1.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,10 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/metal3-io/baremetal-operator/apis v0.2.0 h1:JdkLP6zCp3KzWvycrUFbAH2geEJjxgpXoZ6TjMNZKQk=
+github.com/metal3-io/baremetal-operator/apis v0.2.0/go.mod h1:B5/1J/S2eXK8Fn9Aho/zgCeie7A8Nq5+dJvAbyzrS/c=
+github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.1.2 h1:9fbzEAanq4zO2quDVDb9Bg3dWjkKy8tUihZJsWGmxGs=
+github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.1.2/go.mod h1:dfWv/o1IDK2hrz2xJG2y1++GzYWxkRx0l/qjtpV6H7k=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -158,6 +162,8 @@ github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230424084746-ecac2
 github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230424084746-ecac2ab4efa0/go.mod h1:Ws7TMN4T1M0k//i61E06yLdi2TFDS6Pm1bG7Xbd9wp4=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230419203517-e2dc6bc77bae h1:CFfeXmE8IHiGZ8Nnw2ifKTk3FvH2saMPce+nGIvH2WA=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230419203517-e2dc6bc77bae/go.mod h1:l1GKO3RXfyQ5Z+c8d2ntEUCKZ1hEq2OVd8nNTPgDwkQ=
+github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230425095503-b6eeffe5c3c7 h1:9qz+ddbgxtVf5plzigUyCveWbBPF1iY5P52Iep8N5Gw=
+github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230425095503-b6eeffe5c3c7/go.mod h1:FOwZQb1fb5Wzfo2O+PD4zXc9qIZ0co3Dqu40xkzmd8Q=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230424055933-51638f9e729f h1:jbsDOXlUVxHt7Ic/JHbMWMWF0Cj49O4lpxWiMgLQjhI=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230424055933-51638f9e729f/go.mod h1:u/uz3GflMJBMXKOO/Xl/dE11DtJR0Tlb0sEePxJrHY0=
 github.com/openstack-k8s-operators/ovs-operator/api v0.0.0-20230424062457-1dd1d6c5611c h1:xgv4XmTbXQMtlg8U3gKpcFVw3gQQ0LwLnTHU3eZ2H9c=

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 	neutronv1 "github.com/openstack-k8s-operators/neutron-operator/api/v1beta1"
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	ansibleeev1 "github.com/openstack-k8s-operators/openstack-ansibleee-operator/api/v1alpha1"
+	baremetalv1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/api/v1beta1"
 	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
 	ovsv1 "github.com/openstack-k8s-operators/ovs-operator/api/v1beta1"
 	placementv1 "github.com/openstack-k8s-operators/placement-operator/api/v1beta1"
@@ -77,6 +78,7 @@ func init() {
 	utilruntime.Must(glancev1.AddToScheme(scheme))
 	utilruntime.Must(cinderv1.AddToScheme(scheme))
 	utilruntime.Must(novav1.AddToScheme(scheme))
+	utilruntime.Must(baremetalv1.AddToScheme(scheme))
 	utilruntime.Must(ironicv1.AddToScheme(scheme))
 	utilruntime.Must(ovnv1.AddToScheme(scheme))
 	utilruntime.Must(ovsv1.AddToScheme(scheme))


### PR DESCRIPTION
We already have dataplane-operator that needs it for baremetal provisioning. We probably should create separate bundle for dataplane-operator that includes it in the future.