### PR TITLE
Increase kuttl test default timeout

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -19,7 +19,7 @@ kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-openstack
 namespace: openstack-kuttl-tests
-timeout: 1000
+timeout: 1380
 parallel: 1
 suppress:
   - events                     # Remove spammy event logs


### PR DESCRIPTION
While running tests in ci-framework, the collapsed-cell is failing with one missing exposed service. The logs show routes with status ok. This patch increase the default timeout to 23min (was 16).