### PR TITLE
Attach storage network to Swift pods

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -350,6 +350,8 @@ spec:
         ringReplicas: 1
       swiftStorage:
         replicas: 1
+        networkAttachments:
+        - storage
       swiftProxy:
         replicas: 1
         override:
@@ -362,6 +364,8 @@ spec:
                   metallb.universe.tf/loadBalancerIPs: 172.17.0.80
               spec:
                 type: LoadBalancer
+        networkAttachments:
+        - storage
   octavia:
     enabled: false
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -352,6 +352,8 @@ spec:
         ringReplicas: 1
       swiftStorage:
         replicas: 1
+        networkAttachements:
+          - storage
       swiftProxy:
         replicas: 1
         override:
@@ -364,6 +366,8 @@ spec:
                   metallb.universe.tf/loadBalancerIPs: 172.17.0.80
               spec:
                 type: LoadBalancer
+        networkAttachements:
+          - storage
   octavia:
     enabled: false
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -346,6 +346,8 @@ spec:
         ringReplicas: 1
       swiftStorage:
         replicas: 1
+        networkAttachments:
+          - storage
       swiftProxy:
         replicas: 1
         override:
@@ -358,6 +360,8 @@ spec:
                   metallb.universe.tf/loadBalancerIPs: 172.17.0.80
               spec:
                 type: LoadBalancer
+        networkAttachments:
+          - storage
   octavia:
     enabled: false
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tlse.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tlse.yaml
@@ -346,6 +346,8 @@ spec:
         ringReplicas: 1
       swiftStorage:
         replicas: 1
+        networkAttachments:
+        - storage
       swiftProxy:
         replicas: 1
         override:
@@ -358,6 +360,8 @@ spec:
                   metallb.universe.tf/loadBalancerIPs: 172.17.0.80
               spec:
                 type: LoadBalancer
+        networkAttachments:
+        - storage
   octavia:
     enabled: false
     template:


### PR DESCRIPTION
With NetworkAttachments now being supported by Swift as well, these pods should be attached to the storage networks too.