### PR TITLE
Fix heat ENV vars in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -283,8 +283,9 @@ func setupServiceOperatorDefaults() {
 
 	// Heat
 	heatDefaults := heatv1.HeatDefaults{
-		APIContainerImageURL:    os.Getenv("HEAT_API_IMAGE_URL_DEFAULT"),
-		EngineContainerImageURL: os.Getenv("HEAT_ENGINE_IMAGE_URL_DEFAULT"),
+		APIContainerImageURL:    os.Getenv("RELATED_IMAGE_HEAT_API_IMAGE_URL_DEFAULT"),
+		CfnAPIContainerImageURL: os.Getenv("RELATED_IMAGE_HEAT_CFNAPI_IMAGE_URL_DEFAULT"),
+		EngineContainerImageURL: os.Getenv("RELATED_IMAGE_HEAT_ENGINE_IMAGE_URL_DEFAULT"),
 	}
 
 	heatv1.SetupHeatDefaults(heatDefaults)


### PR DESCRIPTION
This aligns with the latest ENV vars used with the heat-operator:
 -includes the RELATED_IMAGES prefix
 -also adds the missing RELATED_IMAGE_HEAT_CFNAPI_IMAGE_URL_DEFAULT
  env var