### PR TITLE
Handle module versions after initial tagging

### DIFF
--- a/hack/pin-bundle-images.sh
+++ b/hack/pin-bundle-images.sh
@@ -26,7 +26,7 @@ for MOD_PATH in $(go list -mod=readonly -m -json all | jq -r '. | select(.Path |
 
     GIT_REPO=${MOD_PATH%"/apis"}
     GIT_REPO=${GIT_REPO%"/api"}
-    REF=$(echo $MOD_VERSION | sed -e 's|v0.0.0-[0-9]*-\(.*\)$|\1|')
+    REF=$(echo $MOD_VERSION | sed -e 's|v[0-9]*.[0-9]*.[0-9]*-.*[0-9]*-\(.*\)$|\1|')
     if [[ "$REF" == v* ]]; then
         REF=$(git ls-remote https://${GIT_REPO} | grep ${REF} | awk 'NR==1{print $1}')
     fi


### PR DESCRIPTION
After service operators recently tagged v0.1.0,
mod versions for post commit are now named like:-
v0.1.1-0.20230722145759-293f6d6ef5f3 which do not
get parsed correctly with current regex.

Made regex more generic in pin-bundle-images.sh
to handle these cases.