### PR TITLE
Add container image default for ironic-neutron-agent

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -3570,6 +3570,7 @@ spec:
                             default: ironic
                             type: string
                         required:
+                        - containerImage
                         - secret
                         type: object
                       nodeSelector:

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20230426101116-5f864a95a7f0
 	github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230428015055-da1916fc8b28
 	github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230427061808-1c6403dc94b9
-	github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230427202945-96cb74d13756
+	github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230502101103-ef1ee2aaba47
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230426060801-5bd3d7853af0
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230427065458-ec1b923df88c
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230427165826-cc152c2f69e8

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -128,8 +128,8 @@ github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230428015055-da
 github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230428015055-da1916fc8b28/go.mod h1:d6Bl9OsnnMnrNFz8iH4+c0v0DupUMTYW65rDGdzU4Kc=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230427061808-1c6403dc94b9 h1:RFkPp9sSUIxzHdJN+FSFnoL1Ma9m3nKh0DcQO8xvDWI=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230427061808-1c6403dc94b9/go.mod h1:f5d795S8RoJn07i0nYCevFJ7rcNbszb4dgyUfOwt3ik=
-github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230427202945-96cb74d13756 h1:yQ/qWfDe+RIPhVHDNEsZCCEaLwoMeBxdmuJ5YmE1GyU=
-github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230427202945-96cb74d13756/go.mod h1:8q5IvQ51KwZ38/J71lbtOZFDsejH4IT89iIpNS46FcU=
+github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230502101103-ef1ee2aaba47 h1:FNE+mVpwMtELNpuNcPN1yDJkUy9ughi88YTsnkpUQVg=
+github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230502101103-ef1ee2aaba47/go.mod h1:8q5IvQ51KwZ38/J71lbtOZFDsejH4IT89iIpNS46FcU=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230426060801-5bd3d7853af0 h1:WwW4bMNz6EZSh3tR9z3OmEuOmenxnGt6gU3lKBF9NIY=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230426060801-5bd3d7853af0/go.mod h1:9Amhqb6U06GyF/+b6KpBdDR63aanc5tMnNuzisShUUU=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230427065458-ec1b923df88c h1:NdiOLRgA3hMnfWq92lgnPfeNVb7d/7dTh+XPByq9yxg=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -3570,6 +3570,7 @@ spec:
                             default: ironic
                             type: string
                         required:
+                        - containerImage
                         - secret
                         type: object
                       nodeSelector:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20230426101116-5f864a95a7f0
 	github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230428015055-da1916fc8b28
 	github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230427061808-1c6403dc94b9
-	github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230427202945-96cb74d13756
+	github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230502101103-ef1ee2aaba47
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230426060801-5bd3d7853af0
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230427065458-ec1b923df88c
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230427165826-cc152c2f69e8

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230428015055-da
 github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230428015055-da1916fc8b28/go.mod h1:d6Bl9OsnnMnrNFz8iH4+c0v0DupUMTYW65rDGdzU4Kc=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230427061808-1c6403dc94b9 h1:RFkPp9sSUIxzHdJN+FSFnoL1Ma9m3nKh0DcQO8xvDWI=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230427061808-1c6403dc94b9/go.mod h1:f5d795S8RoJn07i0nYCevFJ7rcNbszb4dgyUfOwt3ik=
-github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230427202945-96cb74d13756 h1:yQ/qWfDe+RIPhVHDNEsZCCEaLwoMeBxdmuJ5YmE1GyU=
-github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230427202945-96cb74d13756/go.mod h1:8q5IvQ51KwZ38/J71lbtOZFDsejH4IT89iIpNS46FcU=
+github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230502101103-ef1ee2aaba47 h1:FNE+mVpwMtELNpuNcPN1yDJkUy9ughi88YTsnkpUQVg=
+github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230502101103-ef1ee2aaba47/go.mod h1:8q5IvQ51KwZ38/J71lbtOZFDsejH4IT89iIpNS46FcU=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230426060801-5bd3d7853af0 h1:WwW4bMNz6EZSh3tR9z3OmEuOmenxnGt6gU3lKBF9NIY=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230426060801-5bd3d7853af0/go.mod h1:9Amhqb6U06GyF/+b6KpBdDR63aanc5tMnNuzisShUUU=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230427065458-ec1b923df88c h1:NdiOLRgA3hMnfWq92lgnPfeNVb7d/7dTh+XPByq9yxg=

--- a/main.go
+++ b/main.go
@@ -217,6 +217,7 @@ func setupServiceOperatorDefaults() {
 		ConductorContainerImageURL: os.Getenv("IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT"),
 		InspectorContainerImageURL: os.Getenv("IRONIC_INSPECTOR_IMAGE_URL_DEFAULT"),
 		PXEContainerImageURL:       os.Getenv("IRONIC_PXE_IMAGE_URL_DEFAULT"),
+		INAContainerImageURL:       os.Getenv("IRONIC_NEUTRON_AGENT_IMAGE_URL_DEFAULT"),
 	}
 
 	ironicv1.SetupIronicDefaults(ironicDefaults)


### PR DESCRIPTION
Bump ironic-operator to latest and add defaulting for ironic-neutron-agent image.

Jira: [osp-24700](https://issues.redhat.com//browse/osp-24700)