### PR TITLE
Pin setup-envtest at working commit to unblock content provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9b
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.


### PR DESCRIPTION
https://github.com/kubernetes-sigs/controller-runtime/pull/2693 broke the content provider while doing docker-build with following issue[1]

In order to unblock the CI, we are pinning
sigs.k8s.io/controller-runtime/tools/setup-envtest at previous working commit[2]

[1]. https://github.com/kubernetes-sigs/controller-runtime/issues/2720 [2]. https://github.com/kubernetes-sigs/controller-runtime/commit/c7e1dc9b5302d649d5531e19168dd7ea0013736d