### PR TITLE
Add support for using local registry for bundle build

### DIFF
--- a/hack/pin-custom-bundle-dockerfile.sh
+++ b/hack/pin-custom-bundle-dockerfile.sh
@@ -5,6 +5,7 @@ DOCKERFILE=${DOCKERFILE:-"custom-bundle.Dockerfile"}
 IMAGENAMESPACE=${IMAGENAMESPACE:-"openstack-k8s-operators"}
 IMAGEREGISTRY=${IMAGEREGISTRY:-"quay.io"}
 IMAGEBASE=${IMAGEBASE:-}
+LOCAL_REGISTRY=${LOCAL_REGISTRY:-0}
 
 cp "$DOCKERFILE" "${DOCKERFILE}.pinned"
 
@@ -23,14 +24,25 @@ for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("ope
     REPO_URL="quay.io/openstack-k8s-operators"
     if [[ "$GITHUB_USER" != "openstack-k8s-operators" || "$BASE" == "$IMAGEBASE" ]]; then
         if [[ "$IMAGENAMESPACE" != "openstack-k8s-operators" || "${IMAGEREGISTRY}" != "quay.io" ]]; then
-            REPO_CURL_URL="https://${IMAGEREGISTRY}/api/v1/repository/${IMAGENAMESPACE}"
             REPO_URL="${IMAGEREGISTRY}/${IMAGENAMESPACE}"
+            # Quay registry v2 api does not return all the tags that's why keeping v1 for quay and v2
+            # for local registry
+            if [[ ${LOCAL_REGISTRY} -eq 1 ]]; then
+                REPO_CURL_URL="${IMAGEREGISTRY}/v2/${IMAGENAMESPACE}"
+            else
+                REPO_CURL_URL="https://${IMAGEREGISTRY}/api/v1/repository/${IMAGENAMESPACE}"
+            fi
         else
             REPO_CURL_URL="https://quay.io/api/v1/repository/${GITHUB_USER}"
             REPO_URL="quay.io/${GITHUB_USER}"
         fi
     fi
 
-    SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/ | jq -r .tags[].name | sort -u | grep $REF)
+    if [[ ${LOCAL_REGISTRY} -eq 1 && "$BASE" == "$IMAGEBASE" ]]; then
+        SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tags/list | jq -r .tags[] | sort -u | grep $REF)
+    else
+        SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/ | jq -r .tags[].name | sort -u | grep $REF)
+    fi
+
     sed -i "${DOCKERFILE}.pinned" -e "s|quay.io/openstack-k8s-operators/${BASE}-operator-bundle.*|${REPO_URL}/${BASE}-operator-bundle:$SHA|"
 done


### PR DESCRIPTION
registry:2 container image is used to spin a local registry.
It supports v2 api.
    
The Quay registry supports both v1 and v2 api. While using v2 api
on quay registry, it does not list all the tags which breaks the
scripts. That's why we have not moved the existing api to v2.
    
registry:2 supports only v2. for making sure both quay and local
registry works together.
    
This patch adds LOCAL_REGISTRY flag to set the v2 api.
By setting LOCAL_REGISTRY=1, v2 api for local registry
can be used.
