### PR TITLE
Allow renovate on dev-preview branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
   "constraints": {
     "go": "1.19"
   },
+  "baseBranches": ["main","dev-preview"],
+  "useBaseBranchConfig": "merge",
   "packageRules": [
     {
       "matchPackageNames": ["github.com/openstack-k8s-operators/openstack-operator/apis"],


### PR DESCRIPTION
By default renovate only looks at the renovate.json on the default branch of the repo and that config file needs to list all the other branches that renovate should manage. So this patch adds dev-preview as managed branch.

Depends-on: https://github.com/openstack-k8s-operators/openstack-operator/pull/428