### PR TITLE
fix local registry support for PRs

### DIFF
--- a/hack/pin-custom-bundle-dockerfile.sh
+++ b/hack/pin-custom-bundle-dockerfile.sh
@@ -38,7 +38,7 @@ for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("ope
         fi
     fi
 
-    if [[ ${LOCAL_REGISTRY} -eq 1 && "$BASE" == "$IMAGEBASE" ]]; then
+    if [[ ${LOCAL_REGISTRY} -eq 1 && ( "$GITHUB_USER" != "openstack-k8s-operators" || "$BASE" == "$IMAGEBASE" ) ]]; then
         SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tags/list | jq -r .tags[] | sort -u | grep $REF)
     else
         SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/ | jq -r .tags[].name | sort -u | grep $REF)


### PR DESCRIPTION
This change updates the pin custom bundle script
to use the same critia to determin if the v2 or v1
endpoint should be used when generating the resouce url
jq expression.

Related: [OSPRH-97](https://issues.redhat.com//browse/OSPRH-97)