### PR TITLE
Bump dataplane-operator to the latest commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/openstack-k8s-operators/cinder-operator/api v0.1.0
-	github.com/openstack-k8s-operators/dataplane-operator/api v0.1.0
+	github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230731222534-a2e91a5bf076
 	github.com/openstack-k8s-operators/glance-operator/api v0.1.0
 	github.com/openstack-k8s-operators/heat-operator/api v0.1.0
 	github.com/openstack-k8s-operators/horizon-operator/api v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxC
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/cinder-operator/api v0.1.0 h1:8QsJidoozdGsV9fSFzzgCstxMvi8tKtsY67+G/gWKB0=
 github.com/openstack-k8s-operators/cinder-operator/api v0.1.0/go.mod h1:GEZ6VarA74XXRa4SagCymoRrxQQVWvxZ2K7O4/YSxK4=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.1.0 h1:4qcU2P+uxccrQ4lHJi7zHv4Q7xRQqX2ig780ry31gzE=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.1.0/go.mod h1:MCFGnnM4FNHBbbmYQNkO3EId9OU7bYfBoODXVixrSEM=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230731222534-a2e91a5bf076 h1:QgvGAU4kJoQamnQlXe2nTiEqx62sY0xDZxq+jvCXOHs=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230731222534-a2e91a5bf076/go.mod h1:5qvkN87pvsGz3LyTM/muQ22u3TrY72ZR7JzI84QHI/w=
 github.com/openstack-k8s-operators/glance-operator/api v0.1.0 h1:FWYUz5iHzzh6b74eor+3t9h4GQojmLFXD4YzFApEWz4=
 github.com/openstack-k8s-operators/glance-operator/api v0.1.0/go.mod h1:I7JjTjU7qvmVr5rqMvlDbhxa3pA3DlCH4ZENGNew6gg=
 github.com/openstack-k8s-operators/heat-operator/api v0.1.0 h1:OTYRtRUP3zwm0zg6JG/s2FYU7QT7xQNTFhMcMKpVRVU=


### PR DESCRIPTION
```
go get github.com/openstack-k8s-operators/dataplane-operator/api@a2e91a5bf0766dced548495bb84a2bcf96ae419e
```
for unblocking https://github.com/openstack-k8s-operators/install_yamls/pull/442
and fixing the CI for EDPM jobs