### PR TITLE
Use -mod=readonly to avoid inconsistent vendoring

### DIFF
--- a/hack/pin-bundle-images.sh
+++ b/hack/pin-bundle-images.sh
@@ -16,11 +16,11 @@ if [ -n "$DOCKERFILE" ]; then
 fi
 
 #loop over each openstack-k8s-operators go.mod entry
-for MOD_PATH in $(go list -m -json all | jq -r '. | select(.Path | contains("openstack")) | .Replace // . |.Path' | grep -v openstack-operator | grep -v lib-common); do
+for MOD_PATH in $(go list -mod=readonly -m -json all | jq -r '. | select(.Path | contains("openstack")) | .Replace // . |.Path' | grep -v openstack-operator | grep -v lib-common); do
     if [[ "$MOD_PATH" == "./apis" ]]; then
         continue
     fi
-    MOD_VERSION=$(go list -m -json all | jq -r ". | select(.Path | contains(\"openstack\")) | .Replace // . | select( .Path == \"$MOD_PATH\") | .Version")
+    MOD_VERSION=$(go list -mod=readonly -m -json all | jq -r ". | select(.Path | contains(\"openstack\")) | .Replace // . | select( .Path == \"$MOD_PATH\") | .Version")
 
     BASE=$(echo $MOD_PATH | sed -e 's|github.com/.*/\(.*\)-operator/.*|\1|')
 


### PR DESCRIPTION
This would possibly avoid the vendoring error[1] and crds not created for other operators with `openstack_crds` target.

[1]

go: inconsistent vendoring in /alabama/install_yamls/out/operator/openstack-operator:
	github.com/ghodss/yaml@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/go-logr/logr@v1.2.4: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/imdario/mergo@v0.3.16: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/cinder-operator/api@v0.0.0-20230531173852-699a87ea2741: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/dataplane-operator/api@v0.0.0-20230609124412-a2ded60d47ee: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/glance-operator/api@v0.0.0-20230606071953-6acfa0ab197d: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/horizon-operator/api@v0.0.0-20230607094525-4da63adb2962: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/infra-operator/apis@v0.0.0-20230609142804-cd3cb0d141df: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/ironic-operator/api@v0.0.0-20230609122455-9857f7df3013: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/keystone-operator/api@v0.0.0-20230602104114-29d472a62f87: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/lib-common/modules/common@v0.0.0-20230606033311-3b01713e4d45: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/manila-operator/api@v0.0.0-20230608200658-12320abbf192: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/mariadb-operator/api@v0.0.0-20230602100742-579cb85d242d: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/neutron-operator/api@v0.0.0-20230605050651-ce5970011e0e: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openstack-k8s-operators/nova-operator/api@v0.0.0-20230607130528-7fdafd5549c4: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt