### PR TITLE
Support storage setting route annotations

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -443,6 +443,22 @@ func (r *OpenStackControlPlane) DefaultServices() {
 	// Glance
 	r.Spec.Glance.Template.Default()
 
+	// initialize the main APIOverride struct
+	if r.Spec.Glance.APIOverride == nil {
+		r.Spec.Glance.APIOverride = map[string]Override{}
+	}
+	for name, glanceAPI := range r.Spec.Glance.Template.GlanceAPIs {
+		var override Override
+		var ok bool
+
+		if override, ok = r.Spec.Glance.APIOverride[name]; !ok {
+			override = Override{}
+		}
+		initializeOverrideSpec(&override.Route, true)
+		glanceAPI.SetDefaultRouteAnnotations(override.Route.Annotations)
+		r.Spec.Glance.APIOverride[name] = override
+	}
+
 	// Ironic
 	// Default Secret
 	if r.Spec.Ironic.Template.Secret == "" {

--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -479,6 +479,8 @@ func (r *OpenStackControlPlane) DefaultServices() {
 
 	// Manila
 	r.Spec.Manila.Template.Default()
+	initializeOverrideSpec(&r.Spec.Manila.APIOverride.Route, true)
+	r.Spec.Manila.Template.SetDefaultRouteAnnotations(r.Spec.Manila.APIOverride.Route.Annotations)
 
 	// Memcached
 	for key, template := range r.Spec.Memcached.Templates {

--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -80,16 +80,8 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		instance.Spec.Glance.Template.GlanceAPIs[name] = glanceAPI
 	}
 
-	// initialize the main APIOverride struct
-	if instance.Spec.Glance.APIOverride == nil {
-		instance.Spec.Glance.APIOverride = map[string]corev1beta1.Override{}
-	}
-
 	var changed = false
 	for name, glanceAPI := range instance.Spec.Glance.Template.GlanceAPIs {
-		if _, ok := instance.Spec.Glance.APIOverride[name]; !ok {
-			instance.Spec.Glance.APIOverride[name] = corev1beta1.Override{}
-		}
 		// Retrieve the services by Label and filter on glanceAPI: for
 		// each instance we should get **only** the associated `SVCs`
 		// and not the whole list. As per the Glance design doc we know
@@ -109,6 +101,7 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 			return ctrl.Result{}, err
 		}
 		// make sure to get to EndpointConfig when all service got created
+		// Webhook initializes APIOverride and always has at least the timeout override
 		if len(svcs.Items) == len(glanceAPI.Override.Service) {
 			endpointDetails, ctrlResult, err := EnsureEndpointConfig(
 				ctx,

--- a/tests/functional/openstackoperator_controller_test.go
+++ b/tests/functional/openstackoperator_controller_test.go
@@ -558,6 +558,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 		It("should have default timeout for the routes set", func() {
 			OSCtlplane := GetOpenStackControlPlane(names.OpenStackControlplaneName)
 			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "120s"))
+			Expect(OSCtlplane.Spec.Cinder.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
+			Expect(OSCtlplane.Spec.Cinder.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.cinder.openstack.org/timeout", "60s"))
 		})
 
 		It("should create selfsigned issuer and public+internal CA and issuer", func() {

--- a/tests/functional/openstackoperator_controller_test.go
+++ b/tests/functional/openstackoperator_controller_test.go
@@ -564,6 +564,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 				Expect(OSCtlplane.Spec.Glance.APIOverride[name].Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
 				Expect(OSCtlplane.Spec.Glance.APIOverride[name].Route.Annotations).Should(HaveKeyWithValue("api.glance.openstack.org/timeout", "60s"))
 			}
+			Expect(OSCtlplane.Spec.Manila.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
+			Expect(OSCtlplane.Spec.Manila.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.manila.openstack.org/timeout", "60s"))
 		})
 
 		It("should create selfsigned issuer and public+internal CA and issuer", func() {

--- a/tests/functional/openstackoperator_controller_test.go
+++ b/tests/functional/openstackoperator_controller_test.go
@@ -560,6 +560,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "120s"))
 			Expect(OSCtlplane.Spec.Cinder.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
 			Expect(OSCtlplane.Spec.Cinder.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.cinder.openstack.org/timeout", "60s"))
+			for name := range OSCtlplane.Spec.Glance.Template.GlanceAPIs {
+				Expect(OSCtlplane.Spec.Glance.APIOverride[name].Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
+				Expect(OSCtlplane.Spec.Glance.APIOverride[name].Route.Annotations).Should(HaveKeyWithValue("api.glance.openstack.org/timeout", "60s"))
+			}
 		})
 
 		It("should create selfsigned issuer and public+internal CA and issuer", func() {


### PR DESCRIPTION
This PR adds support for Cinder, Glance, and Manila to set their route annotations.

Depends-On: https://github.com/openstack-k8s-operators/cinder-operator/pull/396
Depends-On: https://github.com/openstack-k8s-operators/glance-operator/pull/550
Depends-On: https://github.com/openstack-k8s-operators/manila-operator/pull/282

Jira: https://issues.redhat.com/browse/OSPRH-7393
Jira: https://issues.redhat.com/browse/OSPRH-7415 