### PR TITLE
[ovndbs] For cert setup do not wait for dbs to be ready

### DIFF
--- a/pkg/openstack/ovn.go
+++ b/pkg/openstack/ovn.go
@@ -96,7 +96,7 @@ func ReconcileOVNDbClusters(ctx context.Context, instance *corev1beta1.OpenStack
 		}
 		dbcluster.TLS.CaBundleSecretName = instance.Status.TLS.CaBundleSecretName
 
-		if OVNDBCluster.Status.Conditions.IsTrue(condition.ExposeServiceReadyCondition) {
+		if instance.Spec.TLS.PodLevel.Enabled {
 			// create certificate for ovndbclusters
 			certRequest := certmanager.CertificateRequest{
 				IssuerName: instance.GetOvnIssuer(),
@@ -131,9 +131,7 @@ func ReconcileOVNDbClusters(ctx context.Context, instance *corev1beta1.OpenStack
 				return false, nil
 			}
 
-			if instance.Spec.TLS.PodLevel.Enabled {
-				dbcluster.TLS.SecretName = &certSecret.Name
-			}
+			dbcluster.TLS.SecretName = &certSecret.Name
 		}
 
 		Log.Info("Reconciling OVNDBCluster", "OVNDBCluster.Namespace", instance.Namespace, "OVNDBCluster.Name", name)


### PR DESCRIPTION
Currently when TLS is enabled OVNDBClusters are created first without Certs, wait for those to be ready, create certs and update ovndbclusters with tls enabled.

This causes issues as with this even with TLS enabled OVN raft is setup with local-address as non-ssl and later scale up do not work due to this. To fix this changing the conditions to create certs when TLS is enabled like other services.

Related-Issue: [OSPRH-6899](https://issues.redhat.com//browse/OSPRH-6899)