### PR TITLE
[tempest] cinder-volume is not configured add more tests to skip

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -36,6 +36,8 @@
         - tempest.scenario.test_stamp_pattern.TestStampPattern
         - tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern
         - tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_live_migration
+        - tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachScenarioOldVersion
+        - tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachmentScenario
       # We need to use a custom cpu model to allow live migrating between
       # slightly different computes coming from the node pool
       cifmw_edpm_deploy_nova_compute_extra_config: |


### PR DESCRIPTION
the following two tests fail due to missing cinder-volume being configured:
- tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachScenarioOldVersion
- tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachmentScenario