### PR TITLE
Fix nova-novncproxy route endpoint type

### DIFF
--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -154,7 +154,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 				nova,
 				svcs,
 				map[service.Endpoint]service.RoutedOverrideSpec{
-					service.EndpointInternal: *cellTemplate.NoVNCProxyServiceTemplate.Override.Service,
+					service.EndpointPublic: *cellTemplate.NoVNCProxyServiceTemplate.Override.Service,
 				},
 				instance.Spec.Nova.CellOverride[cellName].NoVNCProxy.Route,
 				corev1beta1.OpenStackControlPlaneExposeNovaReadyCondition,
@@ -165,7 +165,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 				return ctrlResult, nil
 			}
 
-			cellTemplate.NoVNCProxyServiceTemplate.Override.Service = ptr.To(routedOverrideSpec[service.EndpointInternal])
+			cellTemplate.NoVNCProxyServiceTemplate.Override.Service = ptr.To(routedOverrideSpec[service.EndpointPublic])
 
 			instance.Spec.Nova.Template.CellTemplates[cellName] = cellTemplate
 


### PR DESCRIPTION
since there should be a route created for the novncproxy, the endpoint into EnsureRoute() needs to be of type public, not internal.