### PR TITLE
Ensure Memcached is deleted after being removed from spec

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -36,9 +36,9 @@ import (
 	novav1 "github.com/openstack-k8s-operators/nova-operator/api/v1beta1"
 	ovnv1 "github.com/openstack-k8s-operators/ovn-operator/api/v1beta1"
 	placementv1 "github.com/openstack-k8s-operators/placement-operator/api/v1beta1"
+	swiftv1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 	rabbitmqv1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
-	swiftv1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/openstack/memcached.go
+++ b/pkg/openstack/memcached.go
@@ -14,6 +14,7 @@ import (
 	corev1beta1 "github.com/openstack-k8s-operators/openstack-operator/apis/core/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type memcachedStatus int
@@ -33,6 +34,53 @@ func ReconcileMemcacheds(
 	var failures []string = []string{}
 	var inprogress []string = []string{}
 
+	// We first remove memcacheds no longer owned
+	memcacheds := &memcachedv1.MemcachedList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(instance.Namespace),
+	}
+	if err := helper.GetClient().List(ctx, memcacheds, listOpts...); err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			corev1beta1.OpenStackControlPlaneMemcachedReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			corev1beta1.OpenStackControlPlaneMemcachedReadyErrorMessage,
+			err))
+		return ctrl.Result{}, err
+	}
+
+	for _, memcached := range memcacheds.Items {
+		for _, ref := range memcached.GetOwnerReferences() {
+			// Check owner UID to ensure the memcached instance is owned by this OpenStackControlPlane instance
+			if ref.UID == instance.GetUID() {
+				owned := false
+
+				// Check whether the name appears in spec
+				for name := range instance.Spec.Memcached.Templates {
+					if name == memcached.GetName() {
+						owned = true
+						break
+					}
+				}
+
+				// The instance name is no longer part of the spec. Let's delete it
+				if !owned {
+					mc := &memcachedv1.Memcached{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      memcached.GetName(),
+							Namespace: memcached.GetNamespace(),
+						},
+					}
+					_, err := EnsureDeleted(ctx, helper, mc)
+					if err != nil {
+						failures = append(failures, fmt.Sprintf("%s(deleted)(%v)", memcached.GetName(), err.Error()))
+					}
+				}
+			}
+		}
+	}
+
+	// then reconcile ones listed in spec
 	for name, spec := range instance.Spec.Memcached.Templates {
 		status, err := reconcileMemcached(ctx, instance, helper, name, &spec)
 


### PR DESCRIPTION
OpenStackControlPlane CR allows defining multiple Memcached instances, and users can remove existing Memcached instances from sppec.

This change ensures the instances are deleted when they are removed from spec.