### PR TITLE
Bump dataplane-operator for CRD changes

### DIFF
--- a/cmd/csv-merger/csv-merger.go
+++ b/cmd/csv-merger/csv-merger.go
@@ -118,7 +118,7 @@ var (
 	importEnvFiles = flag.String("import-env-files", "", "Comma separated list of file names to read default operator ENVs from. Used for inter-bundle ENV merging.")
 	exportEnvFile  = flag.String("export-env-file", "", "Name the external file to write operator ENVs to. Used for inter-bundle ENV merging.")
 	almExamples    = flag.Bool("alm-examples", false, "Merge almExamples into the CSV")
-	visibleCRDList = flag.String("visible-crds-list", "openstackcontrolplanes.core.openstack.org,openstackdataplanes.dataplane.openstack.org,openstackdataplaneroles.dataplane.openstack.org,openstackdataplanenodes.dataplane.openstack.org",
+	visibleCRDList = flag.String("visible-crds-list", "openstackcontrolplanes.core.openstack.org,openstackdataplanenodesets.dataplane.openstack.org",
 		"Comma separated list of all the CRDs that should be visible in OLM console")
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.10
 	github.com/openstack-k8s-operators/cinder-operator/api v0.1.1-0.20230822085155-98a680937115
-	github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230829012108-d1bde177e5a4
+	github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230906145103-e071f2c2dc01
 	github.com/openstack-k8s-operators/glance-operator/api v0.1.1-0.20230827173355-391b0669d71f
 	github.com/openstack-k8s-operators/heat-operator/api v0.1.1-0.20230828054057-36837cde8504
 	github.com/openstack-k8s-operators/horizon-operator/api v0.1.1-0.20230828060631-f5678c16313e

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxC
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/cinder-operator/api v0.1.1-0.20230822085155-98a680937115 h1:7O/YnKJEUnn1bh3eEH4Yuqx0GzTe4HXd4zyzOD+NWxc=
 github.com/openstack-k8s-operators/cinder-operator/api v0.1.1-0.20230822085155-98a680937115/go.mod h1:GEZ6VarA74XXRa4SagCymoRrxQQVWvxZ2K7O4/YSxK4=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230829012108-d1bde177e5a4 h1:1nLv/JrcNbW82xa26RcI6FGRs4tuVt512qttDA8No8s=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230829012108-d1bde177e5a4/go.mod h1:xwL2kjh+IdDB5LCaU39VxtQN8L70cmYUzofkq1PV0Vw=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230906145103-e071f2c2dc01 h1:ZPexOHJk6dwoVPtDNaGT1KCHPM/Rsr2rwOmvATt9ZM4=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230906145103-e071f2c2dc01/go.mod h1:LnOxN8FwbHtDf6/9U5VYgZggkMXcKfKbywtuKHFvx9Q=
 github.com/openstack-k8s-operators/glance-operator/api v0.1.1-0.20230827173355-391b0669d71f h1:dIDdStKBEtE5p3YvAwXIePNw7N/X6WMk2dRxcHTBHE4=
 github.com/openstack-k8s-operators/glance-operator/api v0.1.1-0.20230827173355-391b0669d71f/go.mod h1:4mRCop53FgDo19PnkFDqQHhsKMaJd/vJe+zvdOEl9oQ=
 github.com/openstack-k8s-operators/heat-operator/api v0.1.1-0.20230828054057-36837cde8504 h1:Aj5Dwb/xLrfb0HqbbtWZ6HroCtK8VaYM72V513UZ+Us=


### PR DESCRIPTION
This bumps the dataplane-operator dependency to pick up the changes from
https://github.com/openstack-k8s-operators/dataplane-operator/pull/303.

The visible CRDs from dataplane-operator are also updated to reflect the
change, with only OpenStackDataPlaneNodeSet being visible.

Signed-off-by: James Slagle <jslagle@redhat.com>

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/521
