### PR TITLE
Configure renovate to pin k8s and controller-runtime for dev preview and pin ocp

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openshift/api v3.9.0+incompatible // indirect
-	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20230712082535-db7193b646f2 // indirect; indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect
+	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20230712082535-db7193b646f2 //indirect
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230712082535-db7193b646f2
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
@@ -78,13 +78,17 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.26.6 // indirect // indirect // indirect
-	k8s.io/apiextensions-apiserver v0.26.6 // indirect; indirect // indirect // indirect
-	k8s.io/client-go v0.26.6 // indirect; indirect // indirect // indirect
-	k8s.io/component-base v0.26.6 // indirect; indirect // indirect // indirect
+	k8s.io/apiextensions-apiserver v0.26.6 //indirect
+	k8s.io/client-go v0.26.6 //indirect
+	k8s.io/component-base v0.26.6 //indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
-	k8s.io/kube-openapi v0.0.0-20230515203736-54b630e78af5 // indirect; indirect // indirect // indirect // indirect // indirect // indirect
-	k8s.io/utils v0.0.0-20230505201702-9f6742963106 // indirect; indirect // indirect // indirect // indirect
-	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect; indirect // indirect
+	k8s.io/kube-openapi v0.0.0-20230515203736-54b630e78af5 //indirect
+	k8s.io/utils v0.0.0-20230505201702-9f6742963106 //indirect
+	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd //indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+// mschuppert: map to latest commit from release-4.13 tag
+// must consistent within modules and service operators
+replace github.com/openshift/api => github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 //allow-merging

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -119,8 +119,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
-github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
-github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230707161104-1e2896501829 h1:UuHwc4EHwDn3t13Fbv5vby6LWgngAhjuurH4Qcn1ieU=
 github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230707161104-1e2896501829/go.mod h1://aFRb/yWjLOOdWhfs+qfzko3OcyZRt+fvdVtEJCcTg=
 github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20230711055526-23fa929a7137 h1:2bDtp3sxSeQUPDgnV7mO/wEbZNdzSMDgGXvN/b2Gaao=

--- a/go.mod
+++ b/go.mod
@@ -69,8 +69,8 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openshift/api v3.9.0+incompatible // indirect
-	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20230712082535-db7193b646f2 // indirect; indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect
-	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230712082535-db7193b646f2 // indirect; indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect // indirect
+	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20230712082535-db7193b646f2 //indirect
+	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20230712082535-db7193b646f2 //indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
@@ -92,14 +92,18 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.26.6 // indirect; indirect // indirect // indirect
-	k8s.io/component-base v0.26.6 // indirect; indirect // indirect // indirect
+	k8s.io/apiextensions-apiserver v0.26.6 //indirect
+	k8s.io/component-base v0.26.6 //indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
-	k8s.io/kube-openapi v0.0.0-20230515203736-54b630e78af5 // indirect; indirect // indirect // indirect // indirect // indirect // indirect
-	k8s.io/utils v0.0.0-20230505201702-9f6742963106 // indirect; indirect // indirect // indirect // indirect
-	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect; indirect // indirect
+	k8s.io/kube-openapi v0.0.0-20230515203736-54b630e78af5 //indirect
+	k8s.io/utils v0.0.0-20230505201702-9f6742963106 //indirect
+	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd //indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace github.com/openstack-k8s-operators/openstack-operator/apis => ./apis
+
+// mschuppert: map to latest commit from release-4.13 tag
+// must consistent within modules and service operators
+replace github.com/openshift/api => github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 //allow-merging

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
-github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
-github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230707161104-1e2896501829 h1:UuHwc4EHwDn3t13Fbv5vby6LWgngAhjuurH4Qcn1ieU=
 github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230707161104-1e2896501829/go.mod h1://aFRb/yWjLOOdWhfs+qfzko3OcyZRt+fvdVtEJCcTg=
 github.com/openstack-k8s-operators/dataplane-operator/api v0.0.0-20230712115735-223957c43c35 h1:deSuUV1v8iNltxdAQKRGP8yB6JArJEpmhw0RpmFfYkk=

--- a/renovate.json
+++ b/renovate.json
@@ -26,8 +26,15 @@
     },
     {
       "groupName": "k8s.io",
-      "matchPackagePatterns": ["^k8s.io", "^sigs.k8s.io"],
-      "allowedVersions": "< 1.0.0",
+      "matchPackagePatterns": ["^k8s.io"],
+      "excludePackagePatterns": ["^k8s.io/kube-openapi"],
+      "allowedVersions": "< 0.27.0",
+      "enabled": true
+    },
+    {
+      "groupName": "sigs.k8s.io/controller-runtime",
+      "matchPackagePatterns": ["^sigs.k8s.io/controller-runtime"],
+      "allowedVersions": "< 0.15.0",
       "enabled": true
     },
     {


### PR DESCRIPTION
- pin k8s and controller runtime to be in sync with lib-common and configure renovate to keep the pin
- pin ocp api version to a hash in sync with lib-common instead of the nonexistent v3.9.0+incompatible tag