### PR TITLE
Version: Create helper before manipulating instance

### DIFF
--- a/controllers/core/openstackversion_controller.go
+++ b/controllers/core/openstackversion_controller.go
@@ -105,15 +105,6 @@ func (r *OpenStackVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	isNewInstance := instance.Status.Conditions == nil
-	if isNewInstance {
-		instance.Status.Conditions = condition.Conditions{}
-	}
-
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
-	// when a condition's state doesn't change.
-	savedConditions := instance.Status.Conditions.DeepCopy()
-
 	versionHelper, err := helper.NewHelper(
 		instance,
 		r.Client,
@@ -125,6 +116,15 @@ func (r *OpenStackVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Log.Error(err, "unable to create helper")
 		return ctrl.Result{}, err
 	}
+
+	isNewInstance := instance.Status.Conditions == nil
+	if isNewInstance {
+		instance.Status.Conditions = condition.Conditions{}
+	}
+
+	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// when a condition's state doesn't change.
+	savedConditions := instance.Status.Conditions.DeepCopy()
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {


### PR DESCRIPTION
The helper.NewHelper creates snapshot of the instance being reconciled
and PatchInstance at the end of the reconcile loop uses this to generate
the Patch to persist the changes done by the reconciler. Therefore the
helper needs to be created before any changes on the instance. This is
fixed now to avoid loosing in memory changes.
