### PR TITLE
Fix MariaDB template for collapsed cell example

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -11,7 +11,8 @@ spec:
       secret: osp-secret
   mariadb:
     template:
-      storageRequest: 500M
+      openstack:
+        storageRequest: 500M
   rabbitmq:
     templates:
       rabbitmq:

--- a/tests/kuttl/tests/collapsed/01-assert-collapsed-cell.yaml
+++ b/tests/kuttl/tests/collapsed/01-assert-collapsed-cell.yaml
@@ -8,6 +8,10 @@ spec:
     template:
       databaseInstance: openstack
       secret: osp-secret
+  mariadb:
+    template:
+      openstack:
+        storageRequest: 500M
   rabbitmq:
     templates:
       rabbitmq:


### PR DESCRIPTION
This fixes the wrong format to define MariaDB instances to fix the overall deployment failure.