### PR TITLE
Remove OSClient default image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,6 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: export ENABLE_WEBHOOKS?=false
-run: export OPENSTACKCLIENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
 run: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/clean_local_webhook.sh
 	go run ./main.go
@@ -340,7 +339,6 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete -n openstack mutatingwebhookconfiguration/mopenstackcontrolplane.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export OPENSTACKCLIENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,7 +11,5 @@ spec:
       containers:
       - name: manager
         env:
-        - name: OPENSTACKCLIENT_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
         - name: RABBITMQ_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-rabbitmq:current-podified

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -55,10 +55,9 @@ import (
 // OpenStackControlPlaneReconciler reconciles a OpenStackControlPlane object
 type OpenStackControlPlaneReconciler struct {
 	client.Client
-	Scheme                        *runtime.Scheme
-	Kclient                       kubernetes.Interface
-	Log                           logr.Logger
-	OpenStackClientContainerImage string
+	Scheme  *runtime.Scheme
+	Kclient kubernetes.Interface
+	Log     logr.Logger
 }
 
 //+kubebuilder:rbac:groups=core.openstack.org,resources=openstackcontrolplanes,verbs=get;list;watch;create;update;patch;delete
@@ -248,7 +247,7 @@ func (r *OpenStackControlPlaneReconciler) reconcileNormal(ctx context.Context, i
 		return ctrlResult, nil
 	}
 
-	ctrlResult, err = openstack.ReconcileOpenStackClient(ctx, instance, helper, r.OpenStackClientContainerImage)
+	ctrlResult, err = openstack.ReconcileOpenStackClient(ctx, instance, helper)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if (ctrlResult != ctrl.Result{}) {

--- a/main.go
+++ b/main.go
@@ -157,11 +157,10 @@ func main() {
 	}
 
 	if err = (&corecontrollers.OpenStackControlPlaneReconciler{
-		Client:                        mgr.GetClient(),
-		Scheme:                        mgr.GetScheme(),
-		Kclient:                       kclient,
-		Log:                           ctrl.Log.WithName("controllers").WithName("OpenStackControlPlane"),
-		OpenStackClientContainerImage: os.Getenv("OPENSTACKCLIENT_IMAGE_URL_DEFAULT"),
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Kclient: kclient,
+		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackControlPlane"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackControlPlane")
 		os.Exit(1)

--- a/pkg/openstack/openstackclient.go
+++ b/pkg/openstack/openstackclient.go
@@ -35,7 +35,7 @@ const (
 )
 
 // ReconcileOpenStackClient -
-func ReconcileOpenStackClient(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, helper *helper.Helper, openstackClientImage string) (ctrl.Result, error) {
+func ReconcileOpenStackClient(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, helper *helper.Helper) (ctrl.Result, error) {
 
 	openstackclient := &clientv1beta1.OpenStackClient{
 		ObjectMeta: metav1.ObjectMeta{
@@ -46,8 +46,6 @@ func ReconcileOpenStackClient(ctx context.Context, instance *corev1beta1.OpenSta
 
 	helper.GetLogger().Info("Reconciling OpenStackClient", "OpenStackClient.Namespace", instance.Namespace, "OpenStackClient.Name", openstackclient.Name)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), openstackclient, func() error {
-		openstackclient.Spec.ContainerImage = openstackClientImage
-
 		// the following are created/owned by keystoneclient
 		openstackclient.Spec.OpenStackConfigMap = "openstack-config"
 		openstackclient.Spec.OpenStackConfigSecret = "openstack-config-secret"


### PR DESCRIPTION
We no longer need to have an environment variable default for the `OpenStackClient`, as that CRD has been moved to the Infra operator and it is already defaulted there.