### PR TITLE
Use the target port name annotation for routes

### DIFF
--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -410,13 +410,18 @@ func (ed *EndpointDetail) CreateRoute(
 	owner metav1.Object,
 ) (ctrl.Result, error) {
 	// initialize the route with any custom provided route override
+	// per default use the service name as targetPortName if we don't have the annotation.
+	targetPortName := ed.Service.Spec.Name
+	if name, ok := ed.Service.Spec.ObjectMeta.Annotations[service.AnnotationIngressTargetPortNameKey]; ok && name != "" {
+		targetPortName = name
+	}
 	enptRoute, err := route.NewRoute(
 		route.GenericRoute(&route.GenericRouteDetails{
 			Name:           ed.Name,
 			Namespace:      ed.Namespace,
 			Labels:         ed.Labels,
 			ServiceName:    ed.Service.Spec.Name,
-			TargetPortName: ed.Service.Spec.Name,
+			TargetPortName: targetPortName,
 		}),
 		time.Duration(5)*time.Second,
 		[]route.OverrideSpec{ed.Route.OverrideSpec},


### PR DESCRIPTION
This uses the new annotation to specify the target port name used by routes created by the openstack-operator. In telemetry we don't manage the prometheus service, so for prometheus the assumption that the target port name is the same as the name of the service is incorrect.

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/465