### PR TITLE
[tlse] internal TLS support for swift

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -15231,6 +15231,24 @@ spec:
                           swiftConfSecret:
                             default: swift-conf
                             type: string
+                          tls:
+                            properties:
+                              api:
+                                properties:
+                                  internal:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                  public:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                type: object
+                              caBundleSecretName:
+                                type: string
+                            type: object
                         required:
                         - containerImageProxy
                         - memcachedServers
@@ -15266,6 +15284,9 @@ spec:
                             type: string
                           containerImageProxy:
                             type: string
+                          containerSharderEnabled:
+                            default: false
+                            type: boolean
                           memcachedServers:
                             default: ""
                             type: string

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240202095506-b8bae01af213
 	github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240131114124-8bdccc638150
 	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240125124919-72883dc08303
-	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202092455-1f31bfa3d313
+	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202170409-a34147b1d7d3
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240130075809-6609fa1c0732
 	github.com/rabbitmq/cluster-operator/v2 v2.5.0
 	k8s.io/apimachinery v0.27.7

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -168,8 +168,8 @@ github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240131114124-8bdc
 github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240131114124-8bdccc638150/go.mod h1:3GRnhrL6Vi0BLaRWVVn1u+lZ632TFS+lSsRt15yjaaE=
 github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240125124919-72883dc08303 h1:tFlCfWHt6AuQokBHP+BSZ3a8ouwsugEdJKzWDrUfNf0=
 github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240125124919-72883dc08303/go.mod h1:G4XUqjS1C8V5U066HUcjnCyxTNhU4cSZOOGXcOCOhz4=
-github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202092455-1f31bfa3d313 h1:4x3HfeXJBMTOd1M4fUf6uLrajSmvVJDh7vpvi49gYIA=
-github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202092455-1f31bfa3d313/go.mod h1:Ihio6ScG9ZN+Lf76z+H+JabQrnzvwC2NcV32YICB/Kw=
+github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202170409-a34147b1d7d3 h1:r8r+blC7pntMnZuMge7LBMx60+stdbdYhwWjSd8fs10=
+github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202170409-a34147b1d7d3/go.mod h1:Ihio6ScG9ZN+Lf76z+H+JabQrnzvwC2NcV32YICB/Kw=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240130075809-6609fa1c0732 h1:xGvG+7KRpf6/GspyUCeY+TyqEdedjyzS6pgFRqoPLfk=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240130075809-6609fa1c0732/go.mod h1:u5GO5fGJ0CsVRivvQoZE400I+jlI4tIoEqNN4HfMiHg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -15231,6 +15231,24 @@ spec:
                           swiftConfSecret:
                             default: swift-conf
                             type: string
+                          tls:
+                            properties:
+                              api:
+                                properties:
+                                  internal:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                  public:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                type: object
+                              caBundleSecretName:
+                                type: string
+                            type: object
                         required:
                         - containerImageProxy
                         - memcachedServers
@@ -15266,6 +15284,9 @@ spec:
                             type: string
                           containerImageProxy:
                             type: string
+                          containerSharderEnabled:
+                            default: false
+                            type: boolean
                           memcachedServers:
                             default: ""
                             type: string

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20230725141229-4ce90d0120fd
 	github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240131114124-8bdccc638150
 	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240125124919-72883dc08303
-	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202092455-1f31bfa3d313
+	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202170409-a34147b1d7d3
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240130075809-6609fa1c0732
 	github.com/operator-framework/api v0.20.0
 	github.com/rabbitmq/cluster-operator/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240131114124-8bdc
 github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240131114124-8bdccc638150/go.mod h1:3GRnhrL6Vi0BLaRWVVn1u+lZ632TFS+lSsRt15yjaaE=
 github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240125124919-72883dc08303 h1:tFlCfWHt6AuQokBHP+BSZ3a8ouwsugEdJKzWDrUfNf0=
 github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240125124919-72883dc08303/go.mod h1:G4XUqjS1C8V5U066HUcjnCyxTNhU4cSZOOGXcOCOhz4=
-github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202092455-1f31bfa3d313 h1:4x3HfeXJBMTOd1M4fUf6uLrajSmvVJDh7vpvi49gYIA=
-github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202092455-1f31bfa3d313/go.mod h1:Ihio6ScG9ZN+Lf76z+H+JabQrnzvwC2NcV32YICB/Kw=
+github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202170409-a34147b1d7d3 h1:r8r+blC7pntMnZuMge7LBMx60+stdbdYhwWjSd8fs10=
+github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240202170409-a34147b1d7d3/go.mod h1:Ihio6ScG9ZN+Lf76z+H+JabQrnzvwC2NcV32YICB/Kw=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240130075809-6609fa1c0732 h1:xGvG+7KRpf6/GspyUCeY+TyqEdedjyzS6pgFRqoPLfk=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240130075809-6609fa1c0732/go.mod h1:u5GO5fGJ0CsVRivvQoZE400I+jlI4tIoEqNN4HfMiHg=
 github.com/operator-framework/api v0.20.0 h1:A2YCRhr+6s0k3pRJacnwjh1Ue8BqjIGuQ2jvPg9XCB4=

--- a/pkg/openstack/swift.go
+++ b/pkg/openstack/swift.go
@@ -57,6 +57,12 @@ func ReconcileSwift(ctx context.Context, instance *corev1beta1.OpenStackControlP
 		}
 	}
 
+	// preserve any previously set TLS certs,set CA cert
+	if instance.Spec.TLS.Enabled(service.EndpointInternal) {
+		instance.Spec.Swift.Template.SwiftProxy.TLS = swift.Spec.SwiftProxy.TLS
+	}
+	instance.Spec.Swift.Template.SwiftProxy.TLS.CaBundleSecretName = instance.Status.TLS.CaBundleSecretName
+
 	if swift.Status.Conditions.IsTrue(swiftv1.SwiftProxyReadyCondition) {
 		svcs, err := service.GetServicesListWithLabel(
 			ctx,
@@ -77,7 +83,7 @@ func ReconcileSwift(ctx context.Context, instance *corev1beta1.OpenStackControlP
 			instance.Spec.Swift.Template.SwiftProxy.Override.Service,
 			instance.Spec.Swift.ProxyOverride,
 			corev1beta1.OpenStackControlPlaneExposeSwiftReadyCondition,
-			true, // TODO: (mschuppert) disable TLS for now until implemented
+			false, // TODO (mschuppert) could be removed when all integrated service support TLS
 		)
 		if err != nil {
 			return ctrlResult, err
@@ -86,9 +92,12 @@ func ReconcileSwift(ctx context.Context, instance *corev1beta1.OpenStackControlP
 		}
 
 		instance.Spec.Swift.Template.SwiftProxy.Override.Service = endpointDetails.GetEndpointServiceOverrides()
+
+		// update TLS settings with cert secret
+		instance.Spec.Swift.Template.SwiftProxy.TLS.API.Public.SecretName = endpointDetails.GetEndptCertSecret(service.EndpointPublic)
+		instance.Spec.Swift.Template.SwiftProxy.TLS.API.Internal.SecretName = endpointDetails.GetEndptCertSecret(service.EndpointInternal)
 	}
 
-	helper.GetLogger().Info("Reconciling Swift", "Swift.Namespace", instance.Namespace, "Swift.Name", "swift")
 	Log.Info("Reconciling Swift", "Swift.Namespace", instance.Namespace, "Swift.Name", "swift")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), swift, func() error {
 		instance.Spec.Swift.Template.DeepCopyInto(&swift.Spec)


### PR DESCRIPTION
Creates certs for k8s service of the service operator when spec.tls.endpoint.internal.enabled: true

For a service like nova which talks to multiple service internal endpoints, this has to be set for each of them for, like:

~~~
  customServiceConfig: |
    [keystone_authtoken]
    insecure = true
    [placement]
    insecure = true
    [neutron]
    insecure = true
    [glance]
    insecure = true
    [cinder]
    insecure = true
~~~

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/428
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/620
Depends-On: https://github.com/openstack-k8s-operators/swift-operator/pull/109

Jira: [OSPRH-4371](https://issues.redhat.com//browse/OSPRH-4371)