### PR TITLE
Explicitly disable Manila

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -193,6 +193,7 @@ spec:
               type: LoadBalancer
       secret: osp-secret
   manila:
+    enabled: false
     apiOverride:
       route: {}
     template:


### PR DESCRIPTION
Manila is disabled by default but if someone follows the example, they may not know this and wonder why the manila pods are not starting. Add `enabled: fase` to the sample so that it gives them a hint about what they need to change if they're trying to use manila so they have a better UX.