### PR TITLE
Add CeilometerProxy image

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17243,6 +17243,8 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
+                  ceilometerProxyImage:
+                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:

--- a/apis/bases/core.openstack.org_openstackversions.yaml
+++ b/apis/bases/core.openstack.org_openstackversions.yaml
@@ -67,6 +67,8 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
+                  ceilometerProxyImage:
+                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:
@@ -258,6 +260,8 @@ spec:
                       type: string
                     ceilometerNotificationImage:
                       type: string
+                    ceilometerProxyImage:
+                      type: string
                     ceilometerSgcoreImage:
                       type: string
                     cinderAPIImage:
@@ -413,6 +417,8 @@ spec:
                   ceilometerIpmiImage:
                     type: string
                   ceilometerNotificationImage:
+                    type: string
+                  ceilometerProxyImage:
                     type: string
                   ceilometerSgcoreImage:
                     type: string

--- a/apis/core/v1beta1/openstackversion_types.go
+++ b/apis/core/v1beta1/openstackversion_types.go
@@ -83,6 +83,7 @@ type ContainerTemplate struct {
 	CeilometerIpmiImage           *string `json:"ceilometerIpmiImage,omitempty"`
 	CeilometerNotificationImage   *string `json:"ceilometerNotificationImage,omitempty"`
 	CeilometerSgcoreImage         *string `json:"ceilometerSgcoreImage,omitempty"`
+	CeilometerProxyImage          *string `json:"ceilometerProxyImage,omitempty"`
 	CinderAPIImage                *string `json:"cinderAPIImage,omitempty"`
 	CinderBackupImage             *string `json:"cinderBackupImage,omitempty"`
 	CinderSchedulerImage          *string `json:"cinderSchedulerImage,omitempty"`

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -279,6 +279,11 @@ func (in *ContainerTemplate) DeepCopyInto(out *ContainerTemplate) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.CeilometerProxyImage != nil {
+		in, out := &in.CeilometerProxyImage, &out.CeilometerProxyImage
+		*out = new(string)
+		**out = **in
+	}
 	if in.CinderAPIImage != nil {
 		in, out := &in.CinderAPIImage, &out.CinderAPIImage
 		*out = new(string)

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17243,6 +17243,8 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
+                  ceilometerProxyImage:
+                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:

--- a/config/crd/bases/core.openstack.org_openstackversions.yaml
+++ b/config/crd/bases/core.openstack.org_openstackversions.yaml
@@ -67,6 +67,8 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
+                  ceilometerProxyImage:
+                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:
@@ -258,6 +260,8 @@ spec:
                       type: string
                     ceilometerNotificationImage:
                       type: string
+                    ceilometerProxyImage:
+                      type: string
                     ceilometerSgcoreImage:
                       type: string
                     cinderAPIImage:
@@ -413,6 +417,8 @@ spec:
                   ceilometerIpmiImage:
                     type: string
                   ceilometerNotificationImage:
+                    type: string
+                  ceilometerProxyImage:
                     type: string
                   ceilometerSgcoreImage:
                     type: string

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -34,6 +34,7 @@ export RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT=quay.io/podified-antel
 export RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
 export RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
 export RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT=quay.io/infrawatch/sg-core:current-podified
+export RELATED_IMAGE_CEILOMETER_PROXY_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
 export RELATED_IMAGE_AODH_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
 export RELATED_IMAGE_AODH_EVALUATOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-evaluator:current-podified
 export RELATED_IMAGE_AODH_NOTIFIER_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-notifier:current-podified

--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -238,6 +238,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		telemetry.Spec.Ceilometer.IpmiImage = *version.Status.ContainerImages.CeilometerIpmiImage
 		telemetry.Spec.Ceilometer.NotificationImage = *version.Status.ContainerImages.CeilometerNotificationImage
 		telemetry.Spec.Ceilometer.SgCoreImage = *version.Status.ContainerImages.CeilometerSgcoreImage
+		telemetry.Spec.Ceilometer.ProxyImage = *version.Status.ContainerImages.CeilometerProxyImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.APIImage = *version.Status.ContainerImages.AodhAPIImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.EvaluatorImage = *version.Status.ContainerImages.AodhEvaluatorImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.NotifierImage = *version.Status.ContainerImages.AodhNotifierImage
@@ -284,6 +285,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Status.ContainerImages.CeilometerIpmiImage = version.Status.ContainerImages.CeilometerIpmiImage
 		instance.Status.ContainerImages.CeilometerNotificationImage = version.Status.ContainerImages.CeilometerNotificationImage
 		instance.Status.ContainerImages.CeilometerSgcoreImage = version.Status.ContainerImages.CeilometerSgcoreImage
+		instance.Status.ContainerImages.CeilometerProxyImage = version.Status.ContainerImages.CeilometerProxyImage
 		instance.Status.ContainerImages.AodhAPIImage = version.Status.ContainerImages.AodhAPIImage
 		instance.Status.ContainerImages.AodhEvaluatorImage = version.Status.ContainerImages.AodhEvaluatorImage
 		instance.Status.ContainerImages.AodhNotifierImage = version.Status.ContainerImages.AodhNotifierImage

--- a/pkg/openstack/version.go
+++ b/pkg/openstack/version.go
@@ -91,6 +91,7 @@ func GetContainerImages(ctx context.Context, defaults *corev1beta1.ContainerDefa
 			CeilometerIpmiImage:           getImg(instance.Spec.CustomContainerImages.CeilometerIpmiImage, defaults.CeilometerIpmiImage),
 			CeilometerNotificationImage:   getImg(instance.Spec.CustomContainerImages.CeilometerNotificationImage, defaults.CeilometerNotificationImage),
 			CeilometerSgcoreImage:         getImg(instance.Spec.CustomContainerImages.CeilometerSgcoreImage, defaults.CeilometerSgcoreImage),
+			CeilometerProxyImage:          getImg(instance.Spec.CustomContainerImages.CeilometerProxyImage, defaults.CeilometerProxyImage),
 			CinderAPIImage:                getImg(instance.Spec.CustomContainerImages.CinderAPIImage, defaults.CinderAPIImage),
 			CinderBackupImage:             getImg(instance.Spec.CustomContainerImages.CinderBackupImage, defaults.CinderBackupImage),
 			CinderSchedulerImage:          getImg(instance.Spec.CustomContainerImages.CinderSchedulerImage, defaults.CinderSchedulerImage),

--- a/tests/functional/openstackversion_controller_test.go
+++ b/tests/functional/openstackversion_controller_test.go
@@ -74,6 +74,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(version.Status.ContainerImages.CeilometerComputeImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CeilometerNotificationImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CeilometerSgcoreImage).ShouldNot(BeNil())
+				g.Expect(version.Status.ContainerImages.CeilometerProxyImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CinderAPIImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CinderBackupImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CinderSchedulerImage).ShouldNot(BeNil())


### PR DESCRIPTION
The ceilometer proxy image (which is used for TLS termination) is missing.

rh-jira: https://issues.redhat.com/browse/OSPRH-6400