### PR TITLE
Update Heat CR definition in samples

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -106,49 +106,14 @@ spec:
   heat:
     enabled: false
     template:
-      customServiceConfig: "# add your customization here"
       databaseInstance: openstack
-      databaseUser: "heat"
-      rabbitMqClusterName: rabbitmq
-      debug:
-        bootstrap: false
-        dbSync: false
-        service: false
       heatAPI:
-        customServiceConfig: "# add your customization here"
-        databaseUser: "heat"
-        debug:
-          bootstrap: false
-          dbSync: false
-          service: false
-        passwordSelectors:
-          service: AdminPassword
-          database: AdminPassword
         replicas: 1
-        resources: {}
-        secret: "osp-secret"
-        serviceUser: ""
       heatEngine:
-        customServiceConfig: "# add your customization here"
-        databaseUser: "heat"
-        debug:
-          bootstrap: false
-          dbSync: false
-          service: false
-        passwordSelectors:
-          service: AdminPassword
-          database: AdminPassword
         replicas: 1
-        resources: {}
-        secret: "osp-secret"
-        serviceUser: ""
-      passwordSelectors:
-        service: AdminPassword
-        database: AdminPassword
-      preserveJobs: false
       secret: osp-secret
-      serviceUser: "heat"
   ironic:
+    enabled: false
     template:
       databaseInstance: openstack
       ironicAPI:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -163,48 +163,12 @@ spec:
   heat:
     enabled: false
     template:
-      customServiceConfig: "# add your customization here"
       databaseInstance: openstack
-      databaseUser: "heat"
-      rabbitMqClusterName: rabbitmq
-      debug:
-        bootstrap: false
-        dbSync: false
-        service: false
       heatAPI:
-        customServiceConfig: "# add your customization here"
-        databaseUser: "heat"
-        debug:
-          bootstrap: false
-          dbSync: false
-          service: false
-        passwordSelectors:
-          service: AdminPassword
-          database: AdminPassword
         replicas: 1
-        resources: {}
-        secret: "osp-secret"
-        serviceUser: ""
       heatEngine:
-        customServiceConfig: "# add your customization here"
-        databaseUser: "heat"
-        debug:
-          bootstrap: false
-          dbSync: false
-          service: false
-        passwordSelectors:
-          service: AdminPassword
-          database: AdminPassword
         replicas: 1
-        resources: {}
-        secret: "osp-secret"
-        serviceUser: ""
-      passwordSelectors:
-        service: AdminPassword
-        database: AdminPassword
-      preserveJobs: false
       secret: osp-secret
-      serviceUser: "heat"
   ironic:
     enabled: false
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -208,48 +208,12 @@ spec:
   heat:
     enabled: false
     template:
-      customServiceConfig: "# add your customization here"
       databaseInstance: openstack
-      databaseUser: "heat"
-      rabbitMqClusterName: rabbitmq
-      debug:
-        bootstrap: false
-        dbSync: false
-        service: false
       heatAPI:
-        customServiceConfig: "# add your customization here"
-        databaseUser: "heat"
-        debug:
-          bootstrap: false
-          dbSync: false
-          service: false
-        passwordSelectors:
-          service: AdminPassword
-          database: AdminPassword
         replicas: 1
-        resources: {}
-        secret: "osp-secret"
-        serviceUser: ""
       heatEngine:
-        customServiceConfig: "# add your customization here"
-        databaseUser: "heat"
-        debug:
-          bootstrap: false
-          dbSync: false
-          service: false
-        passwordSelectors:
-          service: AdminPassword
-          database: AdminPassword
         replicas: 1
-        resources: {}
-        secret: "osp-secret"
-        serviceUser: ""
-      passwordSelectors:
-        service: AdminPassword
-        database: AdminPassword
-      preserveJobs: false
       secret: osp-secret
-      serviceUser: "heat"
   ironic:
     enabled: false
     template:


### PR DESCRIPTION
Some spec keys are now hidden since the recent refactoring. This updates the definitions and leaves only minimum set.