### PR TITLE
Use default storage class for galera resource

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -20,12 +20,10 @@ spec:
     enabled: true
     templates:
       openstack:
-        storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
         replicas: 1
       openstack-cell1:
-        storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
         replicas: 1

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -20,12 +20,10 @@ spec:
     enabled: true
     templates:
       openstack:
-        storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
         replicas: 3
       openstack-cell1:
-        storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
         replicas: 3

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -71,12 +71,10 @@ spec:
     enabled: true
     templates:
       openstack:
-        storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
         replicas: 1
       openstack-cell1:
-        storageClass: local-storage
         storageRequest: 500M
         secret: osp-secret
         replicas: 1


### PR DESCRIPTION
Rely on webhooks to populate a default storage class if not provided in the CR. This is useful in e.g. CI to provide a custom storage class during runs.