### PR TITLE
Revert "Remove OpenStackClient CR"

### DIFF
--- a/apis/core/v1beta1/conditions.go
+++ b/apis/core/v1beta1/conditions.go
@@ -60,6 +60,12 @@ const (
 	// OpenStackControlPlaneHorizonReadyCondition Status=True condition which indicates if Horizon is configured and operational
 	OpenStackControlPlaneHorizonReadyCondition condition.Type = "OpenStackControlPlaneHorizonReady"
 
+	// OpenStackControlPlaneClientReadyCondition Status=True condition which indicates if OpenStackClient is configured and operational
+	OpenStackControlPlaneClientReadyCondition condition.Type = "OpenStackControlPlaneClientReady"
+
+	// OpenStackClientReadyCondition Status=True condition which indicates if OpenStackClient is configured and operational
+	OpenStackClientReadyCondition condition.Type = "OpenStackClientReady"
+
 	// OpenStackControlPlaneManilaReadyCondition Status=True condition which indicates if Manila is configured and operational
 	OpenStackControlPlaneManilaReadyCondition condition.Type = "OpenStackControlPlaneManilaReady"
 
@@ -252,6 +258,18 @@ const (
 
 	// OpenStackControlPlaneIronicReadyErrorMessage
 	OpenStackControlPlaneIronicReadyErrorMessage = "OpenStackControlPlane Ironic error occured %s"
+
+	// OpenStackControlPlaneClientReadyInitMessage
+	OpenStackControlPlaneClientReadyInitMessage = "OpenStackControlPlane Client not started"
+
+	// OpenStackControlPlaneClientReadyMessage
+	OpenStackControlPlaneClientReadyMessage = "OpenStackControlPlane Client completed"
+
+	// OpenStackControlPlaneClientReadyRunningMessage
+	OpenStackControlPlaneClientReadyRunningMessage = "OpenStackControlPlane Client in progress"
+
+	// OpenStackControlPlaneClientReadyErrorMessage
+	OpenStackControlPlaneClientReadyErrorMessage = "OpenStackControlPlane Client error occured %s"
 
 	// OpenStackControlPlaneHorizonReadyInitMessage
 	OpenStackControlPlaneHorizonReadyInitMessage = "OpenStackControlPlane Horizon not started"

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -548,6 +548,7 @@ func (instance *OpenStackControlPlane) InitConditions() {
 		condition.UnknownCondition(OpenStackControlPlaneCinderReadyCondition, condition.InitReason, OpenStackControlPlaneCinderReadyInitMessage),
 		condition.UnknownCondition(OpenStackControlPlaneNovaReadyCondition, condition.InitReason, OpenStackControlPlaneNovaReadyInitMessage),
 		condition.UnknownCondition(OpenStackControlPlaneIronicReadyCondition, condition.InitReason, OpenStackControlPlaneIronicReadyInitMessage),
+		condition.UnknownCondition(OpenStackControlPlaneClientReadyCondition, condition.InitReason, OpenStackControlPlaneClientReadyInitMessage),
 		condition.UnknownCondition(OpenStackControlPlaneManilaReadyCondition, condition.InitReason, OpenStackControlPlaneManilaReadyInitMessage),
 		condition.UnknownCondition(OpenStackControlPlaneHorizonReadyCondition, condition.InitReason, OpenStackControlPlaneHorizonReadyInitMessage),
 		condition.UnknownCondition(OpenStackControlPlaneDNSReadyCondition, condition.InitReason, OpenStackControlPlaneDNSReadyInitMessage),

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - client.openstack.org
+  resources:
+  - openstackclients
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - core.openstack.org
   resources:
   - openstackcontrolplanes

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -24,6 +24,7 @@ import (
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
 	heatv1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
 	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1beta1"
+	clientv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/client/v1beta1"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
@@ -62,6 +63,7 @@ type OpenStackControlPlaneReconciler struct {
 //+kubebuilder:rbac:groups=core.openstack.org,resources=openstackcontrolplanes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core.openstack.org,resources=openstackcontrolplanes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core.openstack.org,resources=openstackcontrolplanes/finalizers,verbs=update
+//+kubebuilder:rbac:groups=client.openstack.org,resources=openstackclients,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ironic.openstack.org,resources=ironics,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=horizon.openstack.org,resources=horizons,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapis,verbs=get;list;watch;create;update;patch;delete
@@ -251,6 +253,13 @@ func (r *OpenStackControlPlaneReconciler) reconcileNormal(ctx context.Context, i
 		return ctrlResult, nil
 	}
 
+	ctrlResult, err = openstack.ReconcileOpenStackClient(ctx, instance, helper)
+	if err != nil {
+		return ctrl.Result{}, err
+	} else if (ctrlResult != ctrl.Result{}) {
+		return ctrlResult, nil
+	}
+
 	ctrlResult, err = openstack.ReconcileManila(ctx, instance, helper)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -303,6 +312,7 @@ func (r *OpenStackControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Owns(&novav1.Nova{}).
 		Owns(&heatv1.Heat{}).
 		Owns(&ironicv1.Ironic{}).
+		Owns(&clientv1beta1.OpenStackClient{}).
 		Owns(&horizonv1.Horizon{}).
 		Owns(&telemetryv1.CeilometerCentral{}).
 		Complete(r)

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
 	heatv1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
 	horizonv1 "github.com/openstack-k8s-operators/horizon-operator/api/v1beta1"
+	clientv1 "github.com/openstack-k8s-operators/infra-operator/apis/client/v1beta1"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	networkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
@@ -89,6 +90,7 @@ func init() {
 	utilruntime.Must(dataplanev1beta1.AddToScheme(scheme))
 	utilruntime.Must(ansibleeev1.AddToScheme(scheme))
 	utilruntime.Must(rabbitmqv1.AddToScheme(scheme))
+	utilruntime.Must(clientv1.AddToScheme(scheme))
 	utilruntime.Must(manilav1.AddToScheme(scheme))
 	utilruntime.Must(horizonv1.AddToScheme(scheme))
 	utilruntime.Must(networkv1.AddToScheme(scheme))
@@ -226,6 +228,9 @@ func setupServiceOperatorDefaults() {
 
 	// Nova
 	novav1.SetupDefaults()
+
+	// OpenStackClient
+	clientv1.SetupDefaults()
 
 	// OVN
 	ovnv1.SetupDefaults()

--- a/pkg/openstack/openstackclient.go
+++ b/pkg/openstack/openstackclient.go
@@ -1,0 +1,87 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+
+	clientv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/client/v1beta1"
+	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	corev1beta1 "github.com/openstack-k8s-operators/openstack-operator/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	// ServiceAccount -
+	ServiceAccount = "openstack-operator-openstackclient"
+)
+
+// ReconcileOpenStackClient -
+func ReconcileOpenStackClient(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, helper *helper.Helper) (ctrl.Result, error) {
+
+	openstackclient := &clientv1beta1.OpenStackClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openstackclient",
+			Namespace: instance.Namespace,
+		},
+	}
+
+	helper.GetLogger().Info("Reconciling OpenStackClient", "OpenStackClient.Namespace", instance.Namespace, "OpenStackClient.Name", openstackclient.Name)
+	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), openstackclient, func() error {
+		// the following are created/owned by keystoneclient
+		openstackclient.Spec.OpenStackConfigMap = "openstack-config"
+		openstackclient.Spec.OpenStackConfigSecret = "openstack-config-secret"
+		openstackclient.Spec.NodeSelector = instance.Spec.NodeSelector
+
+		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), openstackclient, helper.GetScheme())
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			corev1beta1.OpenStackControlPlaneClientReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			corev1beta1.OpenStackControlPlaneClientReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, err
+	}
+	if op != controllerutil.OperationResultNone {
+		helper.GetLogger().Info(fmt.Sprintf("OpenStackClient %s - %s", openstackclient.Name, op))
+	}
+
+	if openstackclient.Status.Conditions.IsTrue(clientv1beta1.OpenStackClientReadyCondition) {
+		helper.GetLogger().Info("OpenStackClient ready condition is true")
+		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneClientReadyCondition, corev1beta1.OpenStackControlPlaneClientReadyMessage)
+	} else {
+		helper.GetLogger().Info("OpenStackClient ready condition is false")
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			corev1beta1.OpenStackControlPlaneClientReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			corev1beta1.OpenStackControlPlaneClientReadyRunningMessage))
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -146,6 +146,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneCinderReady
+  - message: OpenStackControlPlane Client completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneClientReady
   - message: OpenStackControlPlane Glance completed
     reason: Ready
     status: "True"


### PR DESCRIPTION
This reverts commit ccd18fcc69d3151af229df071faa825253bb264e, which caused a promotion pipeline failure. We can reintroduce it when we're ready to land the patch that reintroduces it in keystone operator.