### PR TITLE
Use dev-preview shared renovate config on dev-preview branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>openstack-k8s-operators/renovate-config"
+    "github>openstack-k8s-operators/renovate-config:dev-preview.json"
   ],
   "constraints": {
     "go": "1.19"
@@ -10,10 +10,5 @@
       "matchPackageNames": ["github.com/openstack-k8s-operators/openstack-operator/apis"],
       "enabled": false
     }
-  ],
-  "postUpgradeTasks": {
-    "commands": ["make gowork", "make tidy", "make manifests generate"],
-    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
-    "executionMode": "update"
-  }
+  ]
 }


### PR DESCRIPTION
Renovate merges config together in the following order when processing the dev-preview branch:
* default.json from renovate-config due to renovate.json@main points to it
* renovate.json@main
* dev-preview.json from renovate-config due to renovate.json@dev-preview points to it
* renovate.json@dev-preview

This means that:
* we can override version handling and pinning defined in default.json in dev-preview.json.
* we need to repeat the rule that we don't want to bump our own api module version in renovate.json@dev-preview as or previous such rule is in renovate.json@main but that was overridden by package rule in dev-preview.json

The go constraint rule was intentionally duplicated now as on main we might want to move forward with the go version and that would directly affect the dev-preview branch as well if the constraint is not duplicated.

Depends-on: https://github.com/openstack-k8s-operators/renovate-config/pull/6