### PR TITLE
Bump horizon-operator

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -2984,7 +2984,6 @@ spec:
                   template:
                     properties:
                       containerImage:
-                        default: quay.io/podified-antelope-centos9/openstack-horizon:current-podified
                         type: string
                       customServiceConfig:
                         default: '# add your customization here'
@@ -3062,6 +3061,7 @@ spec:
                       sharedMemcached:
                         type: string
                     required:
+                    - containerImage
                     - secret
                     type: object
                 type: object

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -21,7 +21,7 @@ import (
 
 	cinderv1 "github.com/openstack-k8s-operators/cinder-operator/api/v1beta1"
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
-	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1alpha1"
+	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1beta1"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230503135759-feac84f5479a
 	github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20230509104211-270c0b77e1d8
-	github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230505031807-115c487f9587
+	github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230511025710-20ef2232badc
 	github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230505165400-46c5e7325f0d
 	github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230508065320-dc6d70c5187a
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230508152039-4d8f35e8b317

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -124,8 +124,8 @@ github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230503135759-fea
 github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230503135759-feac84f5479a/go.mod h1:VHo557CgE1hX48JNdBtAlRpSSYquWkqRNcykMKrKATQ=
 github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20230509104211-270c0b77e1d8 h1:OGdwzZsDWjXnUCfUZdSmWvdEsK7nAvtpGg+ynLQqSnI=
 github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20230509104211-270c0b77e1d8/go.mod h1:fuQmko/6uilDf+AiWR3HeYUYv2JkeLWGF813BF7QEHE=
-github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230505031807-115c487f9587 h1:lDH36k0FUgI4jsYkRTZ1XWrbfmgU29lfRRpSJU9YsjQ=
-github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230505031807-115c487f9587/go.mod h1:d6Bl9OsnnMnrNFz8iH4+c0v0DupUMTYW65rDGdzU4Kc=
+github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230511025710-20ef2232badc h1:gP+s8B7YU9OyW4900GXrf3nWuBtwdXQneIQDasHjamA=
+github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230511025710-20ef2232badc/go.mod h1:aX89VD2zUjg6JIrGUezUpclXBjs5hzJLFuuIgaeow90=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230505165400-46c5e7325f0d h1:84Esxv8bl9AM2W3vRmObzOx6YxLJXIioLrr8+jaQeHw=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230505165400-46c5e7325f0d/go.mod h1:FNMsD6dzcDpx8F6bJIgS/KKjtJufekAPnE8U/xCIpq4=
 github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230508065320-dc6d70c5187a h1:6xRyc423CqqT9dZO4VO6zEECMmg8Dgf2klWtA1RURX4=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -2984,7 +2984,6 @@ spec:
                   template:
                     properties:
                       containerImage:
-                        default: quay.io/podified-antelope-centos9/openstack-horizon:current-podified
                         type: string
                       customServiceConfig:
                         default: '# add your customization here'
@@ -3062,6 +3061,7 @@ spec:
                       sharedMemcached:
                         type: string
                     required:
+                    - containerImage
                     - secret
                     type: object
                 type: object

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -22,7 +22,7 @@ import (
 
 	cinderv1 "github.com/openstack-k8s-operators/cinder-operator/api/v1beta1"
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
-	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1alpha1"
+	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1beta1"
 	clientv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/client/v1beta1"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230503135759-feac84f5479a
 	github.com/openstack-k8s-operators/dataplane-operator/api v0.0.0-20230509105748-90bdb364c0ea
 	github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20230509104211-270c0b77e1d8
-	github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230505031807-115c487f9587
+	github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230511025710-20ef2232badc
 	github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230505165400-46c5e7325f0d
 	github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230508065320-dc6d70c5187a
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230508152039-4d8f35e8b317

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/openstack-k8s-operators/dataplane-operator/api v0.0.0-20230509105748-
 github.com/openstack-k8s-operators/dataplane-operator/api v0.0.0-20230509105748-90bdb364c0ea/go.mod h1:SpOrPUsSm7kQjR1vhOdh6stBebj7UGnX5HFBULAYV2Q=
 github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20230509104211-270c0b77e1d8 h1:OGdwzZsDWjXnUCfUZdSmWvdEsK7nAvtpGg+ynLQqSnI=
 github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20230509104211-270c0b77e1d8/go.mod h1:fuQmko/6uilDf+AiWR3HeYUYv2JkeLWGF813BF7QEHE=
-github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230505031807-115c487f9587 h1:lDH36k0FUgI4jsYkRTZ1XWrbfmgU29lfRRpSJU9YsjQ=
-github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230505031807-115c487f9587/go.mod h1:d6Bl9OsnnMnrNFz8iH4+c0v0DupUMTYW65rDGdzU4Kc=
+github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230511025710-20ef2232badc h1:gP+s8B7YU9OyW4900GXrf3nWuBtwdXQneIQDasHjamA=
+github.com/openstack-k8s-operators/horizon-operator/api v0.0.0-20230511025710-20ef2232badc/go.mod h1:aX89VD2zUjg6JIrGUezUpclXBjs5hzJLFuuIgaeow90=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230505165400-46c5e7325f0d h1:84Esxv8bl9AM2W3vRmObzOx6YxLJXIioLrr8+jaQeHw=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230505165400-46c5e7325f0d/go.mod h1:FNMsD6dzcDpx8F6bJIgS/KKjtJufekAPnE8U/xCIpq4=
 github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230508065320-dc6d70c5187a h1:6xRyc423CqqT9dZO4VO6zEECMmg8Dgf2klWtA1RURX4=

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 	cinderv1 "github.com/openstack-k8s-operators/cinder-operator/api/v1beta1"
 	dataplanev1beta1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
-	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1alpha1"
+	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1beta1"
 	clientv1 "github.com/openstack-k8s-operators/infra-operator/apis/client/v1beta1"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"

--- a/pkg/openstack/horizon.go
+++ b/pkg/openstack/horizon.go
@@ -9,7 +9,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1alpha1"
+	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1beta1"
 	corev1beta1 "github.com/openstack-k8s-operators/openstack-operator/apis/core/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION
We have updated api version of horizon-operator from v1alpha to v1beta. This bumps the operator version and adapt to the new api version.

Depends-on: https://github.com/openstack-k8s-operators/horizon-operator/pull/110