### PR TITLE
Bump for dataplane-operator webhook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.10
 	github.com/openstack-k8s-operators/cinder-operator/api v0.1.1-0.20230822085155-98a680937115
-	github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230908064757-8a2b7f4f9b97
+	github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230911122617-d3fe1b87bed6
 	github.com/openstack-k8s-operators/glance-operator/api v0.1.1-0.20230827173355-391b0669d71f
 	github.com/openstack-k8s-operators/heat-operator/api v0.1.1-0.20230828054057-36837cde8504
 	github.com/openstack-k8s-operators/horizon-operator/api v0.1.1-0.20230828060631-f5678c16313e

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxC
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/cinder-operator/api v0.1.1-0.20230822085155-98a680937115 h1:7O/YnKJEUnn1bh3eEH4Yuqx0GzTe4HXd4zyzOD+NWxc=
 github.com/openstack-k8s-operators/cinder-operator/api v0.1.1-0.20230822085155-98a680937115/go.mod h1:GEZ6VarA74XXRa4SagCymoRrxQQVWvxZ2K7O4/YSxK4=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230908064757-8a2b7f4f9b97 h1:TOuQliZvYiJMQtcXBCSrxRXXvmRBBYdm0CN1qvKz8iQ=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230908064757-8a2b7f4f9b97/go.mod h1:LnOxN8FwbHtDf6/9U5VYgZggkMXcKfKbywtuKHFvx9Q=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230911122617-d3fe1b87bed6 h1:hqa0mwzP7MD6dQqVdRFuRuRlqgeIsID/rboOX4PtC7Q=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.1.1-0.20230911122617-d3fe1b87bed6/go.mod h1:LnOxN8FwbHtDf6/9U5VYgZggkMXcKfKbywtuKHFvx9Q=
 github.com/openstack-k8s-operators/glance-operator/api v0.1.1-0.20230827173355-391b0669d71f h1:dIDdStKBEtE5p3YvAwXIePNw7N/X6WMk2dRxcHTBHE4=
 github.com/openstack-k8s-operators/glance-operator/api v0.1.1-0.20230827173355-391b0669d71f/go.mod h1:4mRCop53FgDo19PnkFDqQHhsKMaJd/vJe+zvdOEl9oQ=
 github.com/openstack-k8s-operators/heat-operator/api v0.1.1-0.20230828054057-36837cde8504 h1:Aj5Dwb/xLrfb0HqbbtWZ6HroCtK8VaYM72V513UZ+Us=


### PR DESCRIPTION
OpenStackDataPlaneNodeSet webhooks are re-introduced with [1].

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/404