### PR TITLE
Validate NovaSpec in the validation webhook

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -219,6 +219,14 @@ func (r *OpenStackControlPlane) ValidateServices(basePath *field.Path) field.Err
 		}
 	}
 
+	// Nova
+	if r.Spec.Nova.Enabled {
+		// NOTE(gibi): as soon as NovaSpec.ValidateCreate starts diverging
+		// from NovaSpec.ValidateUpdate we need to split ValidateServices to
+		// ValidateCreateServicesCreate and ValidateUpdateServices
+		allErrs = append(allErrs, r.Spec.Nova.Template.ValidateCreate(basePath.Child("nova").Child("template"))...)
+	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
Now the validation webhook of OpenstackControlPlane CR calls the validation logic of the NovaSpec implemented in the nova-operator.

Depends-on https://github.com/openstack-k8s-operators/nova-operator/pull/411 (merged)