### PR TITLE
Concatenate global and service specific extraMounts

### DIFF
--- a/pkg/openstack/cinder.go
+++ b/pkg/openstack/cinder.go
@@ -111,20 +111,13 @@ func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControl
 			//cinder.Spec.DatabaseInstance = instance.Name // name of MariaDB we create here
 			cinder.Spec.DatabaseInstance = "openstack" //FIXME: see above
 		}
-		// if already defined at service level (template section), we don't merge
-		// with the global defined extra volumes
-		if len(cinder.Spec.ExtraMounts) == 0 {
-
-			var cinderVolumes []cinderv1.CinderExtraVolMounts
-
-			for _, ev := range instance.Spec.ExtraMounts {
-				cinderVolumes = append(cinderVolumes, cinderv1.CinderExtraVolMounts{
-					Name:      ev.Name,
-					Region:    ev.Region,
-					VolMounts: ev.VolMounts,
-				})
-			}
-			cinder.Spec.ExtraMounts = cinderVolumes
+		// Append globally defined extraMounts to the service's own list.
+		for _, ev := range instance.Spec.ExtraMounts {
+			cinder.Spec.ExtraMounts = append(cinder.Spec.ExtraMounts, cinderv1.CinderExtraVolMounts{
+				Name:      ev.Name,
+				Region:    ev.Region,
+				VolMounts: ev.VolMounts,
+			})
 		}
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), cinder, helper.GetScheme())
 		if err != nil {

--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -150,20 +150,13 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		if glance.Spec.StorageClass == "" {
 			glance.Spec.StorageClass = instance.Spec.StorageClass
 		}
-		// if already defined at service level (template section), we don't merge
-		// with the global defined extra volumes
-		if len(glance.Spec.ExtraMounts) == 0 {
-
-			var glanceVolumes []glancev1.GlanceExtraVolMounts
-
-			for _, ev := range instance.Spec.ExtraMounts {
-				glanceVolumes = append(glanceVolumes, glancev1.GlanceExtraVolMounts{
-					Name:      ev.Name,
-					Region:    ev.Region,
-					VolMounts: ev.VolMounts,
-				})
-			}
-			glance.Spec.ExtraMounts = glanceVolumes
+		// Append globally defined extraMounts to the service's own list.
+		for _, ev := range instance.Spec.ExtraMounts {
+			glance.Spec.ExtraMounts = append(glance.Spec.ExtraMounts, glancev1.GlanceExtraVolMounts{
+				Name:      ev.Name,
+				Region:    ev.Region,
+				VolMounts: ev.VolMounts,
+			})
 		}
 
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), glance, helper.GetScheme())

--- a/pkg/openstack/manila.go
+++ b/pkg/openstack/manila.go
@@ -112,20 +112,13 @@ func ReconcileManila(ctx context.Context, instance *corev1beta1.OpenStackControl
 			//manila.Spec.DatabaseInstance = instance.Name // name of MariaDB we create here
 			manila.Spec.DatabaseInstance = "openstack" //FIXME: see above
 		}
-		// if already defined at service level (template section), we don't merge
-		// with the global defined extra volumes
-		if len(manila.Spec.ExtraMounts) == 0 {
-
-			var manilaVolumes []manilav1.ManilaExtraVolMounts
-
-			for _, ev := range instance.Spec.ExtraMounts {
-				manilaVolumes = append(manilaVolumes, manilav1.ManilaExtraVolMounts{
-					Name:      ev.Name,
-					Region:    ev.Region,
-					VolMounts: ev.VolMounts,
-				})
-			}
-			manila.Spec.ExtraMounts = manilaVolumes
+		// Append globally defined extraMounts to the service's own list.
+		for _, ev := range instance.Spec.ExtraMounts {
+			manila.Spec.ExtraMounts = append(manila.Spec.ExtraMounts, manilav1.ManilaExtraVolMounts{
+				Name:      ev.Name,
+				Region:    ev.Region,
+				VolMounts: ev.VolMounts,
+			})
 		}
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), manila, helper.GetScheme())
 		if err != nil {

--- a/pkg/openstack/neutron.go
+++ b/pkg/openstack/neutron.go
@@ -143,20 +143,13 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 			neutronAPI.Spec.DatabaseInstance = "openstack"
 		}
 
-		// if already defined at service level (template section), we don't merge
-		// with the global defined extra volumes
-		if len(neutronAPI.Spec.ExtraMounts) == 0 {
-
-			var neutronVolumes []neutronv1.NeutronExtraVolMounts
-
-			for _, ev := range instance.Spec.ExtraMounts {
-				neutronVolumes = append(neutronVolumes, neutronv1.NeutronExtraVolMounts{
-					Name:      ev.Name,
-					Region:    ev.Region,
-					VolMounts: ev.VolMounts,
-				})
-			}
-			neutronAPI.Spec.ExtraMounts = neutronVolumes
+		// Append globally defined extraMounts to the service's own list.
+		for _, ev := range instance.Spec.ExtraMounts {
+			neutronAPI.Spec.ExtraMounts = append(neutronAPI.Spec.ExtraMounts, neutronv1.NeutronExtraVolMounts{
+				Name:      ev.Name,
+				Region:    ev.Region,
+				VolMounts: ev.VolMounts,
+			})
 		}
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), neutronAPI, helper.GetScheme())
 		if err != nil {


### PR DESCRIPTION
The list of global and service specific extraMounts are now concatenated, instead of the previous behavior where service specific extraMounts would supersede/override the global list.

The services that support their own list of extraMounts is unchanged. Those services are cinder, glance, manila and neutron.