### PR TITLE
Bind manila-share to the storage network

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -127,13 +127,11 @@ spec:
         - internalapi
       manilaScheduler:
         replicas: 1
-        networkAttachments:
-        - internalapi
       manilaShares:
         share1:
           replicas: 1
           networkAttachments:
-          - internalapi
+          - storage
   ovn:
     template:
       ovnDBCluster:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -127,13 +127,11 @@ spec:
         - internalapi
       manilaScheduler:
         replicas: 1
-        networkAttachments:
-        - internalapi
       manilaShares:
         share1:
           replicas: 1
           networkAttachments:
-          - internalapi
+          - storage
   ovn:
     template:
       ovnDBCluster:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -115,13 +115,11 @@ spec:
         - internalapi
       manilaScheduler:
         replicas: 1
-        networkAttachments:
-        - internalapi
       manilaShares:
         share1:
           replicas: 1
           networkAttachments:
-          - internalapi
+          - storage
   ovn:
     template:
       ovnDBCluster:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -13,6 +13,7 @@ spec:
           - CinderVolume
           - CinderBackup
           - GlanceAPI
+          - ManilaShare
           extraVolType: Ceph
           volumes:
           - name: ceph
@@ -159,8 +160,6 @@ spec:
         - internalapi
       manilaScheduler:
         replicas: 1
-        networkAttachments:
-        - internalapi
       manilaShares:
         share1:
           customServiceConfig: |
@@ -178,7 +177,7 @@ spec:
             cephfs_protocol_helper_type=CEPHFS
           replicas: 1
           networkAttachments:
-          - internalapi
+          - storage
   ovn:
     template:
       ovnDBCluster:


### PR DESCRIPTION
The sample had a wrong networkAttachment in both scheduler and manilaShare. This patch is supposed to fix the NAD part of the template specs.