### PR TITLE
[tlse] enable galera tls for internal TLS

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -94,7 +94,7 @@ func CreateNames(openstackControlplaneName types.NamespacedName) Names {
 		},
 		DBCertName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,
-			Name:      "cert-openstack-svc",
+			Name:      "cert-galera-openstack-svc",
 		},
 		DBCell1Name: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,
@@ -102,7 +102,7 @@ func CreateNames(openstackControlplaneName types.NamespacedName) Names {
 		},
 		DBCell1CertName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,
-			Name:      "cert-openstack-cell1-svc",
+			Name:      "cert-galera-openstack-cell1-svc",
 		},
 		RabbitMQName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,


### PR DESCRIPTION
Create cert for galera instance and configure the instance to use it. Galera will always be configured to support TLS as its on the DB user level if TLS will be enforced or not.

Jira: [OSPRH-2440](https://issues.redhat.com//browse/OSPRH-2440)