### PR TITLE
Drop dev-preview from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "constraints": {
     "go": "1.19"
   },
-  "baseBranches": ["main","dev-preview"],
+  "baseBranches": ["main"],
   "useBaseBranchConfig": "merge",
   "packageRules": [
     {


### PR DESCRIPTION
We haven't been merging these for some time and should no longer be needed.