### PR TITLE
[tlse] internal TLS support for glance

### DIFF
--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -59,7 +59,7 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 				glanceAPI.Override.Service[endpointType], glance.Name)
 
 			svcOverride := glanceAPI.Override.Service[endpointType]
-			svcOverride.AddLabel(getGlanceAPILabelMap(glance.Name, name))
+			svcOverride.AddLabel(getGlanceAPILabelMap(glance.Name, name, glanceAPI.Type))
 			glanceAPI.Override.Service[endpointType] = svcOverride
 		}
 
@@ -92,7 +92,7 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 				ctx,
 				helper,
 				instance.Namespace,
-				getGlanceAPILabelMap(glance.Name, name),
+				getGlanceAPILabelMap(glance.Name, name, glanceAPI.Type),
 			)
 			if err != nil {
 				return ctrl.Result{}, err
@@ -191,8 +191,8 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 	return ctrl.Result{}, nil
 }
 
-func getGlanceAPILabelMap(name string, apiName string) map[string]string {
-	apiFilter := fmt.Sprintf("%s-%s", name, apiName)
+func getGlanceAPILabelMap(name string, apiName string, apiType string) map[string]string {
+	apiFilter := fmt.Sprintf("%s-%s-%s", name, apiName, apiType)
 
 	return map[string]string{
 		svcSelector: apiFilter,


### PR DESCRIPTION
Creates certs for k8s service of the service operator when spec.tls.endpoint.internal.enabled: true

For a service like nova which talks to multiple service internal endpoints, this has to be set for each of them for, like:

~~~
  customServiceConfig: |
    [keystone_authtoken]
    insecure = true
    [placement]
    insecure = true
    [neutron]
    insecure = true
    [glance]
    insecure = true
    [cinder]
    insecure = true
~~~

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/428
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/620
Depends-On: https://github.com/openstack-k8s-operators/glance-operator/pull/391

Jira: [OSPRH-1233](https://issues.redhat.com//browse/OSPRH-1233)