### PR TITLE
Re-enable encrypted volume test

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -10,10 +10,6 @@
             compute-feature-enabled.vnc_console: true
             compute-feature-enabled.stable_rescue: true
             compute_feature_enabled.hostname_fqdn_sanitization: true
-            # NOTE(alee) these tests will fail with barbican in the mix
-            # while cinder/nova is not configured to talk to barbican
-            # re-enable this when that support is added
-            compute-feature-enabled.attach_encrypted_volume: false
             validation.run_validation: true
             # NOTE(gibi): This is a WA to force the publicURL as otherwise
             # tempest gets configured with adminURL and that causes test


### PR DESCRIPTION
Now that barbican is integrated with cinder and nova, re-enable this test to make sure it still works