### PR TITLE
[tlse] internal TLS support for octavia

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -9721,6 +9721,10 @@ spec:
                           - name
                           type: object
                         type: array
+                      amphoraImageContainerImage:
+                        type: string
+                      apacheContainerImage:
+                        type: string
                       customServiceConfig:
                         default: '# add your customization here'
                         type: string
@@ -9887,6 +9891,24 @@ spec:
                           serviceUser:
                             default: octavia
                             type: string
+                          tls:
+                            properties:
+                              api:
+                                properties:
+                                  internal:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                  public:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                type: object
+                              caBundleSecretName:
+                                type: string
+                            type: object
                           transportURLSecret:
                             type: string
                         required:
@@ -9935,18 +9957,12 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
-                          lbMgmtNetwork:
-                            default:
-                              manageLbMgmtNetworks: true
-                              subnetIpVersion: 4
-                            properties:
-                              manageLbMgmtNetworks:
-                                default: true
-                                type: boolean
-                              subnetIpVersion:
-                                default: 4
-                                type: integer
-                            type: object
+                          lbMgmtNetworkID:
+                            default: ""
+                            type: string
+                          lbSecurityGroupID:
+                            default: ""
+                            type: string
                           networkAttachments:
                             items:
                               type: string
@@ -10016,6 +10032,11 @@ spec:
                           tenantName:
                             default: service
                             type: string
+                          tls:
+                            properties:
+                              caBundleSecretName:
+                                type: string
+                            type: object
                           transportURLSecret:
                             type: string
                         required:
@@ -10064,18 +10085,12 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
-                          lbMgmtNetwork:
-                            default:
-                              manageLbMgmtNetworks: true
-                              subnetIpVersion: 4
-                            properties:
-                              manageLbMgmtNetworks:
-                                default: true
-                                type: boolean
-                              subnetIpVersion:
-                                default: 4
-                                type: integer
-                            type: object
+                          lbMgmtNetworkID:
+                            default: ""
+                            type: string
+                          lbSecurityGroupID:
+                            default: ""
+                            type: string
                           networkAttachments:
                             items:
                               type: string
@@ -10145,6 +10160,11 @@ spec:
                           tenantName:
                             default: service
                             type: string
+                          tls:
+                            properties:
+                              caBundleSecretName:
+                                type: string
+                            type: object
                           transportURLSecret:
                             type: string
                         required:
@@ -10193,18 +10213,12 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
-                          lbMgmtNetwork:
-                            default:
-                              manageLbMgmtNetworks: true
-                              subnetIpVersion: 4
-                            properties:
-                              manageLbMgmtNetworks:
-                                default: true
-                                type: boolean
-                              subnetIpVersion:
-                                default: 4
-                                type: integer
-                            type: object
+                          lbMgmtNetworkID:
+                            default: ""
+                            type: string
+                          lbSecurityGroupID:
+                            default: ""
+                            type: string
                           networkAttachments:
                             items:
                               type: string
@@ -10274,6 +10288,11 @@ spec:
                           tenantName:
                             default: service
                             type: string
+                          tls:
+                            properties:
+                              caBundleSecretName:
+                                type: string
+                            type: object
                           transportURLSecret:
                             type: string
                         required:
@@ -10302,7 +10321,40 @@ spec:
                       rabbitMqClusterName:
                         default: rabbitmq
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       secret:
+                        type: string
+                      serviceAccount:
                         type: string
                       serviceUser:
                         default: octavia
@@ -10313,11 +10365,16 @@ spec:
                       sshPubkey:
                         default: octavia-ssh-pubkey
                         type: string
+                      tenantName:
+                        default: service
+                        type: string
                     required:
+                    - apacheContainerImage
                     - databaseInstance
                     - octaviaAPI
                     - rabbitMqClusterName
                     - secret
+                    - serviceAccount
                     type: object
                 type: object
               openstackclient:

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240314113200-40cf3e6aa38e
 	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240308065128-4ba88761f83f
 	github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240313153742-4685453be3fb
-	github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240314110716-d81f1e5d229d
+	github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240326115129-7fd1a4fa51c3
 	github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240318052728-f132fab5c943
 	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240313145348-1dd69c7bc338
 	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240315154317-8b38ff1e6a8d

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -105,8 +105,8 @@ github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240308065128-
 github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240308065128-4ba88761f83f/go.mod h1:gOepjTKpq6rF0Lf69edviPOjFpjw4LHan/tWC4LB4Fs=
 github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240313153742-4685453be3fb h1:WwiFdrd3Qk7AsXQWMIysL8LW4XHC9gJhJ4LmbIYi4HI=
 github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240313153742-4685453be3fb/go.mod h1:s9ZDTDlY5f7cu/ZT35kGYvLD8v6mto6MOLPcsK73e54=
-github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240314110716-d81f1e5d229d h1:Tg83hIGk29fYXPV/QICyFeAmamuD4v+2aQ87ZNi0R/k=
-github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240314110716-d81f1e5d229d/go.mod h1:w46sjTz5g4qxAd3xkEYTakmRoZOF8TfVr5WKG0vmPSw=
+github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240326115129-7fd1a4fa51c3 h1:eBwnx+PrS4SBQxYLlByJFX7poKigiBJsv/CGoEFGIaI=
+github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240326115129-7fd1a4fa51c3/go.mod h1:w46sjTz5g4qxAd3xkEYTakmRoZOF8TfVr5WKG0vmPSw=
 github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240318052728-f132fab5c943 h1:klU6Jc46yVMFAoXZgJO1gaJiw3ZjaYTNshfirR0M5oA=
 github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240318052728-f132fab5c943/go.mod h1:dcKA0ZNATdkWVmltQQX8jYpEzM89FRIvzlo9Byj8H04=
 github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240313145348-1dd69c7bc338 h1:4px3BVSfWmfvJf+Nurf0EJb4ViKHW4qM8ocDqH0u8C4=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -9721,6 +9721,10 @@ spec:
                           - name
                           type: object
                         type: array
+                      amphoraImageContainerImage:
+                        type: string
+                      apacheContainerImage:
+                        type: string
                       customServiceConfig:
                         default: '# add your customization here'
                         type: string
@@ -9887,6 +9891,24 @@ spec:
                           serviceUser:
                             default: octavia
                             type: string
+                          tls:
+                            properties:
+                              api:
+                                properties:
+                                  internal:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                  public:
+                                    properties:
+                                      secretName:
+                                        type: string
+                                    type: object
+                                type: object
+                              caBundleSecretName:
+                                type: string
+                            type: object
                           transportURLSecret:
                             type: string
                         required:
@@ -9935,18 +9957,12 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
-                          lbMgmtNetwork:
-                            default:
-                              manageLbMgmtNetworks: true
-                              subnetIpVersion: 4
-                            properties:
-                              manageLbMgmtNetworks:
-                                default: true
-                                type: boolean
-                              subnetIpVersion:
-                                default: 4
-                                type: integer
-                            type: object
+                          lbMgmtNetworkID:
+                            default: ""
+                            type: string
+                          lbSecurityGroupID:
+                            default: ""
+                            type: string
                           networkAttachments:
                             items:
                               type: string
@@ -10016,6 +10032,11 @@ spec:
                           tenantName:
                             default: service
                             type: string
+                          tls:
+                            properties:
+                              caBundleSecretName:
+                                type: string
+                            type: object
                           transportURLSecret:
                             type: string
                         required:
@@ -10064,18 +10085,12 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
-                          lbMgmtNetwork:
-                            default:
-                              manageLbMgmtNetworks: true
-                              subnetIpVersion: 4
-                            properties:
-                              manageLbMgmtNetworks:
-                                default: true
-                                type: boolean
-                              subnetIpVersion:
-                                default: 4
-                                type: integer
-                            type: object
+                          lbMgmtNetworkID:
+                            default: ""
+                            type: string
+                          lbSecurityGroupID:
+                            default: ""
+                            type: string
                           networkAttachments:
                             items:
                               type: string
@@ -10145,6 +10160,11 @@ spec:
                           tenantName:
                             default: service
                             type: string
+                          tls:
+                            properties:
+                              caBundleSecretName:
+                                type: string
+                            type: object
                           transportURLSecret:
                             type: string
                         required:
@@ -10193,18 +10213,12 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
-                          lbMgmtNetwork:
-                            default:
-                              manageLbMgmtNetworks: true
-                              subnetIpVersion: 4
-                            properties:
-                              manageLbMgmtNetworks:
-                                default: true
-                                type: boolean
-                              subnetIpVersion:
-                                default: 4
-                                type: integer
-                            type: object
+                          lbMgmtNetworkID:
+                            default: ""
+                            type: string
+                          lbSecurityGroupID:
+                            default: ""
+                            type: string
                           networkAttachments:
                             items:
                               type: string
@@ -10274,6 +10288,11 @@ spec:
                           tenantName:
                             default: service
                             type: string
+                          tls:
+                            properties:
+                              caBundleSecretName:
+                                type: string
+                            type: object
                           transportURLSecret:
                             type: string
                         required:
@@ -10302,7 +10321,40 @@ spec:
                       rabbitMqClusterName:
                         default: rabbitmq
                         type: string
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       secret:
+                        type: string
+                      serviceAccount:
                         type: string
                       serviceUser:
                         default: octavia
@@ -10313,11 +10365,16 @@ spec:
                       sshPubkey:
                         default: octavia-ssh-pubkey
                         type: string
+                      tenantName:
+                        default: service
+                        type: string
                     required:
+                    - apacheContainerImage
                     - databaseInstance
                     - octaviaAPI
                     - rabbitMqClusterName
                     - secret
+                    - serviceAccount
                     type: object
                 type: object
               openstackclient:

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240314113200-40cf3e6aa38e
 	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240308065128-4ba88761f83f
 	github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240313153742-4685453be3fb
-	github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240314110716-d81f1e5d229d
+	github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240326115129-7fd1a4fa51c3
 	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240313103756-fb4ac5373b65
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20240318080957-e5f6ab918182
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240308065128-
 github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240308065128-4ba88761f83f/go.mod h1:gOepjTKpq6rF0Lf69edviPOjFpjw4LHan/tWC4LB4Fs=
 github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240313153742-4685453be3fb h1:WwiFdrd3Qk7AsXQWMIysL8LW4XHC9gJhJ4LmbIYi4HI=
 github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240313153742-4685453be3fb/go.mod h1:s9ZDTDlY5f7cu/ZT35kGYvLD8v6mto6MOLPcsK73e54=
-github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240314110716-d81f1e5d229d h1:Tg83hIGk29fYXPV/QICyFeAmamuD4v+2aQ87ZNi0R/k=
-github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240314110716-d81f1e5d229d/go.mod h1:w46sjTz5g4qxAd3xkEYTakmRoZOF8TfVr5WKG0vmPSw=
+github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240326115129-7fd1a4fa51c3 h1:eBwnx+PrS4SBQxYLlByJFX7poKigiBJsv/CGoEFGIaI=
+github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240326115129-7fd1a4fa51c3/go.mod h1:w46sjTz5g4qxAd3xkEYTakmRoZOF8TfVr5WKG0vmPSw=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240313103756-fb4ac5373b65 h1:AeHvh2ah7KDYmNF4Q9G8EKgaiuO4PRmK0B5dxLuASaY=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240313103756-fb4ac5373b65/go.mod h1:SONAy6PaXQfqSyx6/KuiUh0ZljeUi4wNoIhEFCkhiZU=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20240318080957-e5f6ab918182 h1:iAPRykcri8fTzMPHbVH7CtDlgshy4IHGodwCJtUVirU=

--- a/pkg/openstack/barbican.go
+++ b/pkg/openstack/barbican.go
@@ -99,7 +99,7 @@ func ReconcileBarbican(ctx context.Context, instance *corev1beta1.OpenStackContr
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), barbican, func() error {
 		instance.Spec.Barbican.Template.DeepCopyInto(&barbican.Spec)
 
-        // FIXME: barbican webhooks are not setting this correctly yet
+		// FIXME: barbican webhooks are not setting this correctly yet
 		if barbican.Spec.DatabaseAccount == "" {
 			barbican.Spec.DatabaseAccount = "barbican"
 		}


### PR DESCRIPTION
Creates certs for k8s service of the service operator when spec.tls.endpoint.internal.enabled: true

For a service like nova which talks to multiple service internal endpoints, this has to be set for each of them for, like:

  customServiceConfig: |
    [keystone_authtoken]
    insecure = true
    [placement]
    insecure = true
    [neutron]
    insecure = true
    [glance]
    insecure = true
    [cinder]
    insecure = true
Depends-On: openstack-k8s-operators/lib-common#428 Depends-On: #620
Depends-On: openstack-k8s-operators/octavia-operator#265