### PR TITLE
[tlse] tls for Horizon

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -5486,6 +5486,13 @@ spec:
                         type: object
                       secret:
                         type: string
+                      tls:
+                        properties:
+                          caBundleSecretName:
+                            type: string
+                          secretName:
+                            type: string
+                        type: object
                     required:
                     - containerImage
                     - memcachedInstance

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240104144436-858a0383741c
 	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240125205602-5078ec145f59
 	github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240126104104-98b57e66f7b5
-	github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240107213124-f2df1172f89e
+	github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240201165829-8bf07cefa542
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240131020128-fea7453a8039
 	github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240201134523-df1ac5ea0807
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240125201204-a18a1e700034

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -140,8 +140,8 @@ github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240125205602-5
 github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240125205602-5078ec145f59/go.mod h1:s1zOUVnG8X7O3MuymRC/BhbOCn5ZjU7FrfX4wOnQs6E=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240126104104-98b57e66f7b5 h1:3OXMNE58GsoH4oik991Jw90zyyC0c4HwtdLXinVtCvA=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240126104104-98b57e66f7b5/go.mod h1:uELus2W9VhyxtcByNyUgNZyTH2qpcJH4c7FZz6SOI/I=
-github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240107213124-f2df1172f89e h1:GbIGvapn+D/fDvK8IoxVbgCLaTxD3OwtYe9PQ9DdVy0=
-github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240107213124-f2df1172f89e/go.mod h1:5U3y8EfcYL21ipAXxPgVMSSfSOdCRN0wNmh0L7aREKw=
+github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240201165829-8bf07cefa542 h1:5JgxlBCmPGDSv7FKv3ZGnuAwr2PFVyRNNmf/UfGVoIk=
+github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240201165829-8bf07cefa542/go.mod h1:vqtXw4Sj2MOZgVP2Kzs1WK2sPweTyhYmwVZau7kc96s=
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240131020128-fea7453a8039 h1:z48vu+NVNS2Pt5Pv0DLSUpTFfb1nqb8jweC2ZRurNlw=
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240131020128-fea7453a8039/go.mod h1:M3859LWhTb+9zahzU3nhkrwUBvAgTmLPaG10haK9djM=
 github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240201134523-df1ac5ea0807 h1:pCGPzFAo85glN8ApN45uyxQ8uaOPCDQYdfF2Kh0ReK8=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -5486,6 +5486,13 @@ spec:
                         type: object
                       secret:
                         type: string
+                      tls:
+                        properties:
+                          caBundleSecretName:
+                            type: string
+                          secretName:
+                            type: string
+                        type: object
                     required:
                     - containerImage
                     - memcachedInstance

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240104144436-858a0383741c
 	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240125205602-5078ec145f59
 	github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240126104104-98b57e66f7b5
-	github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240107213124-f2df1172f89e
+	github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240201165829-8bf07cefa542
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240131020128-fea7453a8039
 	github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240201134523-df1ac5ea0807
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240125201204-a18a1e700034

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240125205602-5
 github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240125205602-5078ec145f59/go.mod h1:s1zOUVnG8X7O3MuymRC/BhbOCn5ZjU7FrfX4wOnQs6E=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240126104104-98b57e66f7b5 h1:3OXMNE58GsoH4oik991Jw90zyyC0c4HwtdLXinVtCvA=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240126104104-98b57e66f7b5/go.mod h1:uELus2W9VhyxtcByNyUgNZyTH2qpcJH4c7FZz6SOI/I=
-github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240107213124-f2df1172f89e h1:GbIGvapn+D/fDvK8IoxVbgCLaTxD3OwtYe9PQ9DdVy0=
-github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240107213124-f2df1172f89e/go.mod h1:5U3y8EfcYL21ipAXxPgVMSSfSOdCRN0wNmh0L7aREKw=
+github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240201165829-8bf07cefa542 h1:5JgxlBCmPGDSv7FKv3ZGnuAwr2PFVyRNNmf/UfGVoIk=
+github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240201165829-8bf07cefa542/go.mod h1:vqtXw4Sj2MOZgVP2Kzs1WK2sPweTyhYmwVZau7kc96s=
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240131020128-fea7453a8039 h1:z48vu+NVNS2Pt5Pv0DLSUpTFfb1nqb8jweC2ZRurNlw=
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240131020128-fea7453a8039/go.mod h1:M3859LWhTb+9zahzU3nhkrwUBvAgTmLPaG10haK9djM=
 github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240201134523-df1ac5ea0807 h1:pCGPzFAo85glN8ApN45uyxQ8uaOPCDQYdfF2Kh0ReK8=


### PR DESCRIPTION
Creates certs for horizon k8s service and pods when spec.tls.endpoint.internal.enabled: true

Jira: [OSPRH-4392](https://issues.redhat.com//browse/OSPRH-4392)