### PR TITLE
Add TestInstancesWithCinderVolumes to skip list

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -39,6 +39,7 @@
         - tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_live_migration
         - tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachScenarioOldVersion
         - tempest.scenario.test_server_volume_attachment.TestServerVolumeAttachmentScenario
+        - tempest.scenario.test_instances_with_cinder_volumes.TestInstancesWithCinderVolumes
         - tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.test_live_block_migration_with_attached_volume
       # We need to use a custom cpu model to allow live migrating between
       # slightly different computes coming from the node pool


### PR DESCRIPTION
The new test is included with tempest 39.0.0[1],
skip it like other cinder tests as job don't have
cinder backend configured.

[1] https://review.rdoproject.org/r/c/rdoinfo/+/53318