### PR TITLE
Revert "Check for Ceilometer and Autoscaling dependencies"

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -167,14 +167,6 @@ func (r *OpenStackControlPlane) checkDepsEnabled(name string) string {
 			r.Spec.Ovn.Enabled) {
 			reqs = "Galera, Memcached, RabbitMQ, Keystone, Glance, Neutron, Nova, OVN"
 		}
-	case "Telemetry.Autoscaling":
-		if !(r.Spec.Galera.Enabled && r.Spec.Heat.Enabled && r.Spec.Rabbitmq.Enabled && r.Spec.Keystone.Enabled) {
-			reqs = "Galera, Heat, RabbitMQ, Keystone"
-		}
-	case "Telemetry.Ceilometer":
-		if !(r.Spec.Rabbitmq.Enabled && r.Spec.Keystone.Enabled) {
-			reqs = "RabbitMQ, Keystone"
-		}
 	}
 
 	// If "reqs" is not the empty string, we have missing requirements
@@ -389,20 +381,6 @@ func (r *OpenStackControlPlane) ValidateServiceDependencies(basePath *field.Path
 	if r.Spec.Barbican.Enabled {
 		if depErrorMsg := r.checkDepsEnabled("Barbican"); depErrorMsg != "" {
 			err := field.Invalid(basePath.Child("barbican").Child("enabled"), r.Spec.Barbican.Enabled, depErrorMsg)
-			allErrs = append(allErrs, err)
-		}
-	}
-	if r.Spec.Telemetry.Enabled && r.Spec.Telemetry.Template.Ceilometer.Enabled {
-		if depErrorMsg := r.checkDepsEnabled("Telemetry.Ceilometer"); depErrorMsg != "" {
-			err := field.Invalid(basePath.Child("telemetry").Child("template").Child("ceilometer").Child("enabled"),
-					     r.Spec.Telemetry.Template.Ceilometer.Enabled, depErrorMsg)
-			allErrs = append(allErrs, err)
-		}
-	}
-	if r.Spec.Telemetry.Enabled && r.Spec.Telemetry.Template.Autoscaling.Enabled {
-		if depErrorMsg := r.checkDepsEnabled("Telemetry.Autoscaling"); depErrorMsg != "" {
-			err := field.Invalid(basePath.Child("telemetry").Child("template").Child("autoscaling").Child("enabled"),
-					     r.Spec.Telemetry.Template.Autoscaling.Enabled, depErrorMsg)
 			allErrs = append(allErrs, err)
 		}
 	}


### PR DESCRIPTION
Reverts openstack-k8s-operators/openstack-operator#837

We have a PR  https://github.com/openstack-k8s-operators/telemetry-operator/pull/404 in telemetry-operator to change the "Enabled" values to *bool. Because of this code, we'd need to simultaneously merge that PR along with a PR here to change how we access the variables. Instead the plan is to revert this PR, merge the PR in telemetry-operator and then create a new PR here, which would reintroduce this code but would access the variables correctly as pointers.