### PR TITLE
[tlse] internal TLS support for manila

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -7442,6 +7442,24 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          tls:
+                            properties:
+                              api:
+                                properties:
+                                  internal:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                  public:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                type: object
+                              caBundleSecretName:
+                                type: string
+                            type: object
                         required:
                         - containerImage
                         type: object

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240202131833-8b6a4ca3bdc5
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240202140528-34883c60812b
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240129151020-c9467a8fbbfc
-	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240205075416-5a5000e56580
+	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240212073017-91c953f42846
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240201121152-3dcb5d5b24f7
 	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240205081907-ca38cd1c0fd7
 	github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240206080218-0a39e8ee1c07

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -154,8 +154,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024012
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240129151020-c9467a8fbbfc/go.mod h1:GammFyM5i2OY0lBEAcyEi9Gk46jXFIlD+z+JqBikfoY=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240129151020-c9467a8fbbfc h1:At0RB1SfDAR50H4R+SGykczEmYz8XkEJllVM5YUujAE=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240129151020-c9467a8fbbfc/go.mod h1:lf4VSkNgy2mPyf4tR5xBXs8wQU9TJ9BYfY/Ay9/JkP0=
-github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240205075416-5a5000e56580 h1:Nem1hsYnQZPZrQKvSJ7ocZsOYaEy6IR76z20Lr0ALtY=
-github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240205075416-5a5000e56580/go.mod h1:TFWmtTRY1KLPoSOOriSEP7LgCrBwF8qM5ASAPxuvzyg=
+github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240212073017-91c953f42846 h1:x3IxqzMPb5V9wl83Sv6cEPWtdqtqRcQrDwSX02MH0/0=
+github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240212073017-91c953f42846/go.mod h1:TFWmtTRY1KLPoSOOriSEP7LgCrBwF8qM5ASAPxuvzyg=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240201121152-3dcb5d5b24f7 h1:pFtnmP9SS0FX1EQVlDmOf26G8G+ZlZkvowJLQUhvV6I=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240201121152-3dcb5d5b24f7/go.mod h1:D4sr4UipU4qjyrcO2mjW8YlSm48AdkY69dloASUbNYE=
 github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240205081907-ca38cd1c0fd7 h1:kHXBC17KCkoHwVGt6kJEY0FAWZuXwTM62xsxfKtRdsk=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -7442,6 +7442,24 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
+                          tls:
+                            properties:
+                              api:
+                                properties:
+                                  internal:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                  public:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                type: object
+                              caBundleSecretName:
+                                type: string
+                            type: object
                         required:
                         - containerImage
                         type: object

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240129151020-c9467a8fbbfc
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240129151020-c9467a8fbbfc
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240129151020-c9467a8fbbfc
-	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240205075416-5a5000e56580
+	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240212073017-91c953f42846
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240201121152-3dcb5d5b24f7
 	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240205081907-ca38cd1c0fd7
 	github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240206080218-0a39e8ee1c07

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.202401291
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240129151020-c9467a8fbbfc/go.mod h1:lf4VSkNgy2mPyf4tR5xBXs8wQU9TJ9BYfY/Ay9/JkP0=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240129151020-c9467a8fbbfc h1:1vqB6G8qvXH030JyVsx4acl5xtbCqwdbTHivc9f4vvY=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240129151020-c9467a8fbbfc/go.mod h1:ni4mvKeubWsTjKmcToJ+hIo7pJipM9hwiUv8qhm1R6Y=
-github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240205075416-5a5000e56580 h1:Nem1hsYnQZPZrQKvSJ7ocZsOYaEy6IR76z20Lr0ALtY=
-github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240205075416-5a5000e56580/go.mod h1:TFWmtTRY1KLPoSOOriSEP7LgCrBwF8qM5ASAPxuvzyg=
+github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240212073017-91c953f42846 h1:x3IxqzMPb5V9wl83Sv6cEPWtdqtqRcQrDwSX02MH0/0=
+github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240212073017-91c953f42846/go.mod h1:TFWmtTRY1KLPoSOOriSEP7LgCrBwF8qM5ASAPxuvzyg=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240201121152-3dcb5d5b24f7 h1:pFtnmP9SS0FX1EQVlDmOf26G8G+ZlZkvowJLQUhvV6I=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240201121152-3dcb5d5b24f7/go.mod h1:D4sr4UipU4qjyrcO2mjW8YlSm48AdkY69dloASUbNYE=
 github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240205081907-ca38cd1c0fd7 h1:kHXBC17KCkoHwVGt6kJEY0FAWZuXwTM62xsxfKtRdsk=


### PR DESCRIPTION
Creates certs for k8s service of the service operator when spec.tls.endpoint.internal.enabled: true

For a service like nova which talks to multiple service internal endpoints, this has to be set for each of them for, like:

~~~
  customServiceConfig: |
    [keystone_authtoken]
    insecure = true
    [placement]
    insecure = true
    [neutron]
    insecure = true
    [glance]
    insecure = true
    [cinder]
    insecure = true
~~~

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/428
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/620
Depends-On: https://github.com/openstack-k8s-operators/manila-operator/pull/212