### PR TITLE
Fix typo in mariadb templates

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -10,7 +10,7 @@ spec:
       databaseInstance: openstack
       secret: osp-secret
   mariadb:
-    template:
+    templates:
       openstack:
         storageRequest: 500M
   rabbitmq:

--- a/tests/kuttl/tests/collapsed/01-assert-collapsed-cell.yaml
+++ b/tests/kuttl/tests/collapsed/01-assert-collapsed-cell.yaml
@@ -9,7 +9,7 @@ spec:
       databaseInstance: openstack
       secret: osp-secret
   mariadb:
-    template:
+    templates:
       openstack:
         storageRequest: 500M
   rabbitmq:


### PR DESCRIPTION
The spec.mariadb.template does not exist and it should be spec.mariadb.template"s".