### PR TITLE
[tempest]Enable cold migration scenario tests

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -26,10 +26,8 @@
         - test_shelve_volume_backed_instance
         - tempest.scenario.test_stamp_pattern.TestStampPattern
         - tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern
-      # NOTE(gibi): move operations does not work yet
-        - test_server_connectivity_cold_migration
+      # NOTE(gibi): live migration does not work yet
         - test_server_connectivity_live_migration
-        - test_server_connectivity_resize
 - project:
     name: openstack-k8s-operators/openstack-operator
     templates:


### PR DESCRIPTION
The deployment now support VM move operations, expect live migration, between EDPM compute nodes. So lets enable the related tempest scenario tests.

https://issues.redhat.com/browse/OSPRH-364