### PR TITLE
update config samples to include default cell template

### DIFF
--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -109,6 +109,21 @@ spec:
       secret: osp-secret
   nova:
     template:
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
       secret: osp-secret
   heat:
     enabled: false

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -108,6 +108,21 @@ spec:
   nova:
     template:
       secret: osp-secret
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
   heat:
     enabled: false
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -108,6 +108,21 @@ spec:
   nova:
     template:
       secret: osp-secret
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
   ironic:
     template:
       databaseInstance: openstack

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -155,6 +155,21 @@ spec:
     apiOverride:
       route: {}
     template:
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
       apiServiceTemplate:
         override:
           service:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -155,6 +155,21 @@ spec:
     apiOverride:
       route: {}
     template:
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
       apiServiceTemplate:
         override:
           service:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas_only_default_enabled_services.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas_only_default_enabled_services.yaml
@@ -149,6 +149,21 @@ spec:
     apiOverride:
       route: {}
     template:
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
       apiServiceTemplate:
         override:
           service:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -151,6 +151,21 @@ spec:
     apiOverride:
       route: {}
     template:
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
       apiServiceTemplate:
         override:
           service:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -195,6 +195,21 @@ spec:
     apiOverride:
       route: {}
     template:
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
       apiServiceTemplate:
         override:
           service:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
@@ -154,6 +154,21 @@ spec:
     apiOverride:
       route: {}
     template:
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          cellDatabaseInstance: openstack
+          cellMessageBusInstance: rabbitmq
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+        cell1:
+          cellDatabaseAccount: nova-cell1
+          cellDatabaseInstance: openstack-cell1
+          cellMessageBusInstance: rabbitmq-cell1
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
       apiServiceTemplate:
         override:
           service:


### PR DESCRIPTION
This change updates the config samples to inculde the cells templates
so that the default behavior fo the cell 1 creation can be modifed in
the future without impacting docs or ci jobs.

currently cell 0 and 1 are created by nova by default
in a feture operator version we plannign to remove the automatic creation
of cell 1 so that the procedure ot add the first and subsequent comptue
cells are identical.
