### PR TITLE
Fix networkAttachment typo in sample files

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -202,15 +202,15 @@ spec:
         replicas: 1
       designateWorker:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateProducer:
         replicas: 0
       designateMdns:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateBackendbind9:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -183,15 +183,15 @@ spec:
         replicas: 1
       designateWorker:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateProducer:
         replicas: 0
       designateMdns:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateBackendbind9:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -387,15 +387,15 @@ spec:
         replicas: 1
       designateWorker:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateProducer:
         replicas: 0
       designateMdns:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateBackendbind9:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -342,7 +342,7 @@ spec:
         ringReplicas: 1
       swiftStorage:
         replicas: 1
-        networkAttachements:
+        networkAttachments:
           - storage
       swiftProxy:
         replicas: 1
@@ -356,7 +356,7 @@ spec:
                   metallb.universe.tf/loadBalancerIPs: 172.17.0.80
               spec:
                 type: LoadBalancer
-        networkAttachements:
+        networkAttachments:
           - storage
   octavia:
     enabled: false
@@ -389,15 +389,15 @@ spec:
         replicas: 1
       designateWorker:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateProducer:
         replicas: 0
       designateMdns:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateBackendbind9:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -383,15 +383,15 @@ spec:
         replicas: 1
       designateWorker:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateProducer:
         replicas: 0
       designateMdns:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateBackendbind9:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -419,15 +419,15 @@ spec:
         replicas: 1
       designateWorker:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateProducer:
         replicas: 0
       designateMdns:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateBackendbind9:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tlse.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tlse.yaml
@@ -386,15 +386,15 @@ spec:
         replicas: 1
       designateWorker:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateProducer:
         replicas: 0
       designateMdns:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate
       designateBackendbind9:
         replicas: 0
-        networkAttachements:
+        networkAttachments:
           - designate


### PR DESCRIPTION
Various sample files for an OpenStackControlPlane mistakenly use
networkAttachement (with a superfluous E). This change fixes that typo.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
