### PR TITLE
Bump nova-operator to v0.1.1

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openstack-k8s-operators/manila-operator/api v0.1.0
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0
 	github.com/openstack-k8s-operators/neutron-operator/api v0.1.0
-	github.com/openstack-k8s-operators/nova-operator/api v0.1.0
+	github.com/openstack-k8s-operators/nova-operator/api v0.1.1
 	github.com/openstack-k8s-operators/ovn-operator/api v0.1.0
 	github.com/openstack-k8s-operators/placement-operator/api v0.1.0
 	github.com/openstack-k8s-operators/swift-operator/api v0.1.0

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -152,8 +152,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0 h1:oM0ZzFHHj+ioCc
 github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0/go.mod h1:m5XuZSa5Zt5uAw3WbJYOIkFAGXy01mybVekcKOq1qHI=
 github.com/openstack-k8s-operators/neutron-operator/api v0.1.0 h1:tGlQ4RPeFtgEHOnyqTnTzjzBaPHdpm0ieMMmQHl3XTg=
 github.com/openstack-k8s-operators/neutron-operator/api v0.1.0/go.mod h1:5VaQboKxg4t65Xt1xcddjjODrUHkwQo9LCUWiGqbFao=
-github.com/openstack-k8s-operators/nova-operator/api v0.1.0 h1:aBabsbpRMdhJEQROdIXOozevghqOgpCOMzJVduuEpS4=
-github.com/openstack-k8s-operators/nova-operator/api v0.1.0/go.mod h1:bQWyn3wTGEjbWk6qzyL7IhcIl9xU5WcGBcKBZZiD3Uo=
+github.com/openstack-k8s-operators/nova-operator/api v0.1.1 h1:4FHCnUBopafOdnR+JEHyPROdi5wUjOk7G9YcfP3rfIE=
+github.com/openstack-k8s-operators/nova-operator/api v0.1.1/go.mod h1:bQWyn3wTGEjbWk6qzyL7IhcIl9xU5WcGBcKBZZiD3Uo=
 github.com/openstack-k8s-operators/ovn-operator/api v0.1.0 h1:AnmXOjUJMgxg8cRewjUIHfOCH1o3jTftYfvXiRGBjmA=
 github.com/openstack-k8s-operators/ovn-operator/api v0.1.0/go.mod h1:SSNSWIHTf2i/yM2KprT7FZeCuQfGwEf5eHnISi3zMAg=
 github.com/openstack-k8s-operators/placement-operator/api v0.1.0 h1:i2UEgkyAommKa3Q3KOwQirbbiLW6EocS457S+3fc46s=

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/openstack-k8s-operators/manila-operator/api v0.1.0
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0
 	github.com/openstack-k8s-operators/neutron-operator/api v0.1.0
-	github.com/openstack-k8s-operators/nova-operator/api v0.1.0
+	github.com/openstack-k8s-operators/nova-operator/api v0.1.1
 	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.1.0
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.1.0
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20230725141229-4ce90d0120fd

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0 h1:oM0ZzFHHj+ioCc
 github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0/go.mod h1:m5XuZSa5Zt5uAw3WbJYOIkFAGXy01mybVekcKOq1qHI=
 github.com/openstack-k8s-operators/neutron-operator/api v0.1.0 h1:tGlQ4RPeFtgEHOnyqTnTzjzBaPHdpm0ieMMmQHl3XTg=
 github.com/openstack-k8s-operators/neutron-operator/api v0.1.0/go.mod h1:5VaQboKxg4t65Xt1xcddjjODrUHkwQo9LCUWiGqbFao=
-github.com/openstack-k8s-operators/nova-operator/api v0.1.0 h1:aBabsbpRMdhJEQROdIXOozevghqOgpCOMzJVduuEpS4=
-github.com/openstack-k8s-operators/nova-operator/api v0.1.0/go.mod h1:bQWyn3wTGEjbWk6qzyL7IhcIl9xU5WcGBcKBZZiD3Uo=
+github.com/openstack-k8s-operators/nova-operator/api v0.1.1 h1:4FHCnUBopafOdnR+JEHyPROdi5wUjOk7G9YcfP3rfIE=
+github.com/openstack-k8s-operators/nova-operator/api v0.1.1/go.mod h1:bQWyn3wTGEjbWk6qzyL7IhcIl9xU5WcGBcKBZZiD3Uo=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.1.0 h1:M0WPgJ4ceFFg80amyOJY694zaMtovQyRN0AM0IuG8JA=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.1.0/go.mod h1:kkCrsqex/cB2DqupYTG0VOTZXQZLrKNhX9L4mHqEEgM=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.1.0 h1:Azz4lBUefF9HUV8WndreRrFlzujhBp0b/fd+TuJBePY=


### PR DESCRIPTION
This is needed to pick up a bugfix for EDPM deployment in real network isolation environment.

See https://github.com/openstack-k8s-operators/nova-operator/pull/479