### PR TITLE
Add EDPM based zuul jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,0 +1,33 @@
+---
+- job:
+    name: openstack-operator-content-provider
+    parent: content-provider-base
+    vars:
+      cifmw_operator_build_org: openstack-k8s-operators
+      cifmw_operator_build_operators:
+        - name: "openstack-operator"
+          src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
+          image_base: openstack
+    irrelevant-files:
+      - tests/kuttl
+      - containers/ci
+      - .github/workflows
+      - .ci-operator.yaml
+      - .dockerignore
+      - .gitignore
+      - .golangci.yaml
+      - .pre-commit-config.yaml
+      - LICENSE
+      - OWNERS*
+      - PROJECT
+      - .*/*.md
+      - kuttl-test.yaml
+      - renovate.json
+
+- job:
+    name: openstack-operator-crc-podified-edpm-deployment
+    parent: cifmw-crc-podified-edpm-deployment
+
+- job:
+    name: openstack-operator-crc-podified-edpm-baremetal
+    parent: cifmw-crc-podified-edpm-baremetal

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,0 +1,10 @@
+---
+- project:
+    name: openstack-k8s-operators/openstack-operator
+    github-check:
+      jobs:
+        - openstack-operator-content-provider
+        - openstack-operator-crc-podified-edpm-baremetal: &content_provider
+            dependencies:
+              - openstack-operator-content-provider
+        - openstack-operator-crc-podified-edpm-deployment: *content_provider


### PR DESCRIPTION
openstack-operator is built in content provider job and then consumed in EDPM job. These jobs are running against baremetal operator, install_yamls, dataplane & ansibleee operator.

We need to run these jobs against meta operator to avoid breaking changes.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/273
Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/224