### PR TITLE
Fix cinderScheduler in config samples

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -26,6 +26,8 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+      cinderScheduler:
+        replicas: 1
       cinderBackup:
         networkAttachments:
         - storage

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -26,6 +26,8 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+      cinderScheduler:
+        replicas: 1
       cinderBackup:
         networkAttachments:
         - storage

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -54,6 +54,7 @@ spec:
         networkAttachments:
         - storage
       cinderScheduler:
+        replicas: 1
       cinderVolumes:
         ceph:
           customServiceConfig: |


### PR DESCRIPTION
Fix the cinderScheduler configuration to ensure an actual replica is created. Even though its default replica count is 1, the service isn't properly initialized unless _something_ is specified in the CR.