### PR TITLE
Move the tempest var to test_operator

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -14,42 +14,42 @@
     vars:
       cifmw_operator_build_golang_ct: "docker.io/library/golang:1.20"
       cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.20"
-      cifmw_run_test_role: tempest
-      cifmw_tempest_container: openstack-tempest-all
-      cifmw_tempest_tempestconf_profile:
-          overrides:
-            compute-feature-enabled.vnc_console: true
-            compute-feature-enabled.stable_rescue: true
-            compute_feature_enabled.hostname_fqdn_sanitization: true
-            # NOTE(alee) these tests will fail with barbican in the mix
-            # while cinder/nova is not configured to talk to barbican
-            # re-enable this when that support is added
-            compute-feature-enabled.attach_encrypted_volume: false
-            compute-feature-enabled.live_migration: true
-            compute-feature-enabled.block_migration_for_live_migration: true
-            # NOTE(gibi): This is a WA to force the publicURL as otherwise
-            # tempest gets configured with adminURL and that causes test
-            # instability.
-            identity.v3_endpoint_type: public
-      cifmw_tempest_tests_allowed:
-      # NOTE(gibi): enable only the high level scenario tests to keep the
-      # job run time reasonable
-        - tempest.scenario
-      # Plus an extra live migration test until we have cinder volumes / ceph
-      # to run the live migration scenario tests with it
-        - tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test
-      cifmw_tempest_tests_skipped:
-      # NOTE(gibi): there are no cinder backend enabled so test needing a
-      # volumes needs to be skipped
-        - tempest.scenario.test_minimum_basic.TestMinimumBasicScenario
-        - test_shelve_volume_backed_instance
-        - tempest.scenario.test_stamp_pattern.TestStampPattern
-        - tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern
-        - tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_live_migration
-        - tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachScenarioOldVersion
-        - tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachmentScenario
-        - tempest.scenario.test_instances_with_cinder_volumes.TestInstancesWithCinderVolumes
-        - tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.test_live_block_migration_with_attached_volume
+      cifmw_tempest_tempestconf_config:
+          # NOTE(alee) these tests will fail with barbican in the mix
+          # while cinder/nova is not configured to talk to barbican
+          # re-enable this when that support is added
+          # NOTE(gibi): This is a WA to force the publicURL as otherwise
+          # tempest gets configured with adminURL and that causes test
+          # instability.
+          overrides: |
+            compute-feature-enabled.vnc_console true
+            compute-feature-enabled.stable_rescue true
+            compute_feature_enabled.hostname_fqdn_sanitization true
+            compute-feature-enabled.attach_encrypted_volume false
+            compute-feature-enabled.live_migration true
+            compute-feature-enabled.block_migration_for_live_migration true
+            identity.v3_endpoint_type public
+      cifmw_test_operator_tempest_include_list: |
+        # NOTE(gibi): enable only the high level scenario tests to keep the
+        # job run time reasonable
+        tempest.scenario
+        # Plus an extra live migration test until we have cinder volumes / ceph
+        # to run the live migration scenario tests with it
+        tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test
+      cifmw_test_operator_tempest_exclude_list: |
+        # NOTE(gibi): there are no cinder backend enabled so test needing a
+        # volumes needs to be skipped
+        tempest.scenario.test_minimum_basic.TestMinimumBasicScenario
+        test_shelve_volume_backed_instance
+        tempest.scenario.test_stamp_pattern.TestStampPattern
+        tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern
+        tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_live_migration
+        tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachScenarioOldVersion
+        tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachmentScenario
+        tempest.scenario.test_instances_with_cinder_volumes.TestInstancesWithCinderVolumes
+        tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.test_live_block_migration_with_attached_volume
+        # TODO (rlandy) remove when https://issues.redhat.com/browse/OSPCIX-126 is fixed
+        tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
       # We need to use a custom cpu model to allow live migrating between
       # slightly different computes coming from the node pool
       cifmw_edpm_deploy_nova_compute_extra_config: |


### PR DESCRIPTION
Since we are already test_operator in all the edpm jobs.Let's use it here also.
    
    Note: it also includes a workaround for https://issues.redhat.com/browse/OSPCIX-487
