### PR TITLE
[TLS] Fix enable/disable of tls configuration

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -769,7 +769,7 @@ func SetupDefaults() {
 // Enabled - returns status of tls configuration for the passed in endpoint type
 func (t *TLSSection) Enabled(endpt service.Endpoint) bool {
 	if t != nil {
-		if cfg, ok := t.Endpoint[service.EndpointInternal]; ok && cfg.Enabled {
+		if cfg, ok := t.Endpoint[endpt]; ok && cfg.Enabled {
 			return true
 		}
 	}


### PR DESCRIPTION
The following is the current expected behavior:
* When TLS was enable and gets disabled previous created certificates won't get deleted.

* adding additional custom CA certs can only be passed to the services if tls is enabled, otherwise CA bundle creation will be skipped and no bundle will be passed to the service CAs. Right now the default is to have TLS enabled for at least routes.

Jira: [OSPRH-3268](https://issues.redhat.com//browse/OSPRH-3268)