### PR TITLE
pin-bundle-images.sh: filtering specific tag in Quay search command

### DIFF
--- a/hack/pin-bundle-images.sh
+++ b/hack/pin-bundle-images.sh
@@ -47,7 +47,12 @@ for MOD_PATH in $(go list -mod=readonly -m -json all | jq -r '. | select(.Path |
     if [[ ${LOCAL_REGISTRY} -eq 1 && ( "$GITHUB_USER" != "openstack-k8s-operators" || "$BASE" == "$IMAGEBASE" ) ]]; then
         SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tags/list | jq -r .tags[] | sort -u | grep $REF)
     else
-        SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/ | jq -r .tags[].name | sort -u | grep $REF)
+        SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/?filter_tag_name=like:$REF | jq -r .tags[].name)
+    fi
+
+    if [ -z "$SHA" ]; then
+        echo "Error: SHA is empty, Could not find container with tag $REF in $REPO_CURL_URL"
+        exit 1
     fi
 
     if [ -n "$DOCKERFILE" ]; then


### PR DESCRIPTION
Recently our CI job failed because we were unable to found an older nova
hash. As quay limit the number of item it returns.

~~~
++ curl -s https://quay.io/api/v1/repository/openstack-k8s-operators/nova-operator-bundle/tag/
++ jq -r '.tags[].name'
++ sort -u
++ grep 7fdafd5549c4
+ SHA=
~~~

We can directly filter the tag we need instead of checking in entire
list

~~~
curl https://quay.io/api/v1/repository/openstack-k8s-operators/nova-operator-bundle/tag/?filter_tag_name=like:7fdafd5549c4 | jq -r '.tags[].name'
7fdafd5549c4a02eed7ca6e35067256b5e4d754e
~~~

We need to add another condition to check if SHA is empty as
with filter_tag_name doesn't fails on its own if tag is
not found.