### PR TITLE
Sync mariadb and galera network_isolation config samples

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -145,13 +145,12 @@ spec:
           networkAttachment: internalapi
       ovnNorthd:
         networkAttachment: internalapi
-  ovs:
-    template:
-      external-ids:
-        system-id: "random"
-        ovn-bridge: "br-int"
-        ovn-encap-type: "geneve"
-      networkAttachment: tenant
+      ovnController:
+        external-ids:
+          system-id: "random"
+          ovn-bridge: "br-int"
+          ovn-encap-type: "geneve"
+        networkAttachment: tenant
   placement:
     template:
       databaseInstance: openstack


### PR DESCRIPTION
To match commit 0b9730ed21909c3253109a22aac6e9d0b561d636