### PR TITLE
Restore lastTransitionTime of ReadyCondition

### DIFF
--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -160,7 +160,6 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
 		// update the Ready condition based on the sub conditions
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
@@ -173,6 +172,8 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 			instance.Status.Conditions.Set(
 				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
+
+		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
 
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {

--- a/controllers/core/openstackversion_controller.go
+++ b/controllers/core/openstackversion_controller.go
@@ -128,8 +128,6 @@ func (r *OpenStackVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		condition.RestoreLastTransitionTimes(
-			&instance.Status.Conditions, savedConditions)
 		// update the Ready condition based on the sub conditions
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
@@ -142,6 +140,9 @@ func (r *OpenStackVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			instance.Status.Conditions.Set(
 				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
+
+		condition.RestoreLastTransitionTimes(
+			&instance.Status.Conditions, savedConditions)
 
 		err := versionHelper.PatchInstance(ctx, instance)
 		if err != nil {


### PR DESCRIPTION
We placed the RestoreLastTransitionTimes before we decide if the
ReadyCondition needs to be set to True or not. This causes that the
lastTransitionTime of the ReadyCondition changes even if nothing is
actually changed during the reconciliation. The OpenStackControlPlane
and OpenStackVersion resources watching each other creating a reconcile
loop.

This change moves the RestoreLastTransitionTimes to happen after the
ReadyCondition status is finally set.
