### PR TITLE
[openstackclient] demo - watch input resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,3 +129,5 @@ replace github.com/openstack-k8s-operators/openstack-operator/apis => ./apis
 // mschuppert: map to latest commit from release-4.13 tag
 // must consistent within modules and service operators
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 //allow-merging
+
+replace github.com/openstack-k8s-operators/lib-common/modules/common => github.com/stuggi/lib-common/modules/common v0.0.0-20231107142729-ffabea31178b

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,6 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20231020144009
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20231020144009-3e445cd965f8/go.mod h1:sDYtAWryP7mF2v4XfmKdAoFquVAMts2J5PuYFV9VBQU=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20231027113646-46f2fdbf77f1 h1:IBqwFm4+3TEkKIie7PhwYf8t46pV+QQIlkFfoRmTYQQ=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20231027113646-46f2fdbf77f1/go.mod h1:TmvBx0eRe/K3hqPPwzhvjBhl3ugtpcmuV5KYjSpCMj0=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20231027113646-46f2fdbf77f1 h1:2bUnS5bGT77jBguPF2zyivaHhcfWti/yB9TUXN803hY=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20231027113646-46f2fdbf77f1/go.mod h1:NvjAETczXby5m3IvylR3YaOiEBWkmWbHBx/UrnUVtfA=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20231027113646-46f2fdbf77f1 h1:tcqkGudMGkhYtLbMq8O0BVggrqsSdcdw1hEzplAO2Xc=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20231027113646-46f2fdbf77f1/go.mod h1:bGwj+Spj1d880n7PhlmaRhLXpzTaX61b+ET0pfhm5gU=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20231027113646-46f2fdbf77f1 h1:XeHpej7gpMu3rMy97+JPm8BUXsxbCwK/prYXmQsIhco=
@@ -226,6 +224,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stuggi/lib-common/modules/common v0.0.0-20231107142729-ffabea31178b h1:AZVWDBvv5ARjkS9HAaEhrGqmUKXfGBGNIdRWADwdJdg=
+github.com/stuggi/lib-common/modules/common v0.0.0-20231107142729-ffabea31178b/go.mod h1:h2C1gYEPICdLGrJDPIi5TFQAxpkn15ANjt0cKkqxgjo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=


### PR DESCRIPTION
This PR demonstrates how to watch named input resources in two different ways, split into two commits:
* [[openstackclient] Use ownerref and watches on ca bundle secret](https://github.com/openstack-k8s-operators/openstack-operator/pull/544/commits/a8bcb44139f16840ae8988d164ee81aa7ea97510)
Also adds itself to the secret specified via the `CaSecretName` as an additional owner. Using `Watches` allows to get notified on a change of the resource. The only downside with this is that it won't get notified if the resource gets recreated from scratch.

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/385

* [[openstackclient] watch named input resources](https://github.com/openstack-k8s-operators/openstack-operator/pull/544/commits/ce9708f0372cd79bbcce3aa66ceeb7c81aba151c)
Adds watches for name secret and configmap resources from the `OpenStackClient` CRD. This allows to watch the specific resources when they change. The advantage over the notification when added as additional owner is that it also reconciles when the resource gets re-created. ( https://kubebuilder.io/reference/watching-resources/externally-managed ) 