### PR TITLE
Use qualified container image names in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_BUILDER=golang:1.20
+ARG GOLANG_BUILDER=docker.io/library/golang:1.20
 ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Build the manager binary


### PR DESCRIPTION
After we bumped to use the golang:1.20 image content provider job fails with.

```
Error: creating build container: short-name resolution enforced but cannot prompt without a TTY
```