### PR TITLE
[tls] fix status.tls.caList[].expires

### DIFF
--- a/pkg/openstack/ca.go
+++ b/pkg/openstack/ca.go
@@ -357,7 +357,6 @@ func ensureCaBundles(
 	bundle *caBundle,
 	caOnlyBundle *caBundle,
 ) (ctrl.Result, error) {
-
 	err := bundle.getCertsFromPEM(caCert)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -367,11 +366,15 @@ func ensureCaBundles(
 		return ctrl.Result{}, err
 	}
 
-	status := corev1.TLSCAStatus{
-		Name: caName,
+	caCertStatusBundle := newBundle()
+	err = caCertStatusBundle.getCertsFromPEM(caCert)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
-	if len(caOnlyBundle.certs) > 0 {
-		status.Expires = caOnlyBundle.certs[0].expire.Format(time.RFC3339)
+
+	status := corev1.TLSCAStatus{
+		Name:    caName,
+		Expires: caCertStatusBundle.certs[0].expire.Format(time.RFC3339),
 	}
 
 	instance.Status.TLS.CAList = append(instance.Status.TLS.CAList, status)


### PR DESCRIPTION
currently always the first element of the bundle list gets used to get the expire date of the cacert to be added to the caList in the status. This is always the same cert and the expire dates will show the same for all ca certs:

```
  tls:
    caBundleSecretName: combined-ca-bundle
    caList:
    - expires: "2029-03-14T14:26:31Z"
      name: rootca-public
    - expires: "2029-03-14T14:26:31Z"
      name: rootca-internal
    - expires: "2029-03-14T14:26:31Z"
      name: rootca-ovn
```

With the fix a temporary bundle is used to get the details for the current cacert. Now the expires time stamps are as expected:

```
  tls:
    caBundleSecretName: combined-ca-bundle
    caList:
    - expires: "2029-03-14T15:19:05Z"
      name: rootca-public-custom
    - expires: "2024-07-01T14:33:01Z"
      name: rootca-internal
    - expires: "2024-07-01T14:22:37Z"
      name: rootca-ovn
```