### PR TITLE
Additional SubjectName in the CertificateRequest

### DIFF
--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -298,6 +298,11 @@ func EnsureEndpointConfig(
 						Labels:      util.MergeMaps(ed.Labels, map[string]string{serviceCertSelector: ""}),
 						Usages:      nil,
 					}
+
+					addSubjNames := util.GetStringListFromMap(svc.Annotations, tls.AdditionalSubjectNamesKey)
+					if len(addSubjNames) > 0 {
+						certRequest.Hostnames = append(certRequest.Hostnames, addSubjNames...)
+					}
 					if instance.Spec.TLS.Ingress.Cert.Duration != nil {
 						certRequest.Duration = &instance.Spec.TLS.Ingress.Cert.Duration.Duration
 					}
@@ -342,6 +347,11 @@ func EnsureEndpointConfig(
 					Annotations: ed.Annotations,
 					Labels:      util.MergeMaps(ed.Labels, map[string]string{serviceCertSelector: ""}),
 					Usages:      nil,
+				}
+
+				addSubjNames := util.GetStringListFromMap(svc.Annotations, tls.AdditionalSubjectNamesKey)
+				if len(addSubjNames) > 0 {
+					certRequest.Hostnames = append(certRequest.Hostnames, addSubjNames...)
 				}
 				if instance.Spec.TLS.PodLevel.Internal.Cert.Duration != nil {
 					certRequest.Duration = &instance.Spec.TLS.PodLevel.Internal.Cert.Duration.Duration


### PR DESCRIPTION
This patch adds a way to check the appropriate annotation within a `SVC` and look for additional `SNs` that should be added to the `CertificateRequest`. `Glance` needs this mechanism because for each `SVC` (`public`, `internal`), we have an associated `headless service`, and it is used to resolve each replica Pod `worker_self_reference_url`. 
This allows to proxy `Pod2Pod` requests via `HTTPS`.

Jira: https://issues.redhat.com/browse/OSPRH-7276