### PR TITLE
Add Neutron's default route annotations

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"fmt"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/route"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -318,6 +319,14 @@ func (r *OpenStackControlPlane) Default() {
 	r.DefaultServices()
 }
 
+// Helper function to initialize overrideSpec object. Could be moved to lib-common.
+func initializeOverrideSpec(override **route.OverrideSpec, anno map[string]string) {
+	if *override == nil {
+		*override = &route.OverrideSpec{}
+	}
+	(*override).AddAnnotation(anno)
+}
+
 // DefaultServices - common function for calling individual services' defaulting functions
 func (r *OpenStackControlPlane) DefaultServices() {
 	// RabbitMQ
@@ -381,6 +390,7 @@ func (r *OpenStackControlPlane) DefaultServices() {
 
 	// Neutron
 	r.Spec.Neutron.Template.Default()
+	initializeOverrideSpec(&r.Spec.Neutron.APIOverride.Route, r.Spec.Neutron.Template.GetDefaultRouteAnnotations())
 
 	// Nova
 	r.Spec.Nova.Template.Default()

--- a/tests/functional/openstackoperator_controller_test.go
+++ b/tests/functional/openstackoperator_controller_test.go
@@ -96,6 +96,11 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(keystoneAPI).Should(Not(BeNil()))
 			}, timeout, interval).Should(Succeed())
 		})
+		// Default route timeouts are set
+		It("should have default timeout for the routes set", func() {
+			OSCtlplane := GetOpenStackControlPlane(names.OpenStackControlplaneName)
+			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "120s"))
+		})
 
 		It("should create selfsigned issuer and public+internal CA and issuer", func() {
 			OSCtlplane := GetOpenStackControlPlane(names.OpenStackControlplaneName)


### PR DESCRIPTION
When the webhook calls for Neutron defaults, it should also write the route override annotation on Neutron's CR section so that the route gets modified.

Currently it is failing when I try to modify the openstack controlplane CR, and I don't get to see anything under neutron apiOverride on the yaml. But I do see the Annotation applied on the OverrideSpec object. I assume I'm doing something wrong here, any help appreciated!

(Goes together with https://github.com/openstack-k8s-operators/neutron-operator/pull/324)
Depends-On: https://github.com/openstack-k8s-operators/neutron-operator/pull/324