### PR TITLE
[sample][memcached]Remove unnecessary defaults

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -43,10 +43,6 @@ spec:
         replicas: 1
   memcached:
     enabled: true
-    templates:
-      memcached:
-        containerImage: quay.io/tripleozedcentos9/openstack-memcached:current-tripleo
-        replicas: 1
   placement:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -25,10 +25,6 @@ spec:
         #    memory: 1Gi
   memcached:
     enabled: true
-    templates:
-      memcached:
-        containerImage: quay.io/tripleozedcentos9/openstack-memcached:current-tripleo
-        replicas: 1
   placement:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -44,10 +44,6 @@ spec:
         replicas: 1
   memcached:
     enabled: true
-    templates:
-      memcached:
-        containerImage: quay.io/tripleozedcentos9/openstack-memcached:current-tripleo
-        replicas: 1
   placement:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -44,10 +44,6 @@ spec:
         replicas: 1
   memcached:
     enabled: true
-    templates:
-      memcached:
-        containerImage: quay.io/tripleozedcentos9/openstack-memcached:current-tripleo
-        replicas: 1
   placement:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -57,10 +57,6 @@ spec:
         storageRequest: 500M
   memcached:
     enabled: true
-    templates:
-      memcached:
-        containerImage: quay.io/tripleozedcentos9/openstack-memcached:current-tripleo
-        replicas: 1
   neutron:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -102,10 +102,6 @@ spec:
         storageRequest: 500M
   memcached:
     enabled: true
-    templates:
-      memcached:
-        containerImage: quay.io/tripleozedcentos9/openstack-memcached:current-tripleo
-        replicas: 1
   neutron:
     template:
       databaseInstance: openstack


### PR DESCRIPTION
The webhook in memcached should do the defaulting now for the containerImage and replica is defaulted to 1 by kubebuilder.