### PR TITLE
Move ironic template defaulting to the webhook

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -232,6 +232,18 @@ func (r *OpenStackControlPlane) DefaultServices() {
 
 	// Ironic
 	if r.Spec.Ironic.Enabled {
+		// Default Secret
+		if r.Spec.Ironic.Template.Secret == "" {
+			r.Spec.Ironic.Template.Secret = r.Spec.Secret
+		}
+		// Default DatabaseInstance
+		if r.Spec.Ironic.Template.DatabaseInstance == "" {
+			r.Spec.Ironic.Template.DatabaseInstance = "openstack"
+		}
+		// Default StorageClass
+		if r.Spec.Ironic.Template.StorageClass == "" {
+			r.Spec.Ironic.Template.StorageClass = r.Spec.StorageClass
+		}
 		r.Spec.Ironic.Template.Default()
 	}
 

--- a/pkg/openstack/ironic.go
+++ b/pkg/openstack/ironic.go
@@ -35,15 +35,6 @@ func ReconcileIronic(ctx context.Context, instance *corev1beta1.OpenStackControl
 	helper.GetLogger().Info("Reconciling Ironic", "Ironic.Namespace", instance.Namespace, "Ironic.Name", "ironic")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), ironic, func() error {
 		instance.Spec.Ironic.Template.DeepCopyInto(&ironic.Spec)
-		if ironic.Spec.Secret == "" {
-			ironic.Spec.Secret = instance.Spec.Secret
-		}
-		if ironic.Spec.DatabaseInstance == "" {
-			ironic.Spec.DatabaseInstance = "openstack"
-		}
-		if ironic.Spec.StorageClass == "" {
-			ironic.Spec.StorageClass = instance.Spec.StorageClass
-		}
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), ironic, helper.GetScheme())
 		if err != nil {
 			return err


### PR DESCRIPTION
Setting the values for Secret, DatabaseInstance and StorageClass in pkg/ironic makes the API result listing the spec for OpenstackControlplane not match actual settings used.

Also, defaulting in the pkg does not work as intended since the webhook call to ironic-operator explicitly set values such as the StorageClass for each conductor in "ironicConductors" - i.e setting StorageClass in the top level "ironics" in pkg/ironic never apply to the conductors. This caused invalid "" be defined for conductors when actual intent was to default it based on what was defined for top level ironics.

This change moves the defaulting of top level ironics properties to the webhook in openstack-controlplane, the defaulting happens before calling the Default() function in the ironic-operator.