### PR TITLE
Switch to tempest role for running tempest

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -6,6 +6,7 @@
     vars:
       cifmw_operator_build_golang_ct: "docker.io/library/golang:1.20"
       cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.20"
+      cifmw_run_test_role: tempest
       cifmw_tempest_tempestconf_profile:
           overrides:
             compute-feature-enabled.vnc_console: true


### PR DESCRIPTION
openstack-k8s-operators/ci-framework#1391 moves to test_operator role for running tempest tests.
 It broke the existing vars based on tempest role. It also needs to be migrated to test_operator. 
Let use tempest role here to bring back running tempest tests.