### PR TITLE
Add test operator into the openstack-operator-index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240529171513-a5b0bf43b21f
 	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240523121736-379011b2cfac
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240529090522-c780bd90b147
+	github.com/openstack-k8s-operators/test-operator/api v0.0.0-20240425083108-038639a6a905
 	github.com/operator-framework/api v0.20.0
 	github.com/rabbitmq/cluster-operator/v2 v2.6.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240523121736-37
 github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240523121736-379011b2cfac/go.mod h1:qCO/0ZLhijlvPbeMKThUqIZWely/0zoaWXFFqTuovhY=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240529090522-c780bd90b147 h1:+X4c8beJnrdFwLX67Y7vK+7hWp1svRp4hT2hTdNP/b8=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240529090522-c780bd90b147/go.mod h1:ADN4s09xZpxhnmjD5s0gcRIOm73IUwA6kpimioiGIAI=
+github.com/openstack-k8s-operators/test-operator/api v0.0.0-20240425083108-038639a6a905 h1:4c1fJGWFKwloFniPUj/o9yO/eFk5OZt+hYe5VaBKF5g=
+github.com/openstack-k8s-operators/test-operator/api v0.0.0-20240425083108-038639a6a905/go.mod h1:UgqzIVmPod3EOAwoaiB4nXSpyOO5NI2GJKAwjLi+VzU=
 github.com/operator-framework/api v0.20.0 h1:A2YCRhr+6s0k3pRJacnwjh1Ue8BqjIGuQ2jvPg9XCB4=
 github.com/operator-framework/api v0.20.0/go.mod h1:rXPOhrQ6mMeXqCmpDgt1ALoar9ZlHL+Iy5qut9R99a4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/main.go
+++ b/main.go
@@ -53,6 +53,9 @@ import (
 	placementv1 "github.com/openstack-k8s-operators/placement-operator/api/v1beta1"
 	swiftv1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
+	// Note(lpiwowar): Please, do not remove! This import is necessary in order
+	// to make the test-operator part of the openstack-operator-index.
+	_ "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
 	rabbitmqclusterv2 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 


### PR DESCRIPTION
This patch adds the test-operator into the openstack-operator-index.
Up until now the test-operator had its own index called
test-operator-index [1].

[1] https://quay.io/repository/openstack-k8s-operators/test-operator-index