### PR TITLE
Filter active tags in quay.rdoproject.io registry

### DIFF
--- a/hack/pin-bundle-images.sh
+++ b/hack/pin-bundle-images.sh
@@ -55,7 +55,7 @@ for MOD_PATH in $(go list -mod=readonly -m -json all | jq -r '. | select(.Path |
         SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tags/list | jq -r .tags[] | sort -u | grep $REF)
     elif [[ "${CURL_REGISTRY}" != "quay.io" ]]; then
         # quay.rdoproject.io doesn't support filter_tag_name, so increase limit to 100
-        SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/?limit=100 | jq -r .tags[].name | sort -u | grep $REF)
+        SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/?onlyActiveTags=true?limit=100 | jq -r .tags[].name | sort -u | grep $REF)
     else
         SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/?onlyActiveTags=true\&filter_tag_name=like:$REF | jq -r .tags[].name)
     fi


### PR DESCRIPTION
In pin-bundle-images script, when listing all tags from quay.rdoproject.io registry, we are not filtering deleted tags, which brings duplicated results when using grep.