### PR TITLE
[tlse] Restore route DestinationCACertificate to use internal bundle

### DIFF
--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -567,7 +567,7 @@ func (ed *EndpointDetail) CreateRoute(
 			// get the TLSInternalCABundleFile to add it to the route
 			// to be able to validate public/internal service endpoints
 			tlsConfig.DestinationCACertificate, ctrlResult, err = secret.GetDataFromSecret(
-				ctx, helper, *ed.Service.TLS.SecretName, 5, tls.CAKey)
+				ctx, helper, ed.Service.TLS.CaBundleSecretName, 5, tls.InternalCABundleKey)
 			if err != nil {
 				return ctrlResult, err
 			} else if (ctrlResult != ctrl.Result{}) {


### PR DESCRIPTION
Restore the route DestinationCACertificate to be the intenal bundle as introduced in 963263b5e581073066185dabed0ee077046f9247 . The reason for this is that routes do not use name based url when doing the re-encrypt and therefore we can end up on the internal vhost config using the public CA for validation, which won't work.