### PR TITLE
Explicitly add enabled: true in the galera sample

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -98,6 +98,7 @@ spec:
       databaseInstance: openstack
       secret: osp-secret
   galera:
+    enabled: true
     templates:
       openstack:
         storageRequest: 500M


### PR DESCRIPTION
In the DP3 content galera is not enabled by default. This patch adds the missing boolean to make sure we don't be blocked by kubebuilder during the CR creation.