### PR TITLE
Propagate nodeSelector for cinder & manila

### DIFF
--- a/pkg/openstack/cinder.go
+++ b/pkg/openstack/cinder.go
@@ -38,9 +38,9 @@ func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControl
 		if cinder.Spec.Secret == "" {
 			cinder.Spec.Secret = instance.Spec.Secret
 		}
-		//if cinder.Spec.NodeSelector == nil && instance.Spec.NodeSelector != nil {
-		//cinder.Spec.NodeSelector = instance.Spec.NodeSelector
-		//}
+		if cinder.Spec.NodeSelector == nil && instance.Spec.NodeSelector != nil {
+			cinder.Spec.NodeSelector = instance.Spec.NodeSelector
+		}
 		if cinder.Spec.DatabaseInstance == "" {
 			//cinder.Spec.DatabaseInstance = instance.Name // name of MariaDB we create here
 			cinder.Spec.DatabaseInstance = "openstack" //FIXME: see above

--- a/pkg/openstack/manila.go
+++ b/pkg/openstack/manila.go
@@ -38,9 +38,9 @@ func ReconcileManila(ctx context.Context, instance *corev1beta1.OpenStackControl
 		if manila.Spec.Secret == "" {
 			manila.Spec.Secret = instance.Spec.Secret
 		}
-		//if manila.Spec.NodeSelector == nil && instance.Spec.NodeSelector != nil {
-		//manila.Spec.NodeSelector = instance.Spec.NodeSelector
-		//}
+		if manila.Spec.NodeSelector == nil && instance.Spec.NodeSelector != nil {
+			manila.Spec.NodeSelector = instance.Spec.NodeSelector
+		}
 		if manila.Spec.DatabaseInstance == "" {
 			//manila.Spec.DatabaseInstance = instance.Name // name of MariaDB we create here
 			manila.Spec.DatabaseInstance = "openstack" //FIXME: see above


### PR DESCRIPTION
Uncomment the code to propagate the `nodeSelector` value from the `OpenStackControlPlane`'s value for Cinder & Manila if the value is not overwritten.