### PR TITLE
[glance] control route create based on annotation

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-20240104150405-d50607d50e9a
 	github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240104132718-a962cceb867d
 	github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240104144436-858a0383741c
-	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240104144437-f17cd244921e
+	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240109080016-338d4287e4ec
 	github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240104130506-4f3841d6042d
 	github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240104144435-fdfef4b8a33f
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240104150635-c4ffc51e0752
 	github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240104144719-8030e9e8c962
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240104144437-5355d932c316
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240104154954-dc504be0d9be
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240108143014-3f12c3253835
 	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240104144719-72b9a4ab968c
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240104162634-fe72003c6343
 	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240104150349-c082ca19cafe
@@ -37,7 +37,7 @@ require (
 	github.com/rhobs/observability-operator v0.0.20 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
-	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b // indirect
+	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc // indirect
 	golang.org/x/tools v0.16.0 // indirect
 )
 

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -136,8 +136,8 @@ github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240104132718-a
 github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240104132718-a962cceb867d/go.mod h1:GH+wo5YUPX95Mqst0yKXZGobehtlIqxDPjjE9GCl8IY=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240104144436-858a0383741c h1:XSRqnJnHCUjn3PRQX16J7gasxnl5DIlyfE3p0F72gL8=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240104144436-858a0383741c/go.mod h1:Wn+GO3Kddf7C5wM2vLNo2Ub1KRmy6qCuTwdyJlxXUuc=
-github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240104144437-f17cd244921e h1:voqTqGJlOFuBTqcHGVIEFihigs3qz2RspKiFZaXJsZY=
-github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240104144437-f17cd244921e/go.mod h1:65hRRxfE1iwuA5gthKcq7dBdxGDvD62I8dvDrDwn+nM=
+github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240109080016-338d4287e4ec h1:rLcBTCgJphWY83hTJrFmYdnzUWXvorh0LiNRycrAxYs=
+github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240109080016-338d4287e4ec/go.mod h1:4eraW+FyYsboi+a75FvKokgv0oeITVQMUAKYYqhViiQ=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240104130506-4f3841d6042d h1:d6b8XI8UZF0q84DoznhWWydu0fAk2txGZAXjLiUu/FY=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240104130506-4f3841d6042d/go.mod h1:R5j2Efz687VHonvB3cxWRhOjWS3OFSKu9U5mjOOcyeQ=
 github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240104144435-fdfef4b8a33f h1:92xuDVbOiDEtJ8igh1wkoNj+UlzZWmYKH+rOb9OmLJ8=
@@ -148,8 +148,8 @@ github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240104144719-8
 github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240104144719-8030e9e8c962/go.mod h1:H6BuZ52u+Dq/vWJgpGIJLttRTnPPH3xdVeqhI99QE/k=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240104144437-5355d932c316 h1:IwTuIoC78bbp3awd8P0tWeknCe2jNLB1FCJDIwI/2Pg=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240104144437-5355d932c316/go.mod h1:qx+z+k0RMK8Vcl5Nug6bOScEg7ROSxEV4FFy0gjcQDQ=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240104154954-dc504be0d9be h1:YiTVQtIoPDoHAiMo4eBRkNy2JNq6IxwYs432ZikM6Ow=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240104154954-dc504be0d9be/go.mod h1:IDd4i2ZXWELCF+Y8Zu9bQBobE6yy3HOEjUeLnSuSWaM=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240108143014-3f12c3253835 h1:+FYUZiEc3ZE2TgpPhhLS8YOcdKBqk7rAi3kXvimhCKQ=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240108143014-3f12c3253835/go.mod h1:ov4lAbniNUsLqZCBp1RTixpqXc8JlzA5B+yTcCkJXQg=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240104154954-dc504be0d9be h1:DuW+qO6nZFeJMDvLvhoP1a0+ynHTzNvUDwngizejgDo=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240104154954-dc504be0d9be/go.mod h1:NcWtgGX7OhEID9BtvAMNB/rlsqw9yA2OoYIjWRYP1HY=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240104154954-dc504be0d9be h1:gFSUckhjuCEae4NjZqspBPYwf7NJXg3hvrabZ6ZTxg4=
@@ -231,8 +231,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72g=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b h1:kLiC65FbiHWFAOu+lxwNPujcsl8VYyTYYEZnsOO1WK4=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
+golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc h1:ao2WRsKSzW6KuUY9IWPwWahcHCgR0s52IfwutMfEbdM=
+golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/go.mod
+++ b/go.mod
@@ -13,14 +13,14 @@ require (
 	github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240104132718-a962cceb867d
 	github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240104172704-238ed4f5b9f5
 	github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240104144436-858a0383741c
-	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240104144437-f17cd244921e
+	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240109080016-338d4287e4ec
 	github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240104130506-4f3841d6042d
 	github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240104144435-fdfef4b8a33f
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240104150635-c4ffc51e0752
 	github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240104144719-8030e9e8c962
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240104144437-5355d932c316
 	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240104154954-dc504be0d9be
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240104154954-dc504be0d9be
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240108143014-3f12c3253835
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240104154954-dc504be0d9be
 	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240104144719-72b9a4ab968c
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240104162634-fe72003c6343
@@ -37,7 +37,7 @@ require (
 	github.com/operator-framework/api v0.20.0
 	github.com/rabbitmq/cluster-operator/v2 v2.5.0
 	go.uber.org/zap v1.26.0
-	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b
+	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	k8s.io/api v0.27.7
 	k8s.io/apimachinery v0.27.7
 	k8s.io/client-go v0.27.7

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.2024010417270
 github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240104172704-238ed4f5b9f5/go.mod h1:sKylgv/UxHSpnbTK6lUtnWxNf+fM2ELqngxtM8XD/Sw=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240104144436-858a0383741c h1:XSRqnJnHCUjn3PRQX16J7gasxnl5DIlyfE3p0F72gL8=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240104144436-858a0383741c/go.mod h1:Wn+GO3Kddf7C5wM2vLNo2Ub1KRmy6qCuTwdyJlxXUuc=
-github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240104144437-f17cd244921e h1:voqTqGJlOFuBTqcHGVIEFihigs3qz2RspKiFZaXJsZY=
-github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240104144437-f17cd244921e/go.mod h1:65hRRxfE1iwuA5gthKcq7dBdxGDvD62I8dvDrDwn+nM=
+github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240109080016-338d4287e4ec h1:rLcBTCgJphWY83hTJrFmYdnzUWXvorh0LiNRycrAxYs=
+github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240109080016-338d4287e4ec/go.mod h1:4eraW+FyYsboi+a75FvKokgv0oeITVQMUAKYYqhViiQ=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240104130506-4f3841d6042d h1:d6b8XI8UZF0q84DoznhWWydu0fAk2txGZAXjLiUu/FY=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240104130506-4f3841d6042d/go.mod h1:R5j2Efz687VHonvB3cxWRhOjWS3OFSKu9U5mjOOcyeQ=
 github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240104144435-fdfef4b8a33f h1:92xuDVbOiDEtJ8igh1wkoNj+UlzZWmYKH+rOb9OmLJ8=
@@ -163,8 +163,8 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240104144437
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240104144437-5355d932c316/go.mod h1:qx+z+k0RMK8Vcl5Nug6bOScEg7ROSxEV4FFy0gjcQDQ=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240104154954-dc504be0d9be h1:b+1s1xx4YxCVSDbq8mwpQkKKpJZKKV5PUFdsAbgN1a8=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240104154954-dc504be0d9be/go.mod h1:OryTcWpGW8JWbkKv4V0i5sTf/KzVbHMiKp7kdQu9sBo=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240104154954-dc504be0d9be h1:YiTVQtIoPDoHAiMo4eBRkNy2JNq6IxwYs432ZikM6Ow=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240104154954-dc504be0d9be/go.mod h1:IDd4i2ZXWELCF+Y8Zu9bQBobE6yy3HOEjUeLnSuSWaM=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240108143014-3f12c3253835 h1:+FYUZiEc3ZE2TgpPhhLS8YOcdKBqk7rAi3kXvimhCKQ=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240108143014-3f12c3253835/go.mod h1:ov4lAbniNUsLqZCBp1RTixpqXc8JlzA5B+yTcCkJXQg=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240104154954-dc504be0d9be h1:DuW+qO6nZFeJMDvLvhoP1a0+ynHTzNvUDwngizejgDo=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240104154954-dc504be0d9be/go.mod h1:NcWtgGX7OhEID9BtvAMNB/rlsqw9yA2OoYIjWRYP1HY=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240104154954-dc504be0d9be h1:gFSUckhjuCEae4NjZqspBPYwf7NJXg3hvrabZ6ZTxg4=
@@ -256,8 +256,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72g=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b h1:kLiC65FbiHWFAOu+lxwNPujcsl8VYyTYYEZnsOO1WK4=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
+golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc h1:ao2WRsKSzW6KuUY9IWPwWahcHCgR0s52IfwutMfEbdM=
+golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=


### PR DESCRIPTION
ATM the glance pkg uses the KeystoneEndpoint parameter to check if a route for which glance-api should get created:

https://github.com/openstack-k8s-operators/openstack-operator/blob/f36c6c4fe938ffe084e5cd556122f1ba8dfe88ed/pkg/openstack/glance.go#L84

This works, but results when the api to expose and register in keystone gets changed, the existing route for the previous set glance-api won't be deleted.

This changes the glance pkg to use the intended annotation on the glance-api services to create the route for the glance-api services with "core.openstack.org/ingress_create": "true". The switched api will have the "core.openstack.org/ingress_create": "false" and if there is an existing route it gets deleted.

Depends-On: https://github.com/openstack-k8s-operators/glance-operator/pull/401