### PR TITLE
Delete galera pvcs in kuttl test

### DIFF
--- a/tests/kuttl/tests/galera-3replicas/02-cleanup.yaml
+++ b/tests/kuttl/tests/galera-3replicas/02-cleanup.yaml
@@ -4,3 +4,9 @@ delete:
 - apiVersion: core.openstack.org/v1beta1
   kind: OpenStackControlPlane
   name: openstack
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    oc delete --ignore-not-found=true -n $NAMESPACE pvc mysql-db-openstack-galera-0 mysql-db-openstack-galera-1 mysql-db-openstack-galera-2


### PR DESCRIPTION
A kuttl test case is deploying openstack with galera but not deleting
its pvcs. That causes the CI job to hang when it tries to delete the
create pvs. This change explicitely deletes the 3 galera pvcs.
