### PR TITLE
Use lib-common functionality to calculate ReadyCondition

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	cinderv1 "github.com/openstack-k8s-operators/cinder-operator/api/v1beta1"
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
 	heatv1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
@@ -539,15 +537,7 @@ func init() {
 
 // IsReady - returns true if service is ready to serve requests
 func (instance OpenStackControlPlane) IsReady() bool {
-	for _, c := range instance.Status.Conditions {
-		if c.Type == condition.ReadyCondition {
-			continue
-		}
-		if c.Status != corev1.ConditionTrue {
-			return false
-		}
-	}
-	return true
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 // InitConditions - Initializes Status Conditons

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -124,15 +124,17 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
 		} else {
 			// something is not ready so reset the Ready condition
 			instance.Status.Conditions.MarkUnknown(
 				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
 			// and recalculate it based on the state of the rest of the conditions
-			instance.Status.Conditions.Set(instance.Status.Conditions.Mirror(condition.ReadyCondition))
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
 
 		err := helper.PatchInstance(ctx, instance)


### PR DESCRIPTION
Recent lib-common provides the way to calculate condition based on sub conditions. This replaces the current implementation by that common one.