### PR TITLE
Update ansibleee to get neutron-metadata tls fixes

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240403153038-cacd7b514718
 	github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240407224322-0ac0a3eea830
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240402154848-e5f862707f49
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240404123425-54f145c97484
-	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240404123425-54f145c97484
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240408095526-357d8fffa034
+	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240408095526-357d8fffa034
 	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240403143013-74e2f3cc4015
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240403152257-75b048d878bf
 	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240403141351-743a139e74b6

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -91,12 +91,12 @@ github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240407224322-0
 github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240407224322-0ac0a3eea830/go.mod h1:x1Hya2LM5fP3iD89Es9YDrG4vj+GIULLAdgxmv3NIvY=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240402154848-e5f862707f49 h1:LSbLg+6iwX2jkVKe0ba6GqSO2mpoJlUZyWIWZA6jv6M=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240402154848-e5f862707f49/go.mod h1:opUQY0YZNCyA11FKLToVhaVZTTEMfbnf0ozOLmkKfGs=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240404123425-54f145c97484 h1:P3I3QBjZql8M5XXB/XBUdeM//e3XHtLv4yu7e+QlYQ8=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240404123425-54f145c97484/go.mod h1:gqByVGUdKQB/NkhKV4eD+8NWYkHq961nC96rTCB3ywE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240408095526-357d8fffa034 h1:HLI/aUA7KnBK5oLPIWXMasz7zqjal4GhNn1P/fdLI20=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240408095526-357d8fffa034/go.mod h1:gqByVGUdKQB/NkhKV4eD+8NWYkHq961nC96rTCB3ywE=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240404123425-54f145c97484 h1:0Wmtd+xyvPvU1O6xd2G27XwZfYY2ewhTrbd9ELHlHwg=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240404123425-54f145c97484/go.mod h1:U32T7Jz/vUBbMJVYuGSmhcPT2+WiOr+8zt2G9RPJGMI=
-github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240404123425-54f145c97484 h1:OvNHhOe3C34x9Oh29XPtjcOyGi790vgso4+okxbLs9s=
-github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240404123425-54f145c97484/go.mod h1:/ieOXgiSRmc2LpZ9kCnvtXagh/QM88prKpisVNLwrjg=
+github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240408095526-357d8fffa034 h1:LDWJWy545zW7KsZ2d2d+J5mJJK5eX/pL7mnSqn63PH4=
+github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240408095526-357d8fffa034/go.mod h1:/ieOXgiSRmc2LpZ9kCnvtXagh/QM88prKpisVNLwrjg=
 github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240403143013-74e2f3cc4015 h1:IYvBU6uEbGb0zXqVjDW2DuXPmQBcEZ8ssc3xAOY2/FY=
 github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240403143013-74e2f3cc4015/go.mod h1:2xtchrVN1qkQcO2Xa2JkQLqBdYL7GRIUUsoiGLHK3OM=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240403152257-75b048d878bf h1:N0HGTE+WXkaVeCpsJO5QG79uyLhRuNa3/gCTGgfZfGo=

--- a/go.mod
+++ b/go.mod
@@ -23,14 +23,14 @@ require (
 	github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240407224322-0ac0a3eea830
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240402154848-e5f862707f49
 	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240404123425-54f145c97484
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240404123425-54f145c97484
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240408095526-357d8fffa034
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240404123425-54f145c97484
 	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240403143013-74e2f3cc4015
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240403152257-75b048d878bf
 	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240403141351-743a139e74b6
 	github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240404163736-a2d67e46f9f2
 	github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240404073049-a8b012482299
-	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240405191225-a61ca8697bf2
+	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240409165939-6e7f030b1a88
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20240403043315-77086641d3fd
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240409005731-765fc25c55d9
@@ -83,7 +83,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240404123425-54f145c97484 // indirect
-	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240404123425-54f145c97484 // indirect
+	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240408095526-357d8fffa034 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,12 +118,12 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240402154848
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240402154848-e5f862707f49/go.mod h1:opUQY0YZNCyA11FKLToVhaVZTTEMfbnf0ozOLmkKfGs=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240404123425-54f145c97484 h1:4PS7ywfixWWDM+UyjWblXInNOb4IwjryvPsTrbnN1bE=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240404123425-54f145c97484/go.mod h1:MkhvdDYL/CI7aQdKGHLVmUwnBGTnWhcUQMdCB9ZE4BI=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240404123425-54f145c97484 h1:P3I3QBjZql8M5XXB/XBUdeM//e3XHtLv4yu7e+QlYQ8=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240404123425-54f145c97484/go.mod h1:gqByVGUdKQB/NkhKV4eD+8NWYkHq961nC96rTCB3ywE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240408095526-357d8fffa034 h1:HLI/aUA7KnBK5oLPIWXMasz7zqjal4GhNn1P/fdLI20=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240408095526-357d8fffa034/go.mod h1:gqByVGUdKQB/NkhKV4eD+8NWYkHq961nC96rTCB3ywE=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240404123425-54f145c97484 h1:0Wmtd+xyvPvU1O6xd2G27XwZfYY2ewhTrbd9ELHlHwg=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240404123425-54f145c97484/go.mod h1:U32T7Jz/vUBbMJVYuGSmhcPT2+WiOr+8zt2G9RPJGMI=
-github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240404123425-54f145c97484 h1:OvNHhOe3C34x9Oh29XPtjcOyGi790vgso4+okxbLs9s=
-github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240404123425-54f145c97484/go.mod h1:/ieOXgiSRmc2LpZ9kCnvtXagh/QM88prKpisVNLwrjg=
+github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240408095526-357d8fffa034 h1:LDWJWy545zW7KsZ2d2d+J5mJJK5eX/pL7mnSqn63PH4=
+github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240408095526-357d8fffa034/go.mod h1:/ieOXgiSRmc2LpZ9kCnvtXagh/QM88prKpisVNLwrjg=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240404123425-54f145c97484 h1:PleqKcc38K3NxJEF8lgZEphEfBkAqRFwtspvv5yq5SM=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240404123425-54f145c97484/go.mod h1:ejPUK2xqh49WTnrLBPJyBAkMn3ZizO9pai39Aufg6C0=
 github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240403143013-74e2f3cc4015 h1:IYvBU6uEbGb0zXqVjDW2DuXPmQBcEZ8ssc3xAOY2/FY=
@@ -136,8 +136,8 @@ github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240404163736-a2d
 github.com/openstack-k8s-operators/nova-operator/api v0.3.1-0.20240404163736-a2d67e46f9f2/go.mod h1:qTPC7HGMWkxan3Z3YD5/cgw8kWraEW5ikdrKZ76XpBw=
 github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240404073049-a8b012482299 h1:G53Kd5koCQn0nUfAvEcvkDZ4ik885sXuuG+5nazdQXA=
 github.com/openstack-k8s-operators/octavia-operator/api v0.3.1-0.20240404073049-a8b012482299/go.mod h1:EZymlUAhQzGNIAGrpGZ5P6oqfq2IhqY2lNPKLG9iKh8=
-github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240405191225-a61ca8697bf2 h1:bSaKuBQAl1hwcDmDDsygjbMIbnfRXb+5gGSa7NCdMQ8=
-github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240405191225-a61ca8697bf2/go.mod h1:LlYu56B20n7SQPqgKaOsqXb3qNcjtR7Gd7ppYwz60kk=
+github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240409165939-6e7f030b1a88 h1:cmQ5s/qrmWnb9cXEcjj+uVMU9GXrchzafjLgxQYH0MA=
+github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.3.1-0.20240409165939-6e7f030b1a88/go.mod h1:av9cDGF4mhKDKy0/u9zTAK1253Ubx+LrPrCpE4i16mM=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20240403043315-77086641d3fd h1:jqRNpIY3sPV1o/F/SmVzo2FFIkdS64gpMDOn/wTtBE4=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.3.1-0.20240403043315-77086641d3fd/go.mod h1:EqjDBKsxNSU9p+Cu5XNAr5ETxpDOJ2oV/EaxB8hKj8Q=
 github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240409005731-765fc25c55d9 h1:8Qx/czqE2YAkR3TIFGuluPfVGrQpwtxmlEbxrWbw25M=


### PR DESCRIPTION
With TLS enabled by default, metadata agent fails without https://github.com/openstack-k8s-operators/edpm-ansible/pull/615, so need to bump ansibleee-operator.