### PR TITLE
Drop OVNController default external-ids from sample CRs

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -104,11 +104,7 @@ spec:
           storageRequest: 10G
       ovnNorthd:
         replicas: 1
-      ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
+      ovnController: {}
   neutron:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -79,11 +79,7 @@ spec:
           storageRequest: 10G
       ovnNorthd:
         replicas: 1
-      ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
+      ovnController: {}
   neutron:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -96,11 +96,7 @@ spec:
           storageRequest: 10G
       ovnNorthd:
         replicas: 1
-      ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
+      ovnController: {}
   neutron:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -96,11 +96,7 @@ spec:
           storageRequest: 10G
       ovnNorthd:
         replicas: 1
-      ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
+      ovnController: {}
   neutron:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -222,10 +222,6 @@ spec:
       ovnNorthd:
         networkAttachment: internalapi
       ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
         networkAttachment: tenant
   placement:
     apiOverride:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -222,10 +222,6 @@ spec:
       ovnNorthd:
         networkAttachment: internalapi
       ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
         networkAttachment: tenant
   placement:
     apiOverride:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -218,10 +218,6 @@ spec:
       ovnNorthd:
         networkAttachment: internalapi
       ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
         networkAttachment: tenant
   placement:
     apiOverride:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -273,10 +273,6 @@ spec:
       ovnNorthd:
         networkAttachment: internalapi
       ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
         networkAttachment: tenant
   placement:
     apiOverride:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tlse.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tlse.yaml
@@ -218,10 +218,6 @@ spec:
       ovnNorthd:
         networkAttachment: internalapi
       ovnController:
-        external-ids:
-          system-id: "random"
-          ovn-bridge: "br-int"
-          ovn-encap-type: "geneve"
         networkAttachment: tenant
   placement:
     apiOverride:


### PR DESCRIPTION
These are defaults so not required to be duplicated.

Depends-On: https://github.com/openstack-k8s-operators/ovn-operator/pull/215