### PR TITLE
Update Ceph secret in the related sample

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -20,7 +20,7 @@ spec:
             projected:
               sources:
               - secret:
-                  name: ceph-conf-files
+                  name: ceph-conf-files-0
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"


### PR DESCRIPTION
This patch represent a follow up of [1] where the idea is to align the ceph secret name considering that we're now able to deploy multiple Ceph Pods.

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/654

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/654
Depends-On: https://github.com/openshift/release/pull/47641
