### PR TITLE
Reconcile Barbican before Swift

### DIFF
--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -301,7 +301,7 @@ func (r *OpenStackControlPlaneReconciler) reconcileNormal(ctx context.Context, i
 		return ctrlResult, nil
 	}
 
-	ctrlResult, err = openstack.ReconcileSwift(ctx, instance, helper)
+	ctrlResult, err = openstack.ReconcileBarbican(ctx, instance, helper)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -329,7 +329,7 @@ func (r *OpenStackControlPlaneReconciler) reconcileNormal(ctx context.Context, i
 		return ctrlResult, nil
 	}
 
-	ctrlResult, err = openstack.ReconcileBarbican(ctx, instance, helper)
+	ctrlResult, err = openstack.ReconcileSwift(ctx, instance, helper)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if (ctrlResult != ctrl.Result{}) {


### PR DESCRIPTION
If Barbican is enabled it will be used by Swift to create and retrieve secrets, thus reconciling Barbican before Swift.