### PR TITLE
Update dataplane-operator/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-20240603141403-1ad477d065a2
 	github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240529155246-4afc791bbb82
-	github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240605111219-06b9cbfa8a2e
+	github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240608024258-319ec0e5a28b
 	github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240604124031-77b21b330d86
 	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240605101720-9531b1fa7924
 	github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240605063719-371c02948c8c

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-20240603141403-1
 github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-20240603141403-1ad477d065a2/go.mod h1:FBMttmFnsXleh/Gohxvgaz5c5HdF7Gsc6/ySC9TU770=
 github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240529155246-4afc791bbb82 h1:Q+U8JpT+grvSaDD9wqpdF6OyrJc1v+qDDkcg60xmDMg=
 github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240529155246-4afc791bbb82/go.mod h1:8Wn6ZAPaJshxozJVPI7uq4qrcUXZmECGAPJK7Ed+uGQ=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240605111219-06b9cbfa8a2e h1:spf4U4j9li8bcdyPn8q83JYdrqRboKtPyZQ8oOR+Gyk=
-github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240605111219-06b9cbfa8a2e/go.mod h1:ESTcEmtCGEvlrMPzdbNDeIUozxfKA4zEqhYt/rxJxmE=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240608024258-319ec0e5a28b h1:VRAXcHzieo0mYoXLwkZD1nrfqXyk0a/ok085KKiJDo0=
+github.com/openstack-k8s-operators/dataplane-operator/api v0.3.1-0.20240608024258-319ec0e5a28b/go.mod h1:ESTcEmtCGEvlrMPzdbNDeIUozxfKA4zEqhYt/rxJxmE=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240604124031-77b21b330d86 h1:pE/BD9Qg5A2CFQHiKJfqZ8Os7obIoTsy8UYNI3sDblc=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240604124031-77b21b330d86/go.mod h1:u53p2KRT083miTWA5oQlU4zITB4FXJOzI/eao51CkbE=
 github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240605101720-9531b1fa7924 h1:FtYYqki9eYmXJ2j8mSO9Sqjn2dByvvziIxJWoCQgUhU=


### PR DESCRIPTION
Somehow current pinned ansibleee-operator-bundle image got updated to include edpm-ansible PR[1] and causing issues as it requires dataplane-operator api[2] to also get updated.

[1] https://github.com/openstack-k8s-operators/edpm-ansible/pull/653/
[2] https://github.com/openstack-k8s-operators/dataplane-operator/pull/875
Related-Issue: [OSPCIX-328](https://issues.redhat.com//browse/OSPCIX-328)