### PR TITLE
Calling PlacementAPI validation webhook

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -191,6 +191,10 @@ func (r *OpenStackControlPlane) ValidateCreateServices(basePath *field.Path) fie
 		errors = append(errors, r.Spec.Nova.Template.ValidateCreate(basePath.Child("nova").Child("template"))...)
 	}
 
+	if r.Spec.Placement.Enabled {
+		errors = append(errors, r.Spec.Placement.Template.ValidateCreate(basePath.Child("placement").Child("template"))...)
+	}
+
 	return errors
 }
 
@@ -207,6 +211,10 @@ func (r *OpenStackControlPlane) ValidateUpdateServices(old OpenStackControlPlane
 
 	if r.Spec.Nova.Enabled {
 		errors = append(errors, r.Spec.Nova.Template.ValidateUpdate(old.Nova.Template, basePath.Child("nova").Child("template"))...)
+	}
+
+	if r.Spec.Placement.Enabled {
+		errors = append(errors, r.Spec.Placement.Template.ValidateUpdate(old.Placement.Template, basePath.Child("placement").Child("template"))...)
 	}
 
 	return errors

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240206080218-0a39e8ee1c07
 	github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240205082155-fca054830e06
 	github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240206110402-41e2d7f8870e
-	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240206120950-4285571a7211
+	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240209144511-533e51daa424
 	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240206105420-de58be701128
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240205163246-3add3edb159c
 	github.com/rabbitmq/cluster-operator/v2 v2.5.0

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -166,8 +166,8 @@ github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240205082155-
 github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240205082155-fca054830e06/go.mod h1:u5RKT1S7MJqUqnEVIDOmwidFhBRIjMcUG78tWW1SUuE=
 github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240206110402-41e2d7f8870e h1:/E9k0cDpYcsvV4P10WSC4k0KKJgC06IwAs+Z+GTkDQ0=
 github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240206110402-41e2d7f8870e/go.mod h1:rYCOWkIWOBRf+6GijQo4uadwR9Sz/prV4HVTdUZoFHQ=
-github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240206120950-4285571a7211 h1:WPMYG5TQl7a7G4Acknp41Er3qjYcp1Onbl1kqvnMQX0=
-github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240206120950-4285571a7211/go.mod h1:G4XUqjS1C8V5U066HUcjnCyxTNhU4cSZOOGXcOCOhz4=
+github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240209144511-533e51daa424 h1:JdJDQ60QVjkTV6+mDt9zQQUIMc/51Cn9vY77QsBjhew=
+github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240209144511-533e51daa424/go.mod h1:xM0W1YMKuIoQnXhFVf4656QpyJlGa9m3cMj45KQt1pQ=
 github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240206105420-de58be701128 h1:j3iwtF7ptHjneP9tboCd1K6H3PdhhdTGXiKbXddEqZY=
 github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240206105420-de58be701128/go.mod h1:WxFJzl/l+1EjCEiBrQ+KydXEnZhxXtRvtcCn5O3q47E=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240205163246-3add3edb159c h1:w5/UiRR7xyJ2qtQ6gA/Exp8XJd3MhVpBOUrnfmDQ92o=

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20240125112403-f184903f8706
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20230725141229-4ce90d0120fd
 	github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240206110402-41e2d7f8870e
-	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240206120950-4285571a7211
+	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240209144511-533e51daa424
 	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240206105420-de58be701128
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240205163246-3add3edb159c
 	github.com/operator-framework/api v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.202
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20240125112403-f184903f8706/go.mod h1:UTK7po+fGYND9AwrTpQvEhWMYXmViwJaaWt0LzhleDE=
 github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240206110402-41e2d7f8870e h1:/E9k0cDpYcsvV4P10WSC4k0KKJgC06IwAs+Z+GTkDQ0=
 github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240206110402-41e2d7f8870e/go.mod h1:rYCOWkIWOBRf+6GijQo4uadwR9Sz/prV4HVTdUZoFHQ=
-github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240206120950-4285571a7211 h1:WPMYG5TQl7a7G4Acknp41Er3qjYcp1Onbl1kqvnMQX0=
-github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240206120950-4285571a7211/go.mod h1:G4XUqjS1C8V5U066HUcjnCyxTNhU4cSZOOGXcOCOhz4=
+github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240209144511-533e51daa424 h1:JdJDQ60QVjkTV6+mDt9zQQUIMc/51Cn9vY77QsBjhew=
+github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240209144511-533e51daa424/go.mod h1:xM0W1YMKuIoQnXhFVf4656QpyJlGa9m3cMj45KQt1pQ=
 github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240206105420-de58be701128 h1:j3iwtF7ptHjneP9tboCd1K6H3PdhhdTGXiKbXddEqZY=
 github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240206105420-de58be701128/go.mod h1:WxFJzl/l+1EjCEiBrQ+KydXEnZhxXtRvtcCn5O3q47E=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240205163246-3add3edb159c h1:w5/UiRR7xyJ2qtQ6gA/Exp8XJd3MhVpBOUrnfmDQ92o=


### PR DESCRIPTION
The placement-operator now has validation webhook, so openstack-operator should call it during validation.

Depends-On: https://github.com/openstack-k8s-operators/placement-operator/pull/148 (merged)
Related: [OSPRH-2503](https://issues.redhat.com//browse/OSPRH-2503)