### PR TITLE
Bump telemetry-operator to avoid duplicate tags

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openstack-k8s-operators/ovn-operator/api v0.1.1-0.20230913151226-aab30786ed97
 	github.com/openstack-k8s-operators/placement-operator/api v0.1.1-0.20230918155857-7af4ec18350b
 	github.com/openstack-k8s-operators/swift-operator/api v0.1.1-0.20230915130355-e5c2b0ff0af1
-	github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230919131927-232275280f55
+	github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230922105757-673cdddaafd2
 	github.com/rabbitmq/cluster-operator v1.14.0
 	k8s.io/apimachinery v0.26.9
 	sigs.k8s.io/controller-runtime v0.14.6

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -164,8 +164,7 @@ github.com/openstack-k8s-operators/placement-operator/api v0.1.1-0.2023091815585
 github.com/openstack-k8s-operators/placement-operator/api v0.1.1-0.20230918155857-7af4ec18350b/go.mod h1:lsu2XlR/HbYoiUrRPBDbXLBoD+omzhK9zBSk4QJppmU=
 github.com/openstack-k8s-operators/swift-operator/api v0.1.1-0.20230915130355-e5c2b0ff0af1 h1:MI+1sJuo+2ekYB/npq9BqMR0Ix03hpRXFOW5NGvL6Zo=
 github.com/openstack-k8s-operators/swift-operator/api v0.1.1-0.20230915130355-e5c2b0ff0af1/go.mod h1:jnhL2sWJW7ABY/mQ0Mp95h0aJR6oh90/rgDINg3Sg88=
-github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230919131927-232275280f55 h1:Os6UuTXdiROpp457nJZUTCbn30bl0M5Pd9vl7fIYysM=
-github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230919131927-232275280f55/go.mod h1:nYAEI/2u2DzXtZoMBIRkogHPpjskwrfJAJ/+XeIcosc=
+github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230922105757-673cdddaafd2 h1:vBh8rN58/P5oSRuAwdYoXO4TpqEZ51JbAlyujlqeY6Y=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/openstack-k8s-operators/ovn-operator/api v0.1.1-0.20230913151226-aab30786ed97
 	github.com/openstack-k8s-operators/placement-operator/api v0.1.1-0.20230918155857-7af4ec18350b
 	github.com/openstack-k8s-operators/swift-operator/api v0.1.1-0.20230915130355-e5c2b0ff0af1
-	github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230919131927-232275280f55
+	github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230922105757-673cdddaafd2
 	github.com/operator-framework/api v0.17.3
 	github.com/rabbitmq/cluster-operator v1.14.0
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/openstack-k8s-operators/placement-operator/api v0.1.1-0.2023091815585
 github.com/openstack-k8s-operators/placement-operator/api v0.1.1-0.20230918155857-7af4ec18350b/go.mod h1:lsu2XlR/HbYoiUrRPBDbXLBoD+omzhK9zBSk4QJppmU=
 github.com/openstack-k8s-operators/swift-operator/api v0.1.1-0.20230915130355-e5c2b0ff0af1 h1:MI+1sJuo+2ekYB/npq9BqMR0Ix03hpRXFOW5NGvL6Zo=
 github.com/openstack-k8s-operators/swift-operator/api v0.1.1-0.20230915130355-e5c2b0ff0af1/go.mod h1:jnhL2sWJW7ABY/mQ0Mp95h0aJR6oh90/rgDINg3Sg88=
-github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230919131927-232275280f55 h1:Os6UuTXdiROpp457nJZUTCbn30bl0M5Pd9vl7fIYysM=
-github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230919131927-232275280f55/go.mod h1:nYAEI/2u2DzXtZoMBIRkogHPpjskwrfJAJ/+XeIcosc=
+github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230922105757-673cdddaafd2 h1:vBh8rN58/P5oSRuAwdYoXO4TpqEZ51JbAlyujlqeY6Y=
+github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230922105757-673cdddaafd2/go.mod h1:nYAEI/2u2DzXtZoMBIRkogHPpjskwrfJAJ/+XeIcosc=
 github.com/operator-framework/api v0.17.3 h1:wddE1SLKTNiIzwt28DbBIO+vPG2GOV6dkB9xBkDfT3o=
 github.com/operator-framework/api v0.17.3/go.mod h1:34tb98EwTN5SZLkgoxwvRkhMJKLHUWHOrrcv1ZwvEeA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
The 232275280f55 tag for the telemetry-operator was dupped and even though only one was active it was breaking the pin bundles script. This bumps the operator version to avoid the breakage.