### PR TITLE
Make the empty SHA error understandable

### DIFF
--- a/hack/pin-bundle-images.sh
+++ b/hack/pin-bundle-images.sh
@@ -74,7 +74,7 @@ for MOD_PATH in $(go list -mod=readonly -m -json all | jq -r '. | select(.Path |
     fi
 
     if [ -z "$SHA" ]; then
-        echo "Error: SHA is empty, Could not find container with tag $REF in $REPO_CURL_URL"
+        echo ",EMPTY_SHA:$SHA:$REPO_CURL_URL"
         exit 1
     fi
 


### PR DESCRIPTION
Now when there is a missing SHA we get an error which is undecipherable. This has started happening recently with the changes in how we call `hack/pin-bundle-images.sh` in `hack/bundle-cache-data.sh`.

The current error we see is as below, that does not tell which operator SHA is missing.

"Invalid source name docker://quay.io/openstack-k8s-operators/openstack-baremetal-operator-bundle:0f74dcdc7782cc03cb82d5f8b845b9e21d292d0dError:: invalid reference format"