### PR TITLE
Align to the validation webhook pattern

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230627094520-8916cd79b366
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230703125502-37e9f97e0185
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493
-	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230630161935-e43995668618
+	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230705154317-b5d831881cf0
 	github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230629214942-7a30c60d8624
 	github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20230629080103-d956585e210c
 	github.com/openstack-k8s-operators/swift-operator/api v0.0.0-20230703062034-9c2f01bb201d

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -147,8 +147,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230703125502-37
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230703125502-37e9f97e0185/go.mod h1:YRgmQI2Z0IbQnDrU1jqvZqntSBmCmBU9CSbzoqPjrPw=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493 h1:TyneX7qu57Ujt7hUBEdVoxeldT5b7Q8rTOWguzKGmPc=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493/go.mod h1:Je+ZJlPz6kDIenaogZQC35ZX/Qnhj8nNdGuQwuaMZ84=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230630161935-e43995668618 h1:9t+cfo/5xo9MxpbF5uIItD49Xlq6fD0W4evI/Ht6gXE=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230630161935-e43995668618/go.mod h1:qZZZhgs5n6sh8ll7iLHGbgFcv1u5mfYjDIl4vIC0Fy0=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230705154317-b5d831881cf0 h1:7jWtr8b1CSdBUtsCA7hVZZQFt8zjTZ43wJpzzte3Wv4=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230705154317-b5d831881cf0/go.mod h1:qZZZhgs5n6sh8ll7iLHGbgFcv1u5mfYjDIl4vIC0Fy0=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230629214942-7a30c60d8624 h1:KUZfeEUHYZNiycIak2cjffRaVfi9HRzXl04Mxvf+Dr0=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230629214942-7a30c60d8624/go.mod h1:KWORlrdNorI0uGIFzh+Fg6R32VoLIt80jtKQEBf5uZ0=
 github.com/openstack-k8s-operators/placement-operator/api v0.0.0-20230629080103-d956585e210c h1:ZIqzGWcDNqRpxq69VzZwj7lOOdaWhQhtPkFw30kox8g=

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openstack-k8s-operators/manila-operator/api v0.0.0-20230627094520-8916cd79b366
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230703125502-37e9f97e0185
 	github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493
-	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230630161935-e43995668618
+	github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230705154317-b5d831881cf0
 	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230703102858-87737b736377
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230703104412-d4214e4a967c
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20230701113805-bd7a30194abd

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230703125502-37
 github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20230703125502-37e9f97e0185/go.mod h1:YRgmQI2Z0IbQnDrU1jqvZqntSBmCmBU9CSbzoqPjrPw=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493 h1:TyneX7qu57Ujt7hUBEdVoxeldT5b7Q8rTOWguzKGmPc=
 github.com/openstack-k8s-operators/neutron-operator/api v0.0.0-20230623073736-9899c3186493/go.mod h1:Je+ZJlPz6kDIenaogZQC35ZX/Qnhj8nNdGuQwuaMZ84=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230630161935-e43995668618 h1:9t+cfo/5xo9MxpbF5uIItD49Xlq6fD0W4evI/Ht6gXE=
-github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230630161935-e43995668618/go.mod h1:qZZZhgs5n6sh8ll7iLHGbgFcv1u5mfYjDIl4vIC0Fy0=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230705154317-b5d831881cf0 h1:7jWtr8b1CSdBUtsCA7hVZZQFt8zjTZ43wJpzzte3Wv4=
+github.com/openstack-k8s-operators/nova-operator/api v0.0.0-20230705154317-b5d831881cf0/go.mod h1:qZZZhgs5n6sh8ll7iLHGbgFcv1u5mfYjDIl4vIC0Fy0=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230703102858-87737b736377 h1:3p9z0lGbZthsrvY7lwtdrlUm1LTUnFKwBJWFadjsEQE=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.0.0-20230703102858-87737b736377/go.mod h1:dpIdzGakxXSbkIC5f3iuqMVMtr7N2VLtKT2sqPK4fso=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.0.0-20230703104412-d4214e4a967c h1:Oj/BqWAKOZtXrwGqvoww4J58JQTqjpAht6z6zR/Jzmg=


### PR DESCRIPTION
* split up the validation calls towards the service CRDs to have a separate ValidateCreate and ValidateUpdate call
* make sure that the service operators ValidateUpdate call gets the old version of the Spec struct so that they can compare

The pattern is documented in https://github.com/openstack-k8s-operators/docs/pull/47

Depends-on: https://github.com/openstack-k8s-operators/ironic-operator/pull/277 (merged)
Depends-on: https://github.com/openstack-k8s-operators/nova-operator/pull/428 (merged)