### PR TITLE
Fix TLS custom CA for rabbitmq and nova

### DIFF
--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -685,3 +685,22 @@ func SetupServiceOperatorDefaults() {
 	//  Barbican
 	barbicanv1.SetupDefaults()
 }
+
+func GetIssuerCertSecret(
+	ctx context.Context,
+	helper *helper.Helper,
+	name string,
+	namespace string,
+) (string, error) {
+	// get  issuer
+	issuer, err := certmanager.GetIssuerByName(
+		ctx,
+		helper,
+		name,
+		namespace,
+	)
+	if err != nil {
+		return "", err
+	}
+	return issuer.Spec.CA.SecretName, nil
+}

--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -173,7 +173,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 			helper,
 			nova.Namespace,
 			instance.Spec.Nova.Template.MetadataServiceTemplate.Override.Service.Labels,
-			tls.DefaultCAPrefix+string(service.EndpointInternal),
+			instance.GetInternalIssuer(),
 			nil)
 		if err != nil && !k8s_errors.IsNotFound(err) {
 			return ctrlResult, err
@@ -196,7 +196,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 				helper,
 				nova.Namespace,
 				cellTemplate.MetadataServiceTemplate.Override.Service.Labels,
-				tls.DefaultCAPrefix+string(service.EndpointInternal),
+				instance.GetInternalIssuer(),
 				nil)
 			if err != nil && !k8s_errors.IsNotFound(err) {
 				return ctrlResult, err


### PR DESCRIPTION
A couple of references to the default internal CA seem to have been missed in https://github.com/openstack-k8s-operators/openstack-operator/pull/713

Related: [OSPRH-5600](https://issues.redhat.com//browse/OSPRH-5600)