### PR TITLE
Switch the operator to use the multinode layout

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -25,8 +25,8 @@
       - renovate.json
 
 - job:
-    name: openstack-operator-crc-podified-edpm-deployment
-    parent: cifmw-crc-podified-edpm-deployment
+    name: openstack-operator-podified-multinode-edpm-deployment-crc
+    parent: podified-multinode-edpm-deployment-crc
     irrelevant-files: *openstack_if
 
 - job:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,4 +7,4 @@
         - openstack-operator-crc-podified-edpm-baremetal: &content_provider
             dependencies:
               - openstack-operator-content-provider
-        - openstack-operator-crc-podified-edpm-deployment: *content_provider
+        - openstack-operator-podified-multinode-edpm-deployment-crc: *content_provider


### PR DESCRIPTION
Since we are getting rid off the nested EDPM jobs we are now changing the openstack-operator to use the multinode based EDPM deployment job.