### PR TITLE
Validate ready status is removed for ovn when it's disabled

### DIFF
--- a/pkg/openstack/ovn.go
+++ b/pkg/openstack/ovn.go
@@ -73,7 +73,6 @@ func ReconcileOVNDbClusters(ctx context.Context, instance *corev1beta1.OpenStack
 			if _, err := EnsureDeleted(ctx, helper, OVNDBCluster); err != nil {
 				return false, err
 			}
-			instance.Status.Conditions.Remove(corev1beta1.OpenStackControlPlaneOVNReadyCondition)
 			continue
 		}
 
@@ -121,7 +120,6 @@ func ReconcileOVNNorthd(ctx context.Context, instance *corev1beta1.OpenStackCont
 		if _, err := EnsureDeleted(ctx, helper, OVNNorthd); err != nil {
 			return false, err
 		}
-		instance.Status.Conditions.Remove(corev1beta1.OpenStackControlPlaneOVNReadyCondition)
 		return false, nil
 	}
 
@@ -170,7 +168,6 @@ func ReconcileOVNController(ctx context.Context, instance *corev1beta1.OpenStack
 		if _, err := EnsureDeleted(ctx, helper, OVNController); err != nil {
 			return false, err
 		}
-		instance.Status.Conditions.Remove(corev1beta1.OpenStackControlPlaneOVNReadyCondition)
 		return false, nil
 	}
 

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -269,3 +269,8 @@ func GetOpenStackControlPlane(name types.NamespacedName) *corev1.OpenStackContro
 	}, timeout, interval).Should(Succeed())
 	return instance
 }
+
+func OpenStackControlPlaneConditionGetter(name types.NamespacedName) condition.Conditions {
+	instance := GetOpenStackControlPlane(name)
+	return instance.Status.Conditions
+}


### PR DESCRIPTION
This is built on top of the other PR from @gibizer that fixed the regression. This PR adds necessary test coverage (plus removes some redundant Remove calls).