### PR TITLE
Switch to structured logging

### DIFF
--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 
 	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -51,14 +50,13 @@ import (
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 	rabbitmqv2 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 
+	"github.com/go-logr/logr"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/go-logr/logr"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // OpenStackControlPlaneReconciler reconciles a OpenStackControlPlane object
@@ -66,7 +64,11 @@ type OpenStackControlPlaneReconciler struct {
 	client.Client
 	Scheme  *runtime.Scheme
 	Kclient kubernetes.Interface
-	Log     logr.Logger
+}
+
+// GetLog returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+func (r *OpenStackControlPlaneReconciler) GetLogger(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("Controllers").WithName("OpenStackControlPlane")
 }
 
 //+kubebuilder:rbac:groups=core.openstack.org,resources=openstackcontrolplanes,verbs=get;list;watch;create;update;patch;delete
@@ -109,8 +111,8 @@ type OpenStackControlPlaneReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.1/pkg/reconcile
 func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	_ = log.FromContext(ctx)
 
+	Log := r.GetLogger(ctx)
 	// Fetch the OpenStackControlPlane instance
 	instance := &corev1beta1.OpenStackControlPlane{}
 	err := r.Client.Get(ctx, req.NamespacedName, instance)
@@ -119,7 +121,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers. Return and don't requeue.
-			r.Log.Info("OpenStackControlPlane instance is not found, probaby deleted. Nothing to do.")
+			Log.Info("OpenStackControlPlane instance is not found, probaby deleted. Nothing to do.")
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -131,11 +133,11 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		r.Log,
+		Log,
 	)
 	if err != nil {
 		// helper might be nil, so can't use util.LogErrorForObject since it requires helper as first arg
-		r.Log.Error(err, fmt.Sprintf("unable to acquire helper for OpenStackControlPlane %s", instance.Name))
+		Log.Error(err, "unable to acquire helper for OpenStackControlPlane")
 		return ctrl.Result{}, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	devMode, err := strconv.ParseBool(os.Getenv("DEV_MODE"))
 	if err != nil {
-		devMode = false
+		devMode = true
 	}
 	opts := zap.Options{
 		Development: devMode,
@@ -180,7 +180,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackControlPlane"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackControlPlane")
 		os.Exit(1)
@@ -190,7 +189,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackClient"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackClient")
 		os.Exit(1)

--- a/pkg/openstack/ceilometer.go
+++ b/pkg/openstack/ceilometer.go
@@ -30,6 +30,8 @@ func ReconcileCeilometer(ctx context.Context, instance *corev1beta1.OpenStackCon
 		},
 	}
 
+	Log := GetLogger(ctx)
+
 	if !instance.Spec.Ceilometer.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, ceilometer); err != nil {
 			return res, err
@@ -38,7 +40,7 @@ func ReconcileCeilometer(ctx context.Context, instance *corev1beta1.OpenStackCon
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling Ceilometer", ceilometerNamespaceLabel, instance.Namespace, ceilometerNameLabel, ceilometerName)
+	Log.Info("Reconciling Ceilometer", ceilometerNamespaceLabel, instance.Namespace, ceilometerNameLabel, ceilometerName)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), ceilometer, func() error {
 		instance.Spec.Ceilometer.Template.DeepCopyInto(&ceilometer.Spec)
 
@@ -63,7 +65,7 @@ func ReconcileCeilometer(ctx context.Context, instance *corev1beta1.OpenStackCon
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("%s %s - %s", ceilometerName, ceilometer.Name, op))
+		Log.Info(fmt.Sprintf("%s %s - %s", ceilometerName, ceilometer.Name, op))
 	}
 
 	if ceilometer.IsReady() {

--- a/pkg/openstack/cinder.go
+++ b/pkg/openstack/cinder.go
@@ -37,6 +37,7 @@ func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControl
 		instance.Status.Conditions.Remove(corev1beta1.OpenStackControlPlaneExposeCinderReadyCondition)
 		return ctrl.Result{}, nil
 	}
+	Log := GetLogger(ctx)
 
 	// add selector to service overrides
 	for _, endpointType := range []service.Endpoint{service.EndpointPublic, service.EndpointInternal} {
@@ -85,7 +86,7 @@ func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControl
 		}
 	}
 
-	helper.GetLogger().Info("Reconciling Cinder", "Cinder.Namespace", instance.Namespace, "Cinder.Name", "cinder")
+	Log.Info("Reconciling Cinder", "Cinder.Namespace", instance.Namespace, "Cinder.Name", "cinder")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), cinder, func() error {
 		instance.Spec.Cinder.Template.DeepCopyInto(&cinder.Spec)
 
@@ -131,7 +132,7 @@ func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControl
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("Cinder %s - %s", cinder.Name, op))
+		Log.Info(fmt.Sprintf("Cinder %s - %s", cinder.Name, op))
 	}
 
 	if cinder.IsReady() {

--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -23,8 +24,14 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// GetLog returns a logger object with a prefix of "controller.name" and aditional controller context fields
+func GetLogger(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("Controllers").WithName("OpenstackControlPlane")
+}
 
 // EnsureDeleted - Delete the object which in turn will clean the sub resources
 func EnsureDeleted(ctx context.Context, helper *helper.Helper, obj client.Object) (ctrl.Result, error) {

--- a/pkg/openstack/dnsmasq.go
+++ b/pkg/openstack/dnsmasq.go
@@ -33,7 +33,9 @@ func ReconcileDNSMasqs(ctx context.Context, instance *corev1beta1.OpenStackContr
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling DNSMasq", "DNSMasq.Namespace", instance.Namespace, "DNSMasq.Name", "dnsmasq")
+	Log := GetLogger(ctx)
+
+	Log.Info("Reconciling DNSMasq", "DNSMasq.Namespace", instance.Namespace, "DNSMasq.Name", "dnsmasq")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), dnsmasq, func() error {
 		instance.Spec.DNS.Template.DeepCopyInto(&dnsmasq.Spec)
 		if dnsmasq.Spec.NodeSelector == nil && instance.Spec.NodeSelector != nil {
@@ -56,7 +58,7 @@ func ReconcileDNSMasqs(ctx context.Context, instance *corev1beta1.OpenStackContr
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("dnsmasq %s - %s", dnsmasq.Name, op))
+		Log.Info(fmt.Sprintf("dnsmasq %s - %s", dnsmasq.Name, op))
 	}
 
 	if dnsmasq.IsReady() {

--- a/pkg/openstack/galera.go
+++ b/pkg/openstack/galera.go
@@ -93,6 +93,7 @@ func reconcileGalera(
 			Namespace: instance.Namespace,
 		},
 	}
+	Log := GetLogger(ctx)
 
 	if !instance.Spec.Galera.Enabled {
 		if _, err := EnsureDeleted(ctx, helper, galera); err != nil {
@@ -102,7 +103,7 @@ func reconcileGalera(
 		return galeraReady, nil
 	}
 
-	helper.GetLogger().Info("Reconciling Galera", "Galera.Namespace", instance.Namespace, "Galera.Name", name)
+	Log.Info("Reconciling Galera", "Galera.Namespace", instance.Namespace, "Galera.Name", name)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), galera, func() error {
 		spec.DeepCopyInto(&galera.Spec)
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), galera, helper.GetScheme())
@@ -117,7 +118,7 @@ func reconcileGalera(
 		return galeraFailed, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("Galera %s - %s", galera.Name, op))
+		Log.Info(fmt.Sprintf("Galera %s - %s", galera.Name, op))
 	}
 
 	if galera.IsReady() {

--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -30,6 +30,8 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		},
 	}
 
+	Log := GetLogger(ctx)
+
 	if !instance.Spec.Glance.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, glance); err != nil {
 			return res, err
@@ -89,7 +91,7 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		}
 	}
 
-	helper.GetLogger().Info("Reconciling Glance", "Glance.Namespace", instance.Namespace, "Glance.Name", "glance")
+	Log.Info("Reconciling Glance", "Glance.Namespace", instance.Namespace, "Glance.Name", "glance")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), glance, func() error {
 		instance.Spec.Glance.Template.DeepCopyInto(&glance.Spec)
 		glance.Spec.GlanceAPIExternal.Override.Service = ptr.To(serviceOverrides[service.EndpointPublic])
@@ -136,7 +138,7 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("glance %s - %s", glance.Name, op))
+		Log.Info(fmt.Sprintf("glance %s - %s", glance.Name, op))
 	}
 
 	if glance.IsReady() {

--- a/pkg/openstack/heat.go
+++ b/pkg/openstack/heat.go
@@ -124,7 +124,9 @@ func ReconcileHeat(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		}
 	}
 
-	helper.GetLogger().Info("Reconcile heat", "heat.Namespace", instance.Namespace, "heat.Name", "heat")
+	Log := GetLogger(ctx)
+
+	Log.Info("Reconcile heat", "heat.Namespace", instance.Namespace, "heat.Name", "heat")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), heat, func() error {
 		instance.Spec.Heat.Template.DeepCopyInto(&heat.Spec)
 
@@ -145,7 +147,7 @@ func ReconcileHeat(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("heat %s - %s", heat.Name, op))
+		Log.Info(fmt.Sprintf("heat %s - %s", heat.Name, op))
 	}
 
 	if heat.IsReady() {

--- a/pkg/openstack/horizon.go
+++ b/pkg/openstack/horizon.go
@@ -29,6 +29,7 @@ func ReconcileHorizon(ctx context.Context, instance *corev1beta1.OpenStackContro
 			Namespace: instance.Namespace,
 		},
 	}
+	Log := GetLogger(ctx)
 
 	if !instance.Spec.Horizon.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, horizon); err != nil {
@@ -96,7 +97,7 @@ func ReconcileHorizon(ctx context.Context, instance *corev1beta1.OpenStackContro
 		}
 	}
 
-	helper.GetLogger().Info("Reconcile Horizon", "horizon.Namespace", instance.Namespace, "horizon.Name", "horizon")
+	Log.Info("Reconcile Horizon", "horizon.Namespace", instance.Namespace, "horizon.Name", "horizon")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), horizon, func() error {
 		instance.Spec.Horizon.Template.DeepCopyInto(&horizon.Spec)
 		horizon.Spec.Override.Service = ptr.To(serviceOverrides[service.EndpointPublic])
@@ -118,7 +119,7 @@ func ReconcileHorizon(ctx context.Context, instance *corev1beta1.OpenStackContro
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("Horizon %s - %s", horizon.Name, op))
+		Log.Info(fmt.Sprintf("Horizon %s - %s", horizon.Name, op))
 	}
 
 	if horizon.IsReady() {

--- a/pkg/openstack/ironic.go
+++ b/pkg/openstack/ironic.go
@@ -28,6 +28,7 @@ func ReconcileIronic(ctx context.Context, instance *corev1beta1.OpenStackControl
 			Namespace: instance.Namespace,
 		},
 	}
+	Log := GetLogger(ctx)
 
 	if !instance.Spec.Ironic.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, ironic); err != nil {
@@ -124,7 +125,7 @@ func ReconcileIronic(ctx context.Context, instance *corev1beta1.OpenStackControl
 		}
 	}
 
-	helper.GetLogger().Info("Reconciling Ironic", "Ironic.Namespace", instance.Namespace, "Ironic.Name", "ironic")
+	Log.Info("Reconciling Ironic", "Ironic.Namespace", instance.Namespace, "Ironic.Name", "ironic")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), ironic, func() error {
 		instance.Spec.Ironic.Template.DeepCopyInto(&ironic.Spec)
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), ironic, helper.GetScheme())
@@ -144,7 +145,7 @@ func ReconcileIronic(ctx context.Context, instance *corev1beta1.OpenStackControl
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("ironic %s - %s", ironic.Name, op))
+		Log.Info(fmt.Sprintf("ironic %s - %s", ironic.Name, op))
 	}
 
 	if ironic.IsReady() {

--- a/pkg/openstack/keystone.go
+++ b/pkg/openstack/keystone.go
@@ -29,6 +29,8 @@ func ReconcileKeystoneAPI(ctx context.Context, instance *corev1beta1.OpenStackCo
 		},
 	}
 
+	Log := GetLogger(ctx)
+
 	if !instance.Spec.Keystone.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, keystoneAPI); err != nil {
 			return res, err
@@ -86,6 +88,7 @@ func ReconcileKeystoneAPI(ctx context.Context, instance *corev1beta1.OpenStackCo
 	}
 
 	helper.GetLogger().Info("Reconciling KeystoneAPI", "KeystoneAPI.Namespace", instance.Namespace, "KeystoneAPI.Name", "keystone")
+	Log.Info("Reconciling KeystoneAPI", "KeystoneAPI.Namespace", instance.Namespace, "KeystoneAPI.Name", "keystone")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), keystoneAPI, func() error {
 		instance.Spec.Keystone.Template.DeepCopyInto(&keystoneAPI.Spec)
 
@@ -116,7 +119,7 @@ func ReconcileKeystoneAPI(ctx context.Context, instance *corev1beta1.OpenStackCo
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("KeystoneAPI %s - %s", keystoneAPI.Name, op))
+		Log.Info(fmt.Sprintf("KeystoneAPI %s - %s", keystoneAPI.Name, op))
 	}
 
 	if keystoneAPI.IsReady() {

--- a/pkg/openstack/manila.go
+++ b/pkg/openstack/manila.go
@@ -28,6 +28,7 @@ func ReconcileManila(ctx context.Context, instance *corev1beta1.OpenStackControl
 			Namespace: instance.Namespace,
 		},
 	}
+	Log := GetLogger(ctx)
 
 	if !instance.Spec.Manila.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, manila); err != nil {
@@ -86,7 +87,7 @@ func ReconcileManila(ctx context.Context, instance *corev1beta1.OpenStackControl
 		}
 	}
 
-	helper.GetLogger().Info("Reconciling Manila", "Manila.Namespace", instance.Namespace, "Manila.Name", "manila")
+	Log.Info("Reconciling Manila", "Manila.Namespace", instance.Namespace, "Manila.Name", "manila")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), manila, func() error {
 		instance.Spec.Manila.Template.DeepCopyInto(&manila.Spec)
 
@@ -132,7 +133,7 @@ func ReconcileManila(ctx context.Context, instance *corev1beta1.OpenStackControl
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("Manila %s - %s", manila.Name, op))
+		Log.Info(fmt.Sprintf("Manila %s - %s", manila.Name, op))
 	}
 
 	if manila.IsReady() {

--- a/pkg/openstack/mariadb.go
+++ b/pkg/openstack/mariadb.go
@@ -94,6 +94,8 @@ func reconcileMariaDB(
 		},
 	}
 
+	Log := GetLogger(ctx)
+
 	if !instance.Spec.Mariadb.Enabled {
 		if _, err := EnsureDeleted(ctx, helper, mariadb); err != nil {
 			return mariadbFailed, err
@@ -102,7 +104,7 @@ func reconcileMariaDB(
 		return mariadbReady, nil
 	}
 
-	helper.GetLogger().Info("Reconciling MariaDB", "MariaDB.Namespace", instance.Namespace, "Mariadb.Name", name)
+	Log.Info("Reconciling MariaDB", "MariaDB.Namespace", instance.Namespace, "Mariadb.Name", name)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), mariadb, func() error {
 		spec.DeepCopyInto(&mariadb.Spec)
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), mariadb, helper.GetScheme())
@@ -117,7 +119,7 @@ func reconcileMariaDB(
 		return mariadbFailed, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("MariaDB %s - %s", mariadb.Name, op))
+		Log.Info(fmt.Sprintf("MariaDB %s - %s", mariadb.Name, op))
 	}
 
 	if mariadb.IsReady() {

--- a/pkg/openstack/memcached.go
+++ b/pkg/openstack/memcached.go
@@ -138,6 +138,8 @@ func reconcileMemcached(
 		},
 	}
 
+	Log := GetLogger(ctx)
+
 	if !instance.Spec.Memcached.Enabled {
 		if _, err := EnsureDeleted(ctx, helper, memcached); err != nil {
 			return memcachedFailed, err
@@ -146,7 +148,7 @@ func reconcileMemcached(
 		return memcachedReady, nil
 	}
 
-	helper.GetLogger().Info("Reconciling Memcached", "Memcached.Namespace", instance.Namespace, "Memcached.Name", name)
+	Log.Info("Reconciling Memcached", "Memcached.Namespace", instance.Namespace, "Memcached.Name", name)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), memcached, func() error {
 		spec.DeepCopyInto(&memcached.Spec)
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), memcached, helper.GetScheme())
@@ -161,7 +163,7 @@ func reconcileMemcached(
 		return memcachedFailed, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("Memcached %s - %s", memcached.Name, op))
+		Log.Info(fmt.Sprintf("Memcached %s - %s", memcached.Name, op))
 	}
 
 	if memcached.IsReady() {

--- a/pkg/openstack/neutron.go
+++ b/pkg/openstack/neutron.go
@@ -28,6 +28,7 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 			Namespace: instance.Namespace,
 		},
 	}
+	Log := GetLogger(ctx)
 
 	if !instance.Spec.Neutron.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, neutronAPI); err != nil {
@@ -85,7 +86,7 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 		}
 	}
 
-	helper.GetLogger().Info("Reconciling NeutronAPI", "NeutronAPI.Namespace", instance.Namespace, "NeutronAPI.Name", "neutron")
+	Log.Info("Reconciling NeutronAPI", "NeutronAPI.Namespace", instance.Namespace, "NeutronAPI.Name", "neutron")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), neutronAPI, func() error {
 		instance.Spec.Neutron.Template.DeepCopyInto(&neutronAPI.Spec)
 
@@ -131,7 +132,7 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("neutronAPI %s - %s", neutronAPI.Name, op))
+		Log.Info(fmt.Sprintf("neutronAPI %s - %s", neutronAPI.Name, op))
 	}
 
 	if neutronAPI.IsReady() {

--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -45,6 +45,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 			Namespace: instance.Namespace,
 		},
 	}
+	Log := GetLogger(ctx)
 
 	if !instance.Spec.Nova.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, nova); err != nil {
@@ -172,7 +173,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		}
 	}
 
-	helper.GetLogger().Info("Reconciling Nova", "Nova.Namespace", instance.Namespace, "Nova.Name", nova.Name)
+	Log.Info("Reconciling Nova", "Nova.Namespace", instance.Namespace, "Nova.Name", nova.Name)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), nova, func() error {
 		// 1)
 		// Nova.Spec.APIDatabaseInstance and each NovaCell.CellDatabaseInstance
@@ -209,7 +210,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("Nova %s - %s", nova.Name, op))
+		Log.Info(fmt.Sprintf("Nova %s - %s", nova.Name, op))
 	}
 
 	if nova.IsReady() {

--- a/pkg/openstack/openstackclient.go
+++ b/pkg/openstack/openstackclient.go
@@ -40,8 +40,9 @@ func ReconcileOpenStackClient(ctx context.Context, instance *corev1.OpenStackCon
 			Namespace: instance.Namespace,
 		},
 	}
+	Log := GetLogger(ctx)
 
-	helper.GetLogger().Info("Reconciling OpenStackClient", "OpenStackClient.Namespace", instance.Namespace, "OpenStackClient.Name", openstackclient.Name)
+	Log.Info("Reconciling OpenStackClient", "OpenStackClient.Namespace", instance.Namespace, "OpenStackClient.Name", openstackclient.Name)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), openstackclient, func() error {
 		instance.Spec.OpenStackClient.Template.DeepCopyInto(&openstackclient.Spec)
 
@@ -69,14 +70,14 @@ func ReconcileOpenStackClient(ctx context.Context, instance *corev1.OpenStackCon
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("OpenStackClient %s - %s", openstackclient.Name, op))
+		Log.Info(fmt.Sprintf("OpenStackClient %s - %s", openstackclient.Name, op))
 	}
 
 	if openstackclient.Status.Conditions.IsTrue(clientv1.OpenStackClientReadyCondition) {
-		helper.GetLogger().Info("OpenStackClient ready condition is true")
+		Log.Info("OpenStackClient ready condition is true")
 		instance.Status.Conditions.MarkTrue(corev1.OpenStackControlPlaneClientReadyCondition, corev1.OpenStackControlPlaneClientReadyMessage)
 	} else {
-		helper.GetLogger().Info("OpenStackClient ready condition is false")
+		Log.Info("OpenStackClient ready condition is false")
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			corev1.OpenStackControlPlaneClientReadyCondition,
 			condition.RequestedReason,

--- a/pkg/openstack/ovn.go
+++ b/pkg/openstack/ovn.go
@@ -17,6 +17,9 @@ import (
 
 // ReconcileOVN -
 func ReconcileOVN(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, helper *helper.Helper) (ctrl.Result, error) {
+
+	Log := GetLogger(ctx)
+
 	OVNDBClustersReady := len(instance.Spec.Ovn.Template.OVNDBCluster) != 0
 	for name, dbcluster := range instance.Spec.Ovn.Template.OVNDBCluster {
 		OVNDBCluster := &ovnv1.OVNDBCluster{
@@ -34,7 +37,7 @@ func ReconcileOVN(ctx context.Context, instance *corev1beta1.OpenStackControlPla
 			continue
 		}
 
-		helper.GetLogger().Info("Reconciling OVNDBCluster", "OVNDBCluster.Namespace", instance.Namespace, "OVNDBCluster.Name", name)
+		Log.Info("Reconciling OVNDBCluster", "OVNDBCluster.Namespace", instance.Namespace, "OVNDBCluster.Name", name)
 		op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), OVNDBCluster, func() error {
 
 			dbcluster.DeepCopyInto(&OVNDBCluster.Spec)
@@ -63,7 +66,7 @@ func ReconcileOVN(ctx context.Context, instance *corev1beta1.OpenStackControlPla
 			return ctrl.Result{}, err
 		}
 		if op != controllerutil.OperationResultNone {
-			helper.GetLogger().Info(fmt.Sprintf("OVNDBCluster %s - %s", OVNDBCluster.Name, op))
+			Log.Info(fmt.Sprintf("OVNDBCluster %s - %s", OVNDBCluster.Name, op))
 		}
 		OVNDBClustersReady = OVNDBClustersReady && OVNDBCluster.IsReady()
 	}
@@ -83,7 +86,7 @@ func ReconcileOVN(ctx context.Context, instance *corev1beta1.OpenStackControlPla
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling OVNNorthd", "OVNNorthd.Namespace", instance.Namespace, "OVNNorthd.Name", "ovnnorthd")
+	Log.Info("Reconciling OVNNorthd", "OVNNorthd.Namespace", instance.Namespace, "OVNNorthd.Name", "ovnnorthd")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), OVNNorthd, func() error {
 
 		instance.Spec.Ovn.Template.OVNNorthd.DeepCopyInto(&OVNNorthd.Spec)
@@ -109,7 +112,7 @@ func ReconcileOVN(ctx context.Context, instance *corev1beta1.OpenStackControlPla
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("OVNNorthd %s - %s", OVNNorthd.Name, op))
+		Log.Info(fmt.Sprintf("OVNNorthd %s - %s", OVNNorthd.Name, op))
 	}
 
 	OVNController := &ovnv1.OVNController{
@@ -127,7 +130,7 @@ func ReconcileOVN(ctx context.Context, instance *corev1beta1.OpenStackControlPla
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling OVNController", "OVNController.Namespace", instance.Namespace, "OVNController.Name", "ovncontroller")
+	Log.Info("Reconciling OVNController", "OVNController.Namespace", instance.Namespace, "OVNController.Name", "ovncontroller")
 	op, err = controllerutil.CreateOrPatch(ctx, helper.GetClient(), OVNController, func() error {
 
 		instance.Spec.Ovn.Template.OVNController.DeepCopyInto(&OVNController.Spec)
@@ -153,7 +156,7 @@ func ReconcileOVN(ctx context.Context, instance *corev1beta1.OpenStackControlPla
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("OVNController %s - %s", OVNController.Name, op))
+		Log.Info(fmt.Sprintf("OVNController %s - %s", OVNController.Name, op))
 	}
 
 	// Expect all services (dbclusters, northd, ovn-controller) ready

--- a/pkg/openstack/placement.go
+++ b/pkg/openstack/placement.go
@@ -28,6 +28,7 @@ func ReconcilePlacementAPI(ctx context.Context, instance *corev1beta1.OpenStackC
 			Namespace: instance.Namespace,
 		},
 	}
+	Log := GetLogger(ctx)
 
 	if !instance.Spec.Placement.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, placementAPI); err != nil {
@@ -84,7 +85,7 @@ func ReconcilePlacementAPI(ctx context.Context, instance *corev1beta1.OpenStackC
 		}
 	}
 
-	helper.GetLogger().Info("Reconciling PlacementAPI", "PlacementAPI.Namespace", instance.Namespace, "PlacementAPI.Name", "placement")
+	Log.Info("Reconciling PlacementAPI", "PlacementAPI.Namespace", instance.Namespace, "PlacementAPI.Name", "placement")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), placementAPI, func() error {
 		instance.Spec.Placement.Template.DeepCopyInto(&placementAPI.Spec)
 
@@ -114,7 +115,7 @@ func ReconcilePlacementAPI(ctx context.Context, instance *corev1beta1.OpenStackC
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("placementAPI %s - %s", placementAPI.Name, op))
+		Log.Info(fmt.Sprintf("placementAPI %s - %s", placementAPI.Name, op))
 	}
 
 	if placementAPI.IsReady() {

--- a/pkg/openstack/rabbitmq.go
+++ b/pkg/openstack/rabbitmq.go
@@ -96,8 +96,9 @@ func reconcileRabbitMQ(
 			Namespace: instance.Namespace,
 		},
 	}
+	Log := GetLogger(ctx)
 
-	helper.GetLogger().Info("Reconciling RabbitMQ", "RabbitMQ.Namespace", instance.Namespace, "RabbitMQ.Name", name)
+	Log.Info("Reconciling RabbitMQ", "RabbitMQ.Namespace", instance.Namespace, "RabbitMQ.Name", name)
 	if !instance.Spec.Rabbitmq.Enabled {
 		if _, err := EnsureDeleted(ctx, helper, rabbitmq); err != nil {
 			return mqFailed, err
@@ -177,12 +178,12 @@ func reconcileRabbitMQ(
 		}
 
 		if rabbitmq.Spec.Persistence.StorageClassName == nil {
-			helper.GetLogger().Info("Setting StorageClassName: " + instance.Spec.StorageClass)
+			Log.Info(fmt.Sprintf("Setting StorageClassName: " + instance.Spec.StorageClass))
 			rabbitmq.Spec.Persistence.StorageClassName = &instance.Spec.StorageClass
 		}
 
 		if rabbitmq.Spec.Override.StatefulSet == nil {
-			helper.GetLogger().Info("Setting StatefulSet")
+			Log.Info("Setting StatefulSet")
 			rabbitmq.Spec.Override.StatefulSet = &defaultStatefulSet
 		}
 
@@ -194,7 +195,7 @@ func reconcileRabbitMQ(
 		}
 
 		if rabbitmq.Spec.Rabbitmq.AdditionalConfig == "" {
-			helper.GetLogger().Info("Setting AdditionalConfig")
+			Log.Info("Setting AdditionalConfig")
 			// This is the same situation as RABBITMQ_UPGRADE_LOG above,
 			// except for the "main" rabbitmq log we can just force it to use the console.
 			rabbitmq.Spec.Rabbitmq.AdditionalConfig = "log.console = true"
@@ -213,7 +214,7 @@ func reconcileRabbitMQ(
 		return mqFailed, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("RabbitMQ %s - %s", rabbitmq.Name, op))
+		Log.Info(fmt.Sprintf("RabbitMQ %s - %s", rabbitmq.Name, op))
 	}
 
 	for _, oldCond := range rabbitmq.Status.Conditions {

--- a/pkg/openstack/swift.go
+++ b/pkg/openstack/swift.go
@@ -29,6 +29,8 @@ func ReconcileSwift(ctx context.Context, instance *corev1beta1.OpenStackControlP
 		},
 	}
 
+	Log := GetLogger(ctx)
+
 	if !instance.Spec.Swift.Enabled {
 		if res, err := EnsureDeleted(ctx, helper, swift); err != nil {
 			return res, err
@@ -86,6 +88,7 @@ func ReconcileSwift(ctx context.Context, instance *corev1beta1.OpenStackControlP
 	}
 
 	helper.GetLogger().Info("Reconciling Swift", "Swift.Namespace", instance.Namespace, "Swift.Name", "swift")
+	Log.Info("Reconciling Swift", "Swift.Namespace", instance.Namespace, "Swift.Name", "swift")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), swift, func() error {
 		instance.Spec.Swift.Template.DeepCopyInto(&swift.Spec)
 
@@ -106,7 +109,7 @@ func ReconcileSwift(ctx context.Context, instance *corev1beta1.OpenStackControlP
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("Swift %s - %s", swift.Name, op))
+		Log.Info(fmt.Sprintf("Swift %s - %s", swift.Name, op))
 	}
 
 	if swift.IsReady() {

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -300,7 +300,6 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackClient"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -308,7 +307,6 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackControlPlane"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
This automatically adds additional Log fields like reconcile_id etc.. from the controller context.

Follow up from: https://github.com/openstack-k8s-operators/keystone-operator/pull/220
Epic :  [OSP-22582](https://issues.redhat.com/browse/OSP-22582) Switch Operators to structured logging

before :
```bash
{"level":"info","ts":"2023-07-04T10:11:14.655+0300","logger":"controllers.OpenStackControlPlane","msg":"Reconciling Glance","Glance.Namespace":"openstack","Glance.Name":"glance"}
```

after:
```bash
2023-10-15T02:37:10.941+0300    INFO    Controllers.OpenStackClient     OpenStackClient CR values       {"controller": "openstackclient", "controllerGroup": "client.openstack.org", "controllerKind": "OpenStackClient", "OpenStackClient": {"name":"openstackclient","namespace":"openstack"}, "namespace": "openstack", "name": "openstackclient", "reconcileID": "21a5c4af-ea9a-4c5c-aae2-78c77b76b01c", "Name": "openstackclient", "Namespace": "openstack", "Secret": "openstack-config-secret", "Image": "quay.io/podified-antelope-centos9/openstack-openstackclient@sha256:66a098b20c2a26ffc43b7d21f76b17bba386c3eebcc33ed48fb31208896d9761"}
```

set log dev true for console output