### PR TITLE
[openstackclient] update osclient to restart on input config change

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,8 +185,10 @@ func main() {
 	}
 
 	if err = (&clientcontrollers.OpenStackClientReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Kclient: kclient,
+		Log:     ctrl.Log.WithName("controllers").WithName("OpenStackClient"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackClient")
 		os.Exit(1)


### PR DESCRIPTION
When parameters like image or hash on input resources change, restart the openstackclient pod as its not possible to get those updated.