### PR TITLE
Fix rabbitmq TLS cert config

### DIFF
--- a/pkg/openstack/rabbitmq.go
+++ b/pkg/openstack/rabbitmq.go
@@ -195,7 +195,6 @@ func reconcileRabbitMQ(
 
 	hostname := fmt.Sprintf("%s.%s.svc", name, instance.Namespace)
 	tlsCert := ""
-	tlsCaCert := ""
 
 	if instance.Spec.TLS.PodLevel.Enabled {
 		certRequest := certmanager.CertificateRequest{
@@ -224,11 +223,6 @@ func reconcileRabbitMQ(
 		}
 
 		tlsCert = certSecret.Name
-
-		tlsCaCert, err = GetIssuerCertSecret(ctx, helper, instance.GetInternalIssuer(), instance.Namespace)
-		if err != nil {
-			return mqFailed, ctrlResult, err
-		}
 	}
 
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), rabbitmq, func() error {
@@ -277,7 +271,7 @@ func reconcileRabbitMQ(
 		}
 
 		if tlsCert != "" {
-			rabbitmq.Spec.TLS.CaSecretName = tlsCaCert
+			rabbitmq.Spec.TLS.CaSecretName = tlsCert
 			rabbitmq.Spec.TLS.SecretName = tlsCert
 			// disable non tls listeners
 			rabbitmq.Spec.TLS.DisableNonTLSListeners = true


### PR DESCRIPTION
When using cert-manager single secret form must be used (both TLS.SecretName and TLS.CASecretName refer to the same secret). Otherwise the CA secret clobbers the cert/key from the TLS secret.

Related: [OSPRH-6889](https://issues.redhat.com//browse/OSPRH-6889)