### PR TITLE
Refine ironic template in config samples

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -112,7 +112,8 @@ spec:
       ironicConductors:
       - replicas: 1
         storageRequest: 10G
-        storageClass: local-storage
       ironicInspector:
+        replicas: 1
+      ironicNeutronAgent:
         replicas: 1
       secret: osp-secret

--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -102,4 +102,6 @@ spec:
         storageRequest: 10G
       ironicInspector:
         replicas: 1
+      ironicNeutronAgent:
+        replicas: 1
       secret: osp-secret

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -113,7 +113,8 @@ spec:
       ironicConductors:
       - replicas: 1
         storageRequest: 10G
-        storageClass: local-storage
       ironicInspector:
+        replicas: 1
+      ironicNeutronAgent:
         replicas: 1
       secret: osp-secret

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -113,7 +113,8 @@ spec:
       ironicConductors:
       - replicas: 1
         storageRequest: 10G
-        storageClass: local-storage
       ironicInspector:
+        replicas: 1
+      ironicNeutronAgent:
         replicas: 1
       secret: osp-secret

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -161,4 +161,6 @@ spec:
         storageRequest: 10G
       ironicInspector:
         replicas: 1
+      ironicNeutronAgent:
+        replicas: 1
       secret: osp-secret

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -206,4 +206,6 @@ spec:
         storageRequest: 10G
       ironicInspector:
         replicas: 1
+      ironicNeutronAgent:
+        replicas: 1
       secret: osp-secret


### PR DESCRIPTION
This change does the following:
- Add missing service config for new service ironicNeutronAgent
- Remove remaining storageClass attributes