### PR TITLE
Bump dataplane-operator api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
 	github.com/gophercloud/gophercloud v1.11.0 // indirect
+	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 // indirect
@@ -82,6 +83,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/openstack-k8s-operators/dataplane-operator v0.1.1-0.20240522210124-c85db455540c // indirect
+	github.com/openstack-k8s-operators/lib-common/modules/ansible v0.3.1-0.20240429052447-09a614506ca6 // indirect
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240429052447-09a614506ca6 // indirect
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240429052447-09a614506ca6 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gophercloud/gophercloud v1.11.0 h1:ls0O747DIq1D8SUHc7r2vI8BFbMLeLFuENaAIfEx7OM=
 github.com/gophercloud/gophercloud v1.11.0/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -100,6 +102,8 @@ github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-20240430093730-9
 github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-20240430093730-98d5b0130ca1/go.mod h1:9Q8Pkquc8LcFN2/fUVUXn27ClMGhN17r2KLC4JEG6qA=
 github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240430093732-100f539bb6e6 h1:OgD/skqNdiuzjSIjcYQwVnF7+YC4okqel5Ir28HsQk8=
 github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240430093732-100f539bb6e6/go.mod h1:5qQAgXQ8xOqRd8zmJkooVut6uWxKpeq47JsfXhlpbaM=
+github.com/openstack-k8s-operators/dataplane-operator v0.1.1-0.20240522210124-c85db455540c h1:aByNxrr7rAzZSpAe0MDA71QBOoTKvhnbd1xJ6sIa12Y=
+github.com/openstack-k8s-operators/dataplane-operator v0.1.1-0.20240522210124-c85db455540c/go.mod h1:qlPGWkPASnBTRcVfsXLq3gfyVeQh1dmSQGRajgrq5Io=
 github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240430064940-efe1bb725a94 h1:UlCJZfbxdSHkolrlDxgLuZobDKjV6q/2s6+VBATRjlc=
 github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240430064940-efe1bb725a94/go.mod h1:TgW0ykQrBJaaKsHwIbB5ypEXD97fvU9nxq2lWSWTsqw=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240430093157-c474602ef7e6 h1:+ntqywFT+BIj1QUi0vLLD7JbvLRk1kaG2buVcG9rEnc=
@@ -116,6 +120,8 @@ github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240430114001-a
 github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240430114001-aa12ec2b2ba4/go.mod h1:aKCIsV3tadtnhr5iGca7/k+KnSI5ORFUt0aEAPFYQi0=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240429164853-7e1e3b111ee9 h1:aS7xUxC/uOXfw0T4ARTu0G1qb6eJ0WnB2JRv9donPOE=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240429164853-7e1e3b111ee9/go.mod h1:Y/ge/l24phVaJb9S8mYRjtnDkohFkX/KEOUXLArcyvQ=
+github.com/openstack-k8s-operators/lib-common/modules/ansible v0.3.1-0.20240429052447-09a614506ca6 h1:0NDlFYyPFD7b7OYmtflhkq4SZkjuZNLG/WJ36HmmPp8=
+github.com/openstack-k8s-operators/lib-common/modules/ansible v0.3.1-0.20240429052447-09a614506ca6/go.mod h1:tP+nxk95PisCKJaXE/an2igG9lluxuOVhdmV9WtkR2s=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240522132119-0d829ccc3fd2 h1:SZ8Eo1aqVlzmHTj1GiTXIWxbxN5saDsDh8De0CCbsik=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240522132119-0d829ccc3fd2/go.mod h1:ORxH/VVsk24ExdxecUiAWhLtV17xIv6lO89LLmSvKPE=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240429052447-09a614506ca6 h1:WLsG3Ko+phW5xZJjncypLWGASoLqKrt05qN9Zxsad6g=


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/dataplane-operator/pull/889 Get AEE runner from OpenstackVersion. In order to use this feature in ci-framework. We need to bump the dataplane-operator version.

This will be used in update_containers role to update the ansibleee image.