### PR TITLE
update the nova-operator and dataplane-operator tags

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openstack-k8s-operators/manila-operator/api v0.1.0
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0
 	github.com/openstack-k8s-operators/neutron-operator/api v0.1.0
-	github.com/openstack-k8s-operators/nova-operator/api v0.1.0
+	github.com/openstack-k8s-operators/nova-operator/api v0.1.1
 	github.com/openstack-k8s-operators/ovn-operator/api v0.1.0
 	github.com/openstack-k8s-operators/placement-operator/api v0.1.0
 	github.com/openstack-k8s-operators/swift-operator/api v0.1.0

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -152,8 +152,7 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0 h1:oM0ZzFHHj+ioCc
 github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0/go.mod h1:m5XuZSa5Zt5uAw3WbJYOIkFAGXy01mybVekcKOq1qHI=
 github.com/openstack-k8s-operators/neutron-operator/api v0.1.0 h1:tGlQ4RPeFtgEHOnyqTnTzjzBaPHdpm0ieMMmQHl3XTg=
 github.com/openstack-k8s-operators/neutron-operator/api v0.1.0/go.mod h1:5VaQboKxg4t65Xt1xcddjjODrUHkwQo9LCUWiGqbFao=
-github.com/openstack-k8s-operators/nova-operator/api v0.1.0 h1:aBabsbpRMdhJEQROdIXOozevghqOgpCOMzJVduuEpS4=
-github.com/openstack-k8s-operators/nova-operator/api v0.1.0/go.mod h1:bQWyn3wTGEjbWk6qzyL7IhcIl9xU5WcGBcKBZZiD3Uo=
+github.com/openstack-k8s-operators/nova-operator/api v0.1.1 h1:4FHCnUBopafOdnR+JEHyPROdi5wUjOk7G9YcfP3rfIE=
 github.com/openstack-k8s-operators/ovn-operator/api v0.1.0 h1:AnmXOjUJMgxg8cRewjUIHfOCH1o3jTftYfvXiRGBjmA=
 github.com/openstack-k8s-operators/ovn-operator/api v0.1.0/go.mod h1:SSNSWIHTf2i/yM2KprT7FZeCuQfGwEf5eHnISi3zMAg=
 github.com/openstack-k8s-operators/placement-operator/api v0.1.0 h1:i2UEgkyAommKa3Q3KOwQirbbiLW6EocS457S+3fc46s=

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/openstack-k8s-operators/cinder-operator/api v0.1.0
-	github.com/openstack-k8s-operators/dataplane-operator/api v0.1.0
+	github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1
 	github.com/openstack-k8s-operators/glance-operator/api v0.1.0
 	github.com/openstack-k8s-operators/heat-operator/api v0.1.0
 	github.com/openstack-k8s-operators/horizon-operator/api v0.1.0
@@ -20,7 +20,7 @@ require (
 	github.com/openstack-k8s-operators/manila-operator/api v0.1.0
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0
 	github.com/openstack-k8s-operators/neutron-operator/api v0.1.0
-	github.com/openstack-k8s-operators/nova-operator/api v0.1.0
+	github.com/openstack-k8s-operators/nova-operator/api v0.1.1
 	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.1.0
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.1.0
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20230725141229-4ce90d0120fd

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxC
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/cinder-operator/api v0.1.0 h1:8QsJidoozdGsV9fSFzzgCstxMvi8tKtsY67+G/gWKB0=
 github.com/openstack-k8s-operators/cinder-operator/api v0.1.0/go.mod h1:GEZ6VarA74XXRa4SagCymoRrxQQVWvxZ2K7O4/YSxK4=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.1.0 h1:4qcU2P+uxccrQ4lHJi7zHv4Q7xRQqX2ig780ry31gzE=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.1.0/go.mod h1:MCFGnnM4FNHBbbmYQNkO3EId9OU7bYfBoODXVixrSEM=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1 h1:sW2JKccOoEKTfXeJEH6lOF29LDAhruI/fU5LQZSdnHE=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1/go.mod h1:MCFGnnM4FNHBbbmYQNkO3EId9OU7bYfBoODXVixrSEM=
 github.com/openstack-k8s-operators/glance-operator/api v0.1.0 h1:FWYUz5iHzzh6b74eor+3t9h4GQojmLFXD4YzFApEWz4=
 github.com/openstack-k8s-operators/glance-operator/api v0.1.0/go.mod h1:I7JjTjU7qvmVr5rqMvlDbhxa3pA3DlCH4ZENGNew6gg=
 github.com/openstack-k8s-operators/heat-operator/api v0.1.0 h1:OTYRtRUP3zwm0zg6JG/s2FYU7QT7xQNTFhMcMKpVRVU=
@@ -161,8 +161,8 @@ github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0 h1:oM0ZzFHHj+ioCc
 github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0/go.mod h1:m5XuZSa5Zt5uAw3WbJYOIkFAGXy01mybVekcKOq1qHI=
 github.com/openstack-k8s-operators/neutron-operator/api v0.1.0 h1:tGlQ4RPeFtgEHOnyqTnTzjzBaPHdpm0ieMMmQHl3XTg=
 github.com/openstack-k8s-operators/neutron-operator/api v0.1.0/go.mod h1:5VaQboKxg4t65Xt1xcddjjODrUHkwQo9LCUWiGqbFao=
-github.com/openstack-k8s-operators/nova-operator/api v0.1.0 h1:aBabsbpRMdhJEQROdIXOozevghqOgpCOMzJVduuEpS4=
-github.com/openstack-k8s-operators/nova-operator/api v0.1.0/go.mod h1:bQWyn3wTGEjbWk6qzyL7IhcIl9xU5WcGBcKBZZiD3Uo=
+github.com/openstack-k8s-operators/nova-operator/api v0.1.1 h1:4FHCnUBopafOdnR+JEHyPROdi5wUjOk7G9YcfP3rfIE=
+github.com/openstack-k8s-operators/nova-operator/api v0.1.1/go.mod h1:bQWyn3wTGEjbWk6qzyL7IhcIl9xU5WcGBcKBZZiD3Uo=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.1.0 h1:M0WPgJ4ceFFg80amyOJY694zaMtovQyRN0AM0IuG8JA=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.1.0/go.mod h1:kkCrsqex/cB2DqupYTG0VOTZXQZLrKNhX9L4mHqEEgM=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.1.0 h1:Azz4lBUefF9HUV8WndreRrFlzujhBp0b/fd+TuJBePY=


### PR DESCRIPTION
This chagne just updates teh nova and dataplane operator
api module tags to take account of the v0.1.1 tags.
While there are no CRD changes in the or other changes in the API
moduels its still good to keep these in sync but will not
break anything in this instance.
