### PR TITLE
[tls] add tls for public endpoint sample

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
@@ -7,7 +7,7 @@ spec:
   storageClass: local-storage
   tls:
     podLevel:
-      enabled: true
+      enabled: false
   dns:
     template:
       override:


### PR DESCRIPTION
Now that tlse is enabled per default with 9e8cd278269d3ba542f952c9ab5355fad5eea5a0, this removes the tlse sample and adds a tls for public endpoints sample.