### PR TITLE
sub resource ready condition updates/fixes

### DIFF
--- a/apis/client/v1beta1/openstackclient_types.go
+++ b/apis/client/v1beta1/openstackclient_types.go
@@ -92,6 +92,11 @@ func init() {
 	SchemeBuilder.Register(&OpenStackClient{}, &OpenStackClientList{})
 }
 
+// IsReady - returns true if OpenStackClient is reconciled successfully
+func (instance OpenStackClient) IsReady() bool {
+	return instance.Status.Conditions.IsTrue(OpenStackClientReadyCondition)
+}
+
 // RbacConditionsSet - set the conditions for the rbac object
 func (instance OpenStackClient) RbacConditionsSet(c *condition.Condition) {
 	instance.Status.Conditions.Set(c)

--- a/pkg/openstack/designate.go
+++ b/pkg/openstack/designate.go
@@ -149,7 +149,7 @@ func ReconcileDesignate(ctx context.Context, instance *corev1beta1.OpenStackCont
 		helper.GetLogger().Info(fmt.Sprintf("Designate %s - %s", designate.Name, op))
 	}
 
-	if designate.IsReady() { //FIXME ObservedGeneration
+	if designate.Status.ObservedGeneration == designate.Generation && designate.IsReady() {
 		instance.Status.ContainerImages.DesignateAPIImage = version.Status.ContainerImages.DesignateAPIImage
 		instance.Status.ContainerImages.DesignateCentralImage = version.Status.ContainerImages.DesignateCentralImage
 		instance.Status.ContainerImages.DesignateMdnsImage = version.Status.ContainerImages.DesignateMdnsImage

--- a/pkg/openstack/dnsmasq.go
+++ b/pkg/openstack/dnsmasq.go
@@ -62,7 +62,7 @@ func ReconcileDNSMasqs(ctx context.Context, instance *corev1beta1.OpenStackContr
 		Log.Info(fmt.Sprintf("dnsmasq %s - %s", dnsmasq.Name, op))
 	}
 
-	if dnsmasq.IsReady() { // FIXME ObservedGeneration
+	if dnsmasq.Status.ObservedGeneration == dnsmasq.Generation && dnsmasq.IsReady() {
 		instance.Status.ContainerImages.InfraDnsmasqImage = version.Status.ContainerImages.InfraDnsmasqImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneDNSReadyCondition, corev1beta1.OpenStackControlPlaneDNSReadyMessage)
 	} else {

--- a/pkg/openstack/galera.go
+++ b/pkg/openstack/galera.go
@@ -173,7 +173,7 @@ func reconcileGalera(
 		Log.Info(fmt.Sprintf("Galera %s - %s", galera.Name, op))
 	}
 
-	if galera.IsReady() { //FIXME ObservedGeneration
+	if galera.Status.ObservedGeneration == galera.Generation && galera.IsReady() {
 		instance.Status.ContainerImages.MariadbImage = version.Status.ContainerImages.MariadbImage
 		return galeraReady, nil
 	}

--- a/pkg/openstack/heat.go
+++ b/pkg/openstack/heat.go
@@ -178,7 +178,7 @@ func ReconcileHeat(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		Log.Info(fmt.Sprintf("heat %s - %s", heat.Name, op))
 	}
 
-	if heat.IsReady() { //FIXME ObservedGeneration
+	if heat.Status.ObservedGeneration == heat.Generation && heat.IsReady() {
 		instance.Status.ContainerImages.HeatAPIImage = version.Status.ContainerImages.HeatAPIImage
 		instance.Status.ContainerImages.HeatCfnapiImage = version.Status.ContainerImages.HeatCfnapiImage
 		instance.Status.ContainerImages.HeatEngineImage = version.Status.ContainerImages.HeatEngineImage

--- a/pkg/openstack/horizon.go
+++ b/pkg/openstack/horizon.go
@@ -131,7 +131,7 @@ func ReconcileHorizon(ctx context.Context, instance *corev1beta1.OpenStackContro
 		Log.Info(fmt.Sprintf("Horizon %s - %s", horizon.Name, op))
 	}
 
-	if horizon.IsReady() { //FIXME ObservedGeneration
+	if horizon.Status.ObservedGeneration == horizon.Generation && horizon.IsReady() {
 		instance.Status.ContainerImages.HorizonImage = version.Status.ContainerImages.HorizonImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneHorizonReadyCondition, corev1beta1.OpenStackControlPlaneHorizonReadyMessage)
 	} else {

--- a/pkg/openstack/ironic.go
+++ b/pkg/openstack/ironic.go
@@ -176,7 +176,7 @@ func ReconcileIronic(ctx context.Context, instance *corev1beta1.OpenStackControl
 		Log.Info(fmt.Sprintf("ironic %s - %s", ironic.Name, op))
 	}
 
-	if ironic.IsReady() { //FIXME ObservedGeneration
+	if ironic.Status.ObservedGeneration == ironic.Generation && ironic.IsReady() {
 		instance.Status.ContainerImages.IronicAPIImage = version.Status.ContainerImages.IronicAPIImage
 		instance.Status.ContainerImages.IronicConductorImage = version.Status.ContainerImages.IronicConductorImage
 		instance.Status.ContainerImages.IronicInspectorImage = version.Status.ContainerImages.IronicInspectorImage

--- a/pkg/openstack/memcached.go
+++ b/pkg/openstack/memcached.go
@@ -213,7 +213,7 @@ func reconcileMemcached(
 		Log.Info(fmt.Sprintf("Memcached %s - %s", memcached.Name, op))
 	}
 
-	if memcached.IsReady() { //FIXME ObservedGeneration
+	if memcached.Status.ObservedGeneration == memcached.Generation && memcached.IsReady() {
 		instance.Status.ContainerImages.InfraMemcachedImage = version.Status.ContainerImages.InfraMemcachedImage
 		return memcachedReady, ctrl.Result{}, nil
 	}

--- a/pkg/openstack/neutron.go
+++ b/pkg/openstack/neutron.go
@@ -177,7 +177,7 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 		Log.Info(fmt.Sprintf("neutronAPI %s - %s", neutronAPI.Name, op))
 	}
 
-	if neutronAPI.IsReady() { //FIXME ObservedGeneration
+	if neutronAPI.Status.ObservedGeneration == neutronAPI.Generation && neutronAPI.IsReady() {
 		instance.Status.ContainerImages.NeutronAPIImage = version.Status.ContainerImages.NeutronAPIImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneNeutronReadyCondition, corev1beta1.OpenStackControlPlaneNeutronReadyMessage)
 	} else {

--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -346,7 +346,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		Log.Info(fmt.Sprintf("Nova %s - %s", nova.Name, op))
 	}
 
-	if nova.IsReady() { //FIXME ObservedGeneration
+	if nova.Status.ObservedGeneration == nova.Generation && nova.IsReady() {
 		instance.Status.ContainerImages.NovaAPIImage = version.Status.ContainerImages.NovaAPIImage
 		instance.Status.ContainerImages.NovaComputeImage = version.Status.ContainerImages.NovaComputeImage
 		instance.Status.ContainerImages.NovaConductorImage = version.Status.ContainerImages.NovaConductorImage

--- a/pkg/openstack/octavia.go
+++ b/pkg/openstack/octavia.go
@@ -185,7 +185,7 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 		helper.GetLogger().Info(fmt.Sprintf("Octavia %s - %s", octavia.Name, op))
 	}
 
-	if octavia.IsReady() { //FIXME ObservedGeneration
+	if octavia.Status.ObservedGeneration == octavia.Generation && octavia.IsReady() {
 		instance.Status.ContainerImages.OctaviaAPIImage = version.Status.ContainerImages.OctaviaAPIImage
 		instance.Status.ContainerImages.OctaviaWorkerImage = version.Status.ContainerImages.OctaviaWorkerImage
 		instance.Status.ContainerImages.OctaviaHealthmanagerImage = version.Status.ContainerImages.OctaviaHealthmanagerImage

--- a/pkg/openstack/openstackclient.go
+++ b/pkg/openstack/openstackclient.go
@@ -73,7 +73,7 @@ func ReconcileOpenStackClient(ctx context.Context, instance *corev1.OpenStackCon
 		Log.Info(fmt.Sprintf("OpenStackClient %s - %s", openstackclient.Name, op))
 	}
 
-	if openstackclient.Status.Conditions.IsTrue(clientv1.OpenStackClientReadyCondition) { //FIXME ObservedGeneration
+	if openstackclient.Status.ObservedGeneration == openstackclient.Generation && openstackclient.IsReady() {
 		Log.Info("OpenStackClient ready condition is true")
 		instance.Status.ContainerImages.OpenstackClientImage = version.Status.ContainerImages.OpenstackClientImage
 		instance.Status.Conditions.MarkTrue(corev1.OpenStackControlPlaneClientReadyCondition, corev1.OpenStackControlPlaneClientReadyMessage)

--- a/pkg/openstack/placement.go
+++ b/pkg/openstack/placement.go
@@ -130,7 +130,7 @@ func ReconcilePlacementAPI(ctx context.Context, instance *corev1beta1.OpenStackC
 		Log.Info(fmt.Sprintf("placementAPI %s - %s", placementAPI.Name, op))
 	}
 
-	if placementAPI.IsReady() {
+	if placementAPI.Status.ObservedGeneration == placementAPI.Generation && placementAPI.IsReady() {
 		instance.Status.ContainerImages.PlacementAPIImage = version.Status.ContainerImages.PlacementAPIImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlanePlacementAPIReadyCondition, corev1beta1.OpenStackControlPlanePlacementAPIReadyMessage)
 	} else {

--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -279,7 +279,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		helper.GetLogger().Info(fmt.Sprintf("%s %s - %s", telemetryName, telemetry.Name, op))
 	}
 
-	if telemetry.IsReady() { //FIXME ObservedGeneration
+	if telemetry.Status.ObservedGeneration == telemetry.Generation && telemetry.IsReady() {
 		instance.Status.ContainerImages.CeilometerCentralImage = version.Status.ContainerImages.CeilometerCentralImage
 		instance.Status.ContainerImages.CeilometerComputeImage = version.Status.ContainerImages.CeilometerComputeImage
 		instance.Status.ContainerImages.CeilometerIpmiImage = version.Status.ContainerImages.CeilometerIpmiImage


### PR DESCRIPTION
Now that all service operators have been updated we can check observed generation here before setting the ready condition of the subresource.

Jira: [OSPRH-5698](https://issues.redhat.com//browse/OSPRH-5698)
Jira: [OSPRH-6112](https://issues.redhat.com//browse/OSPRH-6112)