### PR TITLE
Fix Manila Ceph sample

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -197,6 +197,9 @@ spec:
       route: {}
     template:
       manilaAPI:
+        customServiceConfig: |
+          [DEFAULT]
+          enabled_share_protocols=nfs,cephfs
         replicas: 1
         networkAttachments:
         - internalapi


### PR DESCRIPTION
The `manilaAPI` section was missing custom config to enable CephFS