### PR TITLE
Fix Manila template when ManilaShares is empty

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230530140223-8d469a030aac
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230530145010-0343d3afb6db
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230530112722-aca578f65ec9
-	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230530073843-dcf75fc7c99f
+	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230531112752-020ab5f5c9c6
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230523102317-8b60f83b1d1f
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230530043145-5ddcfcff15e5
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230530075145-122c78de03fc

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -138,8 +138,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-202305301
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20230530112722-aca578f65ec9/go.mod h1:1Ka9t16pCIdnb/tgjYtL6xeIcN8GFAUxyz6x5UzzDbU=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230530112722-aca578f65ec9 h1:e5pkK2XNAVUQxbXrzjczC/lfs0t08hXrmxliVC2tAR0=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230530112722-aca578f65ec9/go.mod h1:7sbo6DydOwpl8Ex1atTbXIrWYvZ++eSOJ0Z6RphJJ44=
-github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230530073843-dcf75fc7c99f h1:v6CLH5a5etjVt0CfWN23yuoLj/0EtHeDXBJFrrgYgV4=
-github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230530073843-dcf75fc7c99f/go.mod h1:SFVadZE/vIFs4tItbfRg/bArnJ4uMgqVlvCYEp5jqh8=
+github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230531112752-020ab5f5c9c6 h1:ErxECkoS4an37SvD4aeXwRBRqu88mrugDKL3/lWo6SA=
+github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230531112752-020ab5f5c9c6/go.mod h1:SFVadZE/vIFs4tItbfRg/bArnJ4uMgqVlvCYEp5jqh8=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230523102317-8b60f83b1d1f h1:RljVu7USKBTSL6Y3wbn6TKYUddk09T8MquvqbBjaJ74=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230523102317-8b60f83b1d1f/go.mod h1:YRgmQI2Z0IbQnDrU1jqvZqntSBmCmBU9CSbzoqPjrPw=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230530043145-5ddcfcff15e5 h1:KsKLeEbZiVS61DOCa5j8ikeULk2p3rgTWNgvXAXojls=

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openstack-k8s-operators/ironic-operator/api v0.0.0-20230530140223-8d469a030aac
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230530145010-0343d3afb6db
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230530112722-aca578f65ec9
-	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230530073843-dcf75fc7c99f
+	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230531112752-020ab5f5c9c6
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230523102317-8b60f83b1d1f
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230530043145-5ddcfcff15e5
 	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230530075145-122c78de03fc

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-202305301
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20230530112722-aca578f65ec9/go.mod h1:1Ka9t16pCIdnb/tgjYtL6xeIcN8GFAUxyz6x5UzzDbU=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230530112722-aca578f65ec9 h1:e5pkK2XNAVUQxbXrzjczC/lfs0t08hXrmxliVC2tAR0=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230530112722-aca578f65ec9/go.mod h1:7sbo6DydOwpl8Ex1atTbXIrWYvZ++eSOJ0Z6RphJJ44=
-github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230530073843-dcf75fc7c99f h1:v6CLH5a5etjVt0CfWN23yuoLj/0EtHeDXBJFrrgYgV4=
-github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230530073843-dcf75fc7c99f/go.mod h1:SFVadZE/vIFs4tItbfRg/bArnJ4uMgqVlvCYEp5jqh8=
+github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230531112752-020ab5f5c9c6 h1:ErxECkoS4an37SvD4aeXwRBRqu88mrugDKL3/lWo6SA=
+github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230531112752-020ab5f5c9c6/go.mod h1:SFVadZE/vIFs4tItbfRg/bArnJ4uMgqVlvCYEp5jqh8=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230523102317-8b60f83b1d1f h1:RljVu7USKBTSL6Y3wbn6TKYUddk09T8MquvqbBjaJ74=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230523102317-8b60f83b1d1f/go.mod h1:YRgmQI2Z0IbQnDrU1jqvZqntSBmCmBU9CSbzoqPjrPw=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230530043145-5ddcfcff15e5 h1:KsKLeEbZiVS61DOCa5j8ikeULk2p3rgTWNgvXAXojls=


### PR DESCRIPTION
Pulls-in latest Manila bits to avoid this error when Manila template is left blank:

```
The OpenStackControlPlane "openstack-collapsed-cell" is invalid: spec.manila.template.manilaShares: Invalid value: "null": spec.manila.template.manilaShares in body must be of type object: "null"
```