### PR TITLE
[tlse] internal TLS support for neutron

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -8736,6 +8736,24 @@ spec:
                       serviceUser:
                         default: neutron
                         type: string
+                      tls:
+                        properties:
+                          api:
+                            properties:
+                              internal:
+                                properties:
+                                  secretName:
+                                    type: string
+                                type: object
+                              public:
+                                properties:
+                                  secretName:
+                                    type: string
+                                type: object
+                            type: object
+                          caBundleSecretName:
+                            type: string
+                        type: object
                     required:
                     - containerImage
                     - databaseInstance

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240124141114-55d029e4658b
 	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240125214002-8d4df0d9e4d6
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240125183550-331c633c453c
-	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240122135031-be5f0da8fa93
+	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240129124731-ae87be79fda6
 	github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240126131503-ccdb40976d65
 	github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240116133406-c220c5e98b5e
 	github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240125084018-043c1fc15b4f

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -158,8 +158,8 @@ github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240125214002-8
 github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240125214002-8d4df0d9e4d6/go.mod h1:7CrBnG7QstRjRHUV6qqiiQh2x//1z3i6AdhPgcLhbvA=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240125183550-331c633c453c h1:6kUiF2FW92Mr76EFagLm25CBGY1D8Ch6g3OQ8FjVe6M=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240125183550-331c633c453c/go.mod h1:gAIo5SMvTTgUomxGC51T3PHIyremhe8xUvz2xpbuCsI=
-github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240122135031-be5f0da8fa93 h1:+B/FsDuwC4mRxl8ZSZlRmSd3x6OwZLoX2cHh3uOD0GY=
-github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240122135031-be5f0da8fa93/go.mod h1:xKX3+Hk0QLbYaeIDyv+c5ACn5CziC5qNR2mYV9fv8kc=
+github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240129124731-ae87be79fda6 h1:iDUnHC2KyVsgbqOIDRR4bPFu/t8uOqVHMCRNeSWSKZA=
+github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240129124731-ae87be79fda6/go.mod h1:xKX3+Hk0QLbYaeIDyv+c5ACn5CziC5qNR2mYV9fv8kc=
 github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240126131503-ccdb40976d65 h1:Z0xCciVPe4jiRAXey6PFP9WZmmlk7PhnjmjvwMwY7UQ=
 github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240126131503-ccdb40976d65/go.mod h1:JCrwkARzRcpwaPuGTOY+jXWCWpYtEuuP+093qyWsnd8=
 github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240116133406-c220c5e98b5e h1:S0IfludwFmDldeLdcmihF4hxUaISOrxJAFAyrAliFMk=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -8736,6 +8736,24 @@ spec:
                       serviceUser:
                         default: neutron
                         type: string
+                      tls:
+                        properties:
+                          api:
+                            properties:
+                              internal:
+                                properties:
+                                  secretName:
+                                    type: string
+                                type: object
+                              public:
+                                properties:
+                                  secretName:
+                                    type: string
+                                type: object
+                            type: object
+                          caBundleSecretName:
+                            type: string
+                        type: object
                     required:
                     - containerImage
                     - databaseInstance

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240124141114-55d029e4658b
 	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240125214002-8d4df0d9e4d6
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240125183550-331c633c453c
-	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240122135031-be5f0da8fa93
+	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240129124731-ae87be79fda6
 	github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240126131503-ccdb40976d65
 	github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240116133406-c220c5e98b5e
 	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240125131508-d8d852696c18

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240125214002-8
 github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240125214002-8d4df0d9e4d6/go.mod h1:7CrBnG7QstRjRHUV6qqiiQh2x//1z3i6AdhPgcLhbvA=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240125183550-331c633c453c h1:6kUiF2FW92Mr76EFagLm25CBGY1D8Ch6g3OQ8FjVe6M=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240125183550-331c633c453c/go.mod h1:gAIo5SMvTTgUomxGC51T3PHIyremhe8xUvz2xpbuCsI=
-github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240122135031-be5f0da8fa93 h1:+B/FsDuwC4mRxl8ZSZlRmSd3x6OwZLoX2cHh3uOD0GY=
-github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240122135031-be5f0da8fa93/go.mod h1:xKX3+Hk0QLbYaeIDyv+c5ACn5CziC5qNR2mYV9fv8kc=
+github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240129124731-ae87be79fda6 h1:iDUnHC2KyVsgbqOIDRR4bPFu/t8uOqVHMCRNeSWSKZA=
+github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240129124731-ae87be79fda6/go.mod h1:xKX3+Hk0QLbYaeIDyv+c5ACn5CziC5qNR2mYV9fv8kc=
 github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240126131503-ccdb40976d65 h1:Z0xCciVPe4jiRAXey6PFP9WZmmlk7PhnjmjvwMwY7UQ=
 github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240126131503-ccdb40976d65/go.mod h1:JCrwkARzRcpwaPuGTOY+jXWCWpYtEuuP+093qyWsnd8=
 github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240116133406-c220c5e98b5e h1:S0IfludwFmDldeLdcmihF4hxUaISOrxJAFAyrAliFMk=


### PR DESCRIPTION
Creates certs for k8s service of the service operator when spec.tls.endpoint.internal.enabled: true

For a service like nova which talks to multiple service internal endpoints, this has to be set for each of them for, like:

~~~
  customServiceConfig: |
    [keystone_authtoken]
    insecure = true
    [placement]
    insecure = true
    [neutron]
    insecure = true
    [glance]
    insecure = true
    [cinder]
    insecure = true
~~~

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/428
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/620
Depends-On: https://github.com/openstack-k8s-operators/neutron-operator/pull/263

Jira: [OSPRH-2197](https://issues.redhat.com//browse/OSPRH-2197)