### PR TITLE
Fix race condition in OpenStackVersion func test

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -254,10 +254,13 @@ func OpenStackVersionConditionGetter(name types.NamespacedName) condition.Condit
 	return instance.Status.Conditions
 }
 
-func OpenStackVersionRemoveFinalizer(ctx context.Context, name types.NamespacedName) error {
-	instance := GetOpenStackVersion(name)
-	instance.SetFinalizers([]string{})
-	return th.K8sClient.Update(ctx, instance)
+func OpenStackVersionRemoveFinalizer(ctx context.Context, name types.NamespacedName) {
+	Eventually(func(g Gomega) {
+		instance := GetOpenStackVersion(name)
+		instance.SetFinalizers([]string{})
+		g.Expect(th.K8sClient.Update(ctx, instance)).Should(Succeed())
+
+	}, timeout, interval).Should(Succeed())
 }
 
 func CreateOpenStackControlPlane(name types.NamespacedName, spec map[string]interface{}) client.Object {


### PR DESCRIPTION
Fixes a race condition for one of the `OpenStackVersion` functional tests that can result in this:

```
DeferCleanup callback returned error: Operation cannot be fulfilled on openstackversions.core.openstack.org "dbb90d6f-3eab-491b-92cb-c": the object has been modified; please apply your changes to the latest version and try again
```

Credit to @gibizer for finding this fix