### PR TITLE
Do not block Ready when OVN is disabled

### DIFF
--- a/pkg/openstack/ovn.go
+++ b/pkg/openstack/ovn.go
@@ -45,6 +45,8 @@ func ReconcileOVN(ctx context.Context, instance *corev1beta1.OpenStackControlPla
 	// Expect all services (dbclusters, northd, ovn-controller) ready
 	if OVNDBClustersReady && OVNNorthdReady && OVNControllerReady {
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneOVNReadyCondition, corev1beta1.OpenStackControlPlaneOVNReadyMessage)
+	} else if !instance.Spec.Ovn.Enabled {
+		instance.Status.Conditions.Remove(corev1beta1.OpenStackControlPlaneOVNReadyCondition)
 	} else {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			corev1beta1.OpenStackControlPlaneOVNReadyCondition,


### PR DESCRIPTION
The fix f7fe693e253652a50174285c498d6b325059a5e4 introduced a regression. If OVN is disabled in OpenStackControlPlane CR then the CR will never become Ready.