### PR TITLE
[TLS] add wild card hostnames for headless galera/rabbitmq svc

### DIFF
--- a/pkg/openstack/galera.go
+++ b/pkg/openstack/galera.go
@@ -43,6 +43,7 @@ func ReconcileGaleras(
 
 	for name, spec := range instance.Spec.Galera.Templates {
 		hostname := fmt.Sprintf("%s.%s.svc", name, instance.Namespace)
+		hostnameHeadless := fmt.Sprintf("%s-galera.%s.svc", name, instance.Namespace)
 
 		// Galera gets always configured to support TLS connections.
 		// If TLS can/must be used is a per user configuration.
@@ -52,6 +53,10 @@ func ReconcileGaleras(
 			Hostnames: []string{
 				hostname,
 				fmt.Sprintf("%s.%s", hostname, ClusterInternalDomain),
+				hostnameHeadless,
+				fmt.Sprintf("%s.%s", hostnameHeadless, ClusterInternalDomain),
+				fmt.Sprintf("*.%s", hostnameHeadless),
+				fmt.Sprintf("*.%s.%s", hostnameHeadless, ClusterInternalDomain),
 			},
 			// Note (dciabrin) from https://github.com/openstack-k8s-operators/openstack-operator/pull/678#issuecomment-1952459166
 			// the certificate created for galera should populate the 'organization' field,

--- a/pkg/openstack/rabbitmq.go
+++ b/pkg/openstack/rabbitmq.go
@@ -195,6 +195,8 @@ func reconcileRabbitMQ(
 	}
 
 	hostname := fmt.Sprintf("%s.%s.svc", name, instance.Namespace)
+	hostnameHeadless := fmt.Sprintf("%s-nodes.%s.svc", name, instance.Namespace)
+
 	tlsCert := ""
 	commonName := fmt.Sprintf("%s.%s", hostname, ClusterInternalDomain)
 
@@ -206,6 +208,10 @@ func reconcileRabbitMQ(
 			Hostnames: []string{
 				hostname,
 				fmt.Sprintf("%s.%s", hostname, ClusterInternalDomain),
+				hostnameHeadless,
+				fmt.Sprintf("%s.%s", hostnameHeadless, ClusterInternalDomain),
+				fmt.Sprintf("*.%s", hostnameHeadless),
+				fmt.Sprintf("*.%s.%s", hostnameHeadless, ClusterInternalDomain),
 			},
 			Subject: &certmgrv1.X509Subject{
 				Organizations: []string{fmt.Sprintf("%s.%s", rabbitmq.Namespace, ClusterInternalDomain)},


### PR DESCRIPTION
For tls cluster interconnect add wild card for the services headless service names.