### PR TITLE
Bump nova-operator dependency

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230622231132-d933ef24a6d4
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230622153114-756aead1d819
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493
-	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230623171224-fe606377229a
+	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230626110819-68c73c394c65
 	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230623204101-50b69509ddc2
 	github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20230623155804-42d1493fb794
 	github.com/openstack-k8s-operators/swift-operator/api v0.0.0-20230626050357-c71d9bfd310d

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -147,8 +147,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230622153114-75
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230622153114-756aead1d819/go.mod h1:YRgmQI2Z0IbQnDrU1jqvZqntSBmCmBU9CSbzoqPjrPw=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493 h1:TyneX7qu57Ujt7hUBEdVoxeldT5b7Q8rTOWguzKGmPc=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493/go.mod h1:Je+ZJlPz6kDIenaogZQC35ZX/Qnhj8nNdGuQwuaMZ84=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230623171224-fe606377229a h1:OaIT45wdIpVU3CWpG52L7zjbKcXj4BxJOBkotlm/F8c=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230623171224-fe606377229a/go.mod h1:TfJOBtdvnoYVy7PoFOwLi4+jIb9I6xL3Hymusv3RrVc=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230626110819-68c73c394c65 h1:3LvwTQxHr6C/s+t/NlLSCVT0oezFqhObpeuKUaq+y3M=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230626110819-68c73c394c65/go.mod h1:TfJOBtdvnoYVy7PoFOwLi4+jIb9I6xL3Hymusv3RrVc=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230623204101-50b69509ddc2 h1:6p1sEWJTQxm3salXmc+G06D2GVlg2zX5LpZMmOC2DBs=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230623204101-50b69509ddc2/go.mod h1:KWORlrdNorI0uGIFzh+Fg6R32VoLIt80jtKQEBf5uZ0=
 github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20230623155804-42d1493fb794 h1:OWJxRkbrVhYxIbY0VJtkapfjaOCI4ndcFJyGSl41a3Y=

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230622231132-d933ef24a6d4
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230622153114-756aead1d819
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493
-	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230623171224-fe606377229a
+	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230626110819-68c73c394c65
 	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230620085730-fddf65f65f88
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230621154304-57314e65f29a
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20230623085000-286a16917df2

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230622153114-75
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230622153114-756aead1d819/go.mod h1:YRgmQI2Z0IbQnDrU1jqvZqntSBmCmBU9CSbzoqPjrPw=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493 h1:TyneX7qu57Ujt7hUBEdVoxeldT5b7Q8rTOWguzKGmPc=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493/go.mod h1:Je+ZJlPz6kDIenaogZQC35ZX/Qnhj8nNdGuQwuaMZ84=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230623171224-fe606377229a h1:OaIT45wdIpVU3CWpG52L7zjbKcXj4BxJOBkotlm/F8c=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230623171224-fe606377229a/go.mod h1:TfJOBtdvnoYVy7PoFOwLi4+jIb9I6xL3Hymusv3RrVc=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230626110819-68c73c394c65 h1:3LvwTQxHr6C/s+t/NlLSCVT0oezFqhObpeuKUaq+y3M=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230626110819-68c73c394c65/go.mod h1:TfJOBtdvnoYVy7PoFOwLi4+jIb9I6xL3Hymusv3RrVc=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230620085730-fddf65f65f88 h1:l1s8NZfIRKeiMrTsDQAKw44EwWQ2waaWv+TpJz+93Bk=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230620085730-fddf65f65f88/go.mod h1:e4hw70sdvXG8anfBSGq5VMq11h52aN/TI3HYxjPyDGE=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230621154304-57314e65f29a h1:fmwTqP94PxkQbKY5R1Tq3WMMLyC3NB8CHfo2PUOD8uE=


### PR DESCRIPTION
We need this to pick up the reverts in nova-operator[1] to fix EDPM deployment

[1] https://github.com/openstack-k8s-operators/nova-operator/pull/418