### PR TITLE
Update network isolation samples as a pre step for route mgmt

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -11,6 +11,15 @@ spec:
       - ipAddressPool: ctlplane
         loadBalancerIPs:
         - 192.168.122.80
+      override:
+        service:
+          metadata:
+            annotations:
+              metallb.universe.tf/address-pool: ctlplane
+              metallb.universe.tf/allow-shared-ip: ctlplane
+              metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+          spec:
+            type: LoadBalancer
       options:
       - key: server
         values:
@@ -26,6 +35,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       cinderScheduler:
         replicas: 1
       cinderBackup:
@@ -48,6 +67,15 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
         networkAttachments:
         - storage
       glanceAPIExternal:
@@ -62,6 +90,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   mariadb:
     enabled: false
     templates:
@@ -93,6 +131,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
       networkAttachments:
       - internalapi
   horizon:
@@ -107,6 +155,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       secret: osp-secret
       metadataServiceTemplate:
         externalEndpoints:
@@ -114,6 +172,15 @@ spec:
            ipAddressPool: internalapi
            loadBalancerIPs:
            - 172.17.0.80
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   manila:
     template:
       manilaAPI:
@@ -123,6 +190,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
         networkAttachments:
         - internalapi
       manilaScheduler:
@@ -160,6 +237,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   rabbitmq:
     templates:
       rabbitmq:
@@ -168,12 +255,28 @@ spec:
           - 172.17.0.85
           ipAddressPool: internalapi
           sharedIP: false
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+            spec:
+              type: LoadBalancer
       rabbitmq-cell1:
         externalEndpoint:
           loadBalancerIPs:
           - 172.17.0.86
           ipAddressPool: internalapi
           sharedIP: false
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+            spec:
+              type: LoadBalancer
   heat:
     enabled: false
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -11,6 +11,15 @@ spec:
       - ipAddressPool: ctlplane
         loadBalancerIPs:
         - 192.168.122.80
+      override:
+        service:
+          metadata:
+            annotations:
+              metallb.universe.tf/address-pool: ctlplane
+              metallb.universe.tf/allow-shared-ip: ctlplane
+              metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+          spec:
+            type: LoadBalancer
       options:
       - key: server
         values:
@@ -26,6 +35,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       cinderScheduler:
         replicas: 1
       cinderBackup:
@@ -48,6 +67,15 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
         networkAttachments:
         - storage
       glanceAPIExternal:
@@ -62,6 +90,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   mariadb:
     enabled: false
     templates:
@@ -93,6 +131,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
       networkAttachments:
       - internalapi
   horizon:
@@ -107,6 +155,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       secret: osp-secret
       metadataServiceTemplate:
         externalEndpoints:
@@ -114,6 +172,15 @@ spec:
            ipAddressPool: internalapi
            loadBalancerIPs:
            - 172.17.0.80
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   manila:
     template:
       manilaAPI:
@@ -123,6 +190,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
         networkAttachments:
         - internalapi
       manilaScheduler:
@@ -160,6 +237,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   rabbitmq:
     templates:
       rabbitmq:
@@ -168,12 +255,28 @@ spec:
           - 172.17.0.85
           ipAddressPool: internalapi
           sharedIP: false
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+            spec:
+              type: LoadBalancer
       rabbitmq-cell1:
         externalEndpoint:
           loadBalancerIPs:
           - 172.17.0.86
           ipAddressPool: internalapi
           sharedIP: false
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+            spec:
+              type: LoadBalancer
   heat:
     enabled: false
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -11,6 +11,15 @@ spec:
       - ipAddressPool: ctlplane
         loadBalancerIPs:
         - 192.168.122.80
+      override:
+        service:
+          metadata:
+            annotations:
+              metallb.universe.tf/address-pool: ctlplane
+              metallb.universe.tf/allow-shared-ip: ctlplane
+              metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+          spec:
+            type: LoadBalancer
       options:
       - key: server
         values:
@@ -26,6 +35,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       cinderScheduler:
         replicas: 1
       cinderBackup:
@@ -48,6 +67,15 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
         networkAttachments:
         - storage
       glanceAPIExternal:
@@ -62,6 +90,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   mariadb:
     templates:
       openstack:
@@ -81,6 +119,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
       networkAttachments:
       - internalapi
   horizon:
@@ -95,6 +143,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       secret: osp-secret
       metadataServiceTemplate:
         externalEndpoints:
@@ -102,6 +160,15 @@ spec:
            ipAddressPool: internalapi
            loadBalancerIPs:
            - 172.17.0.80
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   manila:
     template:
       manilaAPI:
@@ -111,6 +178,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
         networkAttachments:
         - internalapi
       manilaScheduler:
@@ -148,6 +225,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   rabbitmq:
     templates:
       rabbitmq:
@@ -156,12 +243,28 @@ spec:
           - 172.17.0.85
           ipAddressPool: internalapi
           sharedIP: false
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+            spec:
+              type: LoadBalancer
       rabbitmq-cell1:
         externalEndpoint:
           loadBalancerIPs:
           - 172.17.0.86
           ipAddressPool: internalapi
           sharedIP: false
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+            spec:
+              type: LoadBalancer
   heat:
     enabled: false
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -31,6 +31,15 @@ spec:
       - ipAddressPool: ctlplane
         loadBalancerIPs:
         - 192.168.122.80
+      override:
+        service:
+          metadata:
+            annotations:
+              metallb.universe.tf/address-pool: ctlplane
+              metallb.universe.tf/allow-shared-ip: ctlplane
+              metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+          spec:
+            type: LoadBalancer
       options:
       - key: server
         values:
@@ -46,6 +55,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       cinderBackup:
         customServiceConfig: |
           [DEFAULT]
@@ -93,6 +112,15 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
         networkAttachments:
         - storage
       glanceAPIExternal:
@@ -107,6 +135,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   mariadb:
     templates:
       openstack:
@@ -126,6 +164,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
       networkAttachments:
       - internalapi
   horizon:
@@ -140,6 +188,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
       secret: osp-secret
       metadataServiceTemplate:
         externalEndpoints:
@@ -147,6 +205,15 @@ spec:
            ipAddressPool: internalapi
            loadBalancerIPs:
            - 172.17.0.80
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   manila:
     template:
       manilaAPI:
@@ -156,6 +223,16 @@ spec:
           ipAddressPool: internalapi
           loadBalancerIPs:
           - 172.17.0.80
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+              spec:
+                type: LoadBalancer
         networkAttachments:
         - internalapi
       manilaScheduler:
@@ -206,6 +283,16 @@ spec:
         ipAddressPool: internalapi
         loadBalancerIPs:
         - 172.17.0.80
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/allow-shared-ip: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
   rabbitmq:
     templates:
       rabbitmq:
@@ -214,12 +301,28 @@ spec:
           - 172.17.0.85
           ipAddressPool: internalapi
           sharedIP: false
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+            spec:
+              type: LoadBalancer
       rabbitmq-cell1:
         externalEndpoint:
           loadBalancerIPs:
           - 172.17.0.86
           ipAddressPool: internalapi
           sharedIP: false
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+            spec:
+              type: LoadBalancer
   heat:
     enabled: false
     template:


### PR DESCRIPTION
Update samples to support the old and new configuration used to setup the services. This allows ci jobs to properly configure the new services with their service overrides.

Cleanup of the samples will then be done in the openstack-operator PR #457.

Jira: [OSP-26690](https://issues.redhat.com//browse/OSP-26690)