### PR TITLE
[tls] introduce dedicated CA for libvirt and update default cert durations

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17103,27 +17103,27 @@ spec:
                 default:
                   ingress:
                     ca:
-                      duration: 43800h
+                      duration: 87600h
                     cert:
-                      duration: 8760h
+                      duration: 10950h
                     enabled: true
                   podLevel:
                     enabled: true
                     internal:
                       ca:
-                        duration: 43800h
+                        duration: 87600h
                       cert:
-                        duration: 8760h
+                        duration: 10950h
                     libvirt:
                       ca:
-                        duration: 43800h
+                        duration: 87600h
                       cert:
-                        duration: 17520h
+                        duration: 43800h
                     ovn:
                       ca:
-                        duration: 43800h
+                        duration: 87600h
                       cert:
-                        duration: 8760h
+                        duration: 10950h
                 properties:
                   caBundleSecretName:
                     type: string

--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17114,6 +17114,11 @@ spec:
                         duration: 43800h
                       cert:
                         duration: 8760h
+                    libvirt:
+                      ca:
+                        duration: 43800h
+                      cert:
+                        duration: 17520h
                     ovn:
                       ca:
                         duration: 43800h
@@ -17148,6 +17153,25 @@ spec:
                       enabled:
                         type: boolean
                       internal:
+                        properties:
+                          ca:
+                            properties:
+                              customIssuer:
+                                type: string
+                              duration:
+                                type: string
+                              renewBefore:
+                                type: string
+                            type: object
+                          cert:
+                            properties:
+                              duration:
+                                type: string
+                              renewBefore:
+                                type: string
+                            type: object
+                        type: object
+                      libvirt:
                         properties:
                           ca:
                             properties:

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -56,6 +56,8 @@ const (
 
 	// OvnDbCaName -
 	OvnDbCaName = tls.DefaultCAPrefix + "ovn"
+	// LibvirtCaName -
+	LibvirtCaName = tls.DefaultCAPrefix + "libvirt"
 )
 
 // OpenStackControlPlaneSpec defines the desired state of OpenStackControlPlane
@@ -78,7 +80,7 @@ type OpenStackControlPlaneSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default={ingress: {enabled: true, ca: {duration: "43800h"}, cert: {duration: "8760h"}}, podLevel: {enabled: true, internal:{ca: {duration: "43800h"}, cert: {duration: "8760h"}}, ovn: {ca: {duration: "43800h"}, cert: {duration: "8760h"}}}}
+	// +kubebuilder:default={ingress: {enabled: true, ca: {duration: "43800h"}, cert: {duration: "8760h"}}, podLevel: {enabled: true, internal:{ca: {duration: "43800h"}, cert: {duration: "8760h"}}, libvirt: {ca: {duration: "43800h"}, cert: {duration: "17520h"}}, ovn: {ca: {duration: "43800h"}, cert: {duration: "8760h"}}}}
 	// TLS - Parameters related to the TLS
 	TLS TLSSection `json:"tls"`
 
@@ -226,6 +228,11 @@ type TLSPodLevelConfig struct {
 	// Internal - default CA used for all OpenStackControlPlane and OpenStackDataplane endpoints,
 	// except OVN related CA and certs
 	Internal CertSection `json:"internal,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Libvirt - CA used for libvirt/qemu services on OpenStackControlPlane and OpenStackDataplane
+	Libvirt CertSection `json:"libvirt,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
@@ -881,4 +888,14 @@ func (instance OpenStackControlPlane) GetOvnIssuer() string {
 	}
 
 	return OvnDbCaName
+}
+
+// GetLibvirtIssuer - returns the libvirt CA issuer name or custom if configured
+func (instance OpenStackControlPlane) GetLibvirtIssuer() string {
+	// use custom issuer if set
+	if instance.Spec.TLS.PodLevel.Libvirt.Ca.IsCustomIssuer() {
+		return *instance.Spec.TLS.PodLevel.Libvirt.Ca.CustomIssuer
+	}
+
+	return LibvirtCaName
 }

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -80,7 +80,7 @@ type OpenStackControlPlaneSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default={ingress: {enabled: true, ca: {duration: "43800h"}, cert: {duration: "8760h"}}, podLevel: {enabled: true, internal:{ca: {duration: "43800h"}, cert: {duration: "8760h"}}, libvirt: {ca: {duration: "43800h"}, cert: {duration: "17520h"}}, ovn: {ca: {duration: "43800h"}, cert: {duration: "8760h"}}}}
+	// +kubebuilder:default={ingress: {enabled: true, ca: {duration: "87600h"}, cert: {duration: "10950h"}}, podLevel: {enabled: true, internal:{ca: {duration: "87600h"}, cert: {duration: "10950h"}}, libvirt: {ca: {duration: "87600h"}, cert: {duration: "43800h"}}, ovn: {ca: {duration: "87600h"}, cert: {duration: "10950h"}}}}
 	// TLS - Parameters related to the TLS
 	TLS TLSSection `json:"tls"`
 

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1400,6 +1400,7 @@ func (in *TLSIngressConfig) DeepCopy() *TLSIngressConfig {
 func (in *TLSPodLevelConfig) DeepCopyInto(out *TLSPodLevelConfig) {
 	*out = *in
 	in.Internal.DeepCopyInto(&out.Internal)
+	in.Libvirt.DeepCopyInto(&out.Libvirt)
 	in.Ovn.DeepCopyInto(&out.Ovn)
 }
 

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17103,27 +17103,27 @@ spec:
                 default:
                   ingress:
                     ca:
-                      duration: 43800h
+                      duration: 87600h
                     cert:
-                      duration: 8760h
+                      duration: 10950h
                     enabled: true
                   podLevel:
                     enabled: true
                     internal:
                       ca:
-                        duration: 43800h
+                        duration: 87600h
                       cert:
-                        duration: 8760h
+                        duration: 10950h
                     libvirt:
                       ca:
-                        duration: 43800h
+                        duration: 87600h
                       cert:
-                        duration: 17520h
+                        duration: 43800h
                     ovn:
                       ca:
-                        duration: 43800h
+                        duration: 87600h
                       cert:
-                        duration: 8760h
+                        duration: 10950h
                 properties:
                   caBundleSecretName:
                     type: string

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17114,6 +17114,11 @@ spec:
                         duration: 43800h
                       cert:
                         duration: 8760h
+                    libvirt:
+                      ca:
+                        duration: 43800h
+                      cert:
+                        duration: 17520h
                     ovn:
                       ca:
                         duration: 43800h
@@ -17148,6 +17153,25 @@ spec:
                       enabled:
                         type: boolean
                       internal:
+                        properties:
+                          ca:
+                            properties:
+                              customIssuer:
+                                type: string
+                              duration:
+                                type: string
+                              renewBefore:
+                                type: string
+                            type: object
+                          cert:
+                            properties:
+                              duration:
+                                type: string
+                              renewBefore:
+                                type: string
+                            type: object
+                        type: object
+                      libvirt:
                         properties:
                           ca:
                             properties:

--- a/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
@@ -435,6 +435,16 @@ spec:
       - description: Cert - defines details for cert config
         displayName: Cert
         path: tls.podLevel.internal.cert
+      - description: Libvirt - CA used for libvirt/qemu services on OpenStackControlPlane
+          and OpenStackDataplane
+        displayName: Libvirt
+        path: tls.podLevel.libvirt
+      - description: Ca - defines details for CA cert config
+        displayName: Ca
+        path: tls.podLevel.libvirt.ca
+      - description: Cert - defines details for cert config
+        displayName: Cert
+        path: tls.podLevel.libvirt.cert
       - description: Ovn - CA used for all OVN services on OpenStackControlPlane and
           OpenStackDataplane
         displayName: Ovn

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -53,6 +53,7 @@ type Names struct {
 	RootCAPublicName            types.NamespacedName
 	RootCAInternalName          types.NamespacedName
 	RootCAOvnName               types.NamespacedName
+	RootCALibvirtName           types.NamespacedName
 	SelfSignedIssuerName        types.NamespacedName
 	CustomIssuerName            types.NamespacedName
 	CustomServiceCertSecretName types.NamespacedName
@@ -83,6 +84,9 @@ func CreateNames(openstackControlplaneName types.NamespacedName) Names {
 		RootCAOvnName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,
 			Name:      "rootca-ovn"},
+		RootCALibvirtName: types.NamespacedName{
+			Namespace: openstackControlplaneName.Namespace,
+			Name:      "rootca-libvirt"},
 		SelfSignedIssuerName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,
 			Name:      "selfsigned-issuer"},

--- a/tests/functional/openstackoperator_controller_test.go
+++ b/tests/functional/openstackoperator_controller_test.go
@@ -61,6 +61,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 		DeferCleanup(k8sClient.Delete, ctx, CreateCertSecret(names.RootCAPublicName))
 		DeferCleanup(k8sClient.Delete, ctx, CreateCertSecret(names.RootCAInternalName))
 		DeferCleanup(k8sClient.Delete, ctx, CreateCertSecret(names.RootCAOvnName))
+		DeferCleanup(k8sClient.Delete, ctx, CreateCertSecret(names.RootCALibvirtName))
 		// create cert secrets for galera instances
 		DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.DBCertName))
 		DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.DBCell1CertName))
@@ -167,6 +168,19 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(issuer).Should(Not(BeNil()))
 				g.Expect(issuer.Spec.CA.SecretName).Should(Equal(names.RootCAOvnName.Name))
 			}, timeout, interval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				// ca cert
+				cert := crtmgr.GetCert(names.RootCALibvirtName)
+				g.Expect(cert).Should(Not(BeNil()))
+				g.Expect(cert.Spec.CommonName).Should(Equal(names.RootCALibvirtName.Name))
+				g.Expect(cert.Spec.IsCA).Should(BeTrue())
+				g.Expect(cert.Spec.IssuerRef.Name).Should(Equal(names.SelfSignedIssuerName.Name))
+				g.Expect(cert.Spec.SecretName).Should(Equal(names.RootCALibvirtName.Name))
+				// issuer
+				issuer := crtmgr.GetIssuer(names.RootCALibvirtName)
+				g.Expect(issuer).Should(Not(BeNil()))
+				g.Expect(issuer.Spec.CA.SecretName).Should(Equal(names.RootCALibvirtName.Name))
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("should create full ca bundle", func() {
@@ -176,6 +190,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 			crtmgr.GetIssuer(names.RootCAInternalName)
 			crtmgr.GetCert(names.RootCAOvnName)
 			crtmgr.GetIssuer(names.RootCAOvnName)
+			crtmgr.GetCert(names.RootCALibvirtName)
+			crtmgr.GetIssuer(names.RootCALibvirtName)
 
 			Eventually(func(g Gomega) {
 				th.GetSecret(names.RootCAPublicName)
@@ -357,6 +373,19 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(issuer).Should(Not(BeNil()))
 				g.Expect(issuer.Spec.CA.SecretName).Should(Equal(names.RootCAOvnName.Name))
 			}, timeout, interval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				// ca cert
+				cert := crtmgr.GetCert(names.RootCALibvirtName)
+				g.Expect(cert).Should(Not(BeNil()))
+				g.Expect(cert.Spec.CommonName).Should(Equal(names.RootCALibvirtName.Name))
+				g.Expect(cert.Spec.IsCA).Should(BeTrue())
+				g.Expect(cert.Spec.IssuerRef.Name).Should(Equal(names.SelfSignedIssuerName.Name))
+				g.Expect(cert.Spec.SecretName).Should(Equal(names.RootCALibvirtName.Name))
+				// issuer
+				issuer := crtmgr.GetIssuer(names.RootCALibvirtName)
+				g.Expect(issuer).Should(Not(BeNil()))
+				g.Expect(issuer.Spec.CA.SecretName).Should(Equal(names.RootCALibvirtName.Name))
+			}, timeout, interval).Should(Succeed())
 
 			th.ExpectCondition(
 				names.OpenStackControlplaneName,
@@ -380,6 +409,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 			crtmgr.GetIssuer(names.RootCAInternalName)
 			crtmgr.GetCert(names.RootCAOvnName)
 			crtmgr.GetIssuer(names.RootCAOvnName)
+			crtmgr.GetCert(names.RootCALibvirtName)
+			crtmgr.GetIssuer(names.RootCALibvirtName)
 
 			Eventually(func(g Gomega) {
 				th.GetSecret(names.RootCAPublicName)
@@ -548,6 +579,19 @@ var _ = Describe("OpenStackOperator controller", func() {
 					issuer := crtmgr.GetIssuer(names.RootCAOvnName)
 					g.Expect(issuer).Should(Not(BeNil()))
 					g.Expect(issuer.Spec.CA.SecretName).Should(Equal(names.RootCAOvnName.Name))
+				}, timeout, interval).Should(Succeed())
+				Eventually(func(g Gomega) {
+					// ca cert
+					cert := crtmgr.GetCert(names.RootCALibvirtName)
+					g.Expect(cert).Should(Not(BeNil()))
+					g.Expect(cert.Spec.CommonName).Should(Equal(names.RootCALibvirtName.Name))
+					g.Expect(cert.Spec.IsCA).Should(BeTrue())
+					g.Expect(cert.Spec.IssuerRef.Name).Should(Equal(names.SelfSignedIssuerName.Name))
+					g.Expect(cert.Spec.SecretName).Should(Equal(names.RootCALibvirtName.Name))
+					// issuer
+					issuer := crtmgr.GetIssuer(names.RootCALibvirtName)
+					g.Expect(issuer).Should(Not(BeNil()))
+					g.Expect(issuer.Spec.CA.SecretName).Should(Equal(names.RootCALibvirtName.Name))
 				}, timeout, interval).Should(Succeed())
 
 				th.ExpectCondition(

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -174,22 +174,27 @@ spec:
   tls:
     ingress:
       ca:
-        duration: 43800h0m0s
+        duration: 87600h0m0s
       cert:
-        duration: 8760h0m0s
+        duration: 10950h0m0s
       enabled: true
     podLevel:
       enabled: true
       internal:
         ca:
-          duration: 43800h0m0s
+          duration: 87600h0m0s
         cert:
-          duration: 8760h0m0s
+          duration: 10950h0m0s
+      libvirt:
+        ca:
+          duration: 87600h0m0s
+        cert:
+          duration: 43800h0m0s
       ovn:
         ca:
-          duration: 43800h0m0s
+          duration: 87600h0m0s
         cert:
-          duration: 8760h0m0s
+          duration: 10950h0m0s
 status:
   conditions:
   - message: Setup complete

--- a/tests/kuttl/tests/collapsed/01-assert-collapsed-cell.yaml
+++ b/tests/kuttl/tests/collapsed/01-assert-collapsed-cell.yaml
@@ -127,22 +127,27 @@ spec:
   tls:
     ingress:
       ca:
-        duration: 43800h0m0s
+        duration: 87600h0m0s
       cert:
-        duration: 8760h0m0s
+        duration: 10950h0m0s
       enabled: true
     podLevel:
       enabled: true
       internal:
         ca:
-          duration: 43800h0m0s
+          duration: 87600h0m0s
         cert:
-          duration: 8760h0m0s
+          duration: 10950h0m0s
+      libvirt:
+        ca:
+          duration: 87600h0m0s
+        cert:
+          duration: 43800h0m0s
       ovn:
         ca:
-          duration: 43800h0m0s
+          duration: 87600h0m0s
         cert:
-          duration: 8760h0m0s
+          duration: 10950h0m0s
 status:
   conditions:
   - message: Setup complete

--- a/tests/kuttl/tests/galera-3replicas/01-assert-galera-3replicas.yaml
+++ b/tests/kuttl/tests/galera-3replicas/01-assert-galera-3replicas.yaml
@@ -130,22 +130,27 @@ spec:
   tls:
     ingress:
       ca:
-        duration: 43800h0m0s
+        duration: 87600h0m0s
       cert:
-        duration: 8760h0m0s
+        duration: 10950h0m0s
       enabled: true
     podLevel:
       enabled: true
       internal:
         ca:
-          duration: 43800h0m0s
+          duration: 87600h0m0s
         cert:
-          duration: 8760h0m0s
+          duration: 10950h0m0s
+      libvirt:
+        ca:
+          duration: 87600h0m0s
+        cert:
+          duration: 43800h0m0s
       ovn:
         ca:
-          duration: 43800h0m0s
+          duration: 87600h0m0s
         cert:
-          duration: 8760h0m0s
+          duration: 10950h0m0s
 status:
   conditions:
   - message: Setup complete

--- a/tests/kuttl/tests/galera-basic/01-assert-galera.yaml
+++ b/tests/kuttl/tests/galera-basic/01-assert-galera.yaml
@@ -149,22 +149,27 @@ spec:
   tls:
     ingress:
       ca:
-        duration: 43800h0m0s
+        duration: 87600h0m0s
       cert:
-        duration: 8760h0m0s
+        duration: 10950h0m0s
       enabled: true
     podLevel:
       enabled: true
       internal:
         ca:
-          duration: 43800h0m0s
+          duration: 87600h0m0s
         cert:
-          duration: 8760h0m0s
+          duration: 10950h0m0s
+      libvirt:
+        ca:
+          duration: 87600h0m0s
+        cert:
+          duration: 43800h0m0s
       ovn:
         ca:
-          duration: 43800h0m0s
+          duration: 87600h0m0s
         cert:
-          duration: 8760h0m0s
+          duration: 10950h0m0s
 status:
   conditions:
   - message: Setup complete


### PR DESCRIPTION
Adds a new CA dedicated for libvirt. This will be used for any libvirt/qemu certs on the dataplane side and in nova novncproxy for vencrypt to secure traffic to the vnc server.

Also updates CA/cert default duration
* CAs to be valid for 10 years
* libvirt certs valid for 5 years
* all other certs valid for 15months. Default renewBefore is 90days. With 15months the certs start to get rotated after one year.

Jira: [OSPRH-6552](https://issues.redhat.com//browse/OSPRH-6552)