### PR TITLE
Generate RabbitMQ TLS config that works with FIPS

### DIFF
--- a/pkg/openstack/ca.go
+++ b/pkg/openstack/ca.go
@@ -530,8 +530,8 @@ func createRootCACertAndIssuer(
 			CommonName: caName,
 			SecretName: caName,
 			PrivateKey: &certmgrv1.CertificatePrivateKey{
-				Algorithm: "ECDSA",
-				Size:      256,
+				Algorithm: "RSA",
+				Size:      3072,
 			},
 			IssuerRef: certmgrmetav1.ObjectReference{
 				Name:  selfsignedIssuerReq.Name,


### PR DESCRIPTION
When TLS is enabled in RabbitMQ with FIPS engaged, the RabbitMQ server has to be given specific TLS options in the RabbitMQ configuration otherwise the rabbitmq Erlang application will fail to create TLS sockets with:

  {insufficient_crypto_support
     {'tlsv1.3',{versions,['tlsv1.3','tlsv1.2']}}}}}}}}}

We now reuse the same config as we had in previous versions of Openstack as they were known to work with FIPS. Moreover the configuration has to be passed as an Erlang structure to ensure the right orderning of option ssl_options.versions.

Related: [OSPRH-6889](https://issues.redhat.com//browse/OSPRH-6889)