### PR TITLE
Support disconnected network environments

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,69 +1,13 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/openstack-operator.clusterserviceversion.yaml"
-
 echo "Creating openstack operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/openstack-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-    digest_image=""
-    echo "CSV line: ${csv_image}"
-
-    # case where @ is in the csv_image image
-    if [[ "$csv_image" =~ .*"@".* ]]; then
-        delimeter='@'
-    else
-        delimeter=':'
-    fi
-
-    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-    if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-        echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-        sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-    else
-        digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-        echo "Base image: $base_image"
-        if [ -n "$digest_image" ]; then
-            echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-            sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-        else
-            echo "$base_image${delimeter}$tag_image not changed"
-        fi
-    fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+DEFAULT_IMG ?= quay.io/openstack-k8s-operators/openstack-operator:latest
+IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 

--- a/apis/client/v1beta1/openstackclient_types.go
+++ b/apis/client/v1beta1/openstackclient_types.go
@@ -98,7 +98,7 @@ func (instance OpenStackClient) RbacResourceName() string {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize OpenStackClient defaults with them
 	openStackClientDefaults := OpenStackClientDefaults{
-		ContainerImageURL: util.GetEnvVar("OPENSTACK_CLIENT_IMAGE_URL_DEFAULT", OpenStackClientContainerImage),
+		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_OPENSTACK_CLIENT_IMAGE_URL_DEFAULT", OpenStackClientContainerImage),
 	}
 
 	SetupOpenStackClientDefaults(openStackClientDefaults)

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -577,7 +577,7 @@ func (instance *OpenStackControlPlane) InitConditions() {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize OpenStackControlPlane defaults with them
 	openstackControlPlaneDefaults := OpenStackControlPlaneDefaults{
-		RabbitMqImageURL: util.GetEnvVar("RABBITMQ_IMAGE_URL_DEFAULT", RabbitMqContainerImage),
+		RabbitMqImageURL: util.GetEnvVar("RELATED_IMAGE_RABBITMQ_IMAGE_URL_DEFAULT", RabbitMqContainerImage),
 	}
 
 	SetupOpenStackControlPlaneDefaults(openstackControlPlaneDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: manager
         env:
-        - name: RABBITMQ_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_RABBITMQ_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-rabbitmq:current-podified
-        - name: OPENSTACK_CLIENT_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_OPENSTACK_CLIENT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: quay.io/openstack-k8s-operators/openstack-operator
   newTag: latest

--- a/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openstack-operators
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: openstack-operator.v0.0.0


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure container registry to test)

Jira: [OSP-26486](https://issues.redhat.com//browse/OSP-26486)