### PR TITLE
Bump Glance with the new storage interface

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -4373,8 +4373,6 @@ spec:
                                     type: object
                                   type: object
                               type: object
-                            pvc:
-                              type: string
                             replicas:
                               default: 1
                               format: int32
@@ -4412,10 +4410,15 @@ spec:
                                     x-kubernetes-int-or-string: true
                                   type: object
                               type: object
-                            storageClass:
-                              type: string
-                            storageRequest:
-                              type: string
+                            storage:
+                              properties:
+                                external:
+                                  type: boolean
+                                storageClass:
+                                  type: string
+                                storageRequest:
+                                  type: string
+                              type: object
                             tls:
                               properties:
                                 api:
@@ -4443,7 +4446,6 @@ spec:
                               type: string
                           required:
                           - containerImage
-                          - storageRequest
                           type: object
                         type: object
                       imageCache:
@@ -4506,10 +4508,15 @@ spec:
                       serviceUser:
                         default: glance
                         type: string
-                      storageClass:
-                        type: string
-                      storageRequest:
-                        type: string
+                      storage:
+                        properties:
+                          external:
+                            type: boolean
+                          storageClass:
+                            type: string
+                          storageRequest:
+                            type: string
+                        type: object
                     required:
                     - databaseInstance
                     - glanceAPIs
@@ -4517,7 +4524,6 @@ spec:
                     - keystoneEndpoint
                     - memcachedInstance
                     - secret
-                    - storageRequest
                     type: object
                 type: object
               heat:

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-20240617164203-79f227e25054
 	github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240612161940-604036e71c7f
 	github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240617072628-d9a4e3570a7b
-	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240616104609-e296d336e2d0
+	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240617143817-90d7bb77c86c
 	github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240617071814-4b53828cc9b0
 	github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240617072342-155b98fbba7f
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240617061457-9ce4f0e12b76

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -96,8 +96,8 @@ github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240612161940-6
 github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240612161940-604036e71c7f/go.mod h1:8Wn6ZAPaJshxozJVPI7uq4qrcUXZmECGAPJK7Ed+uGQ=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240617072628-d9a4e3570a7b h1:KodjRfVnaQt9tRztidjT9F3zpKWmRSc369Z7c1n556c=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240617072628-d9a4e3570a7b/go.mod h1:sN6FNMjzbVZSuh1IzhnVLXwdKvi8LoxuRRGLGT8CRb4=
-github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240616104609-e296d336e2d0 h1:Wx4xa5Jh/Wa9pAsoCYROJKycesBAy3RBjf/2WnG1Da8=
-github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240616104609-e296d336e2d0/go.mod h1:fYNG/9X9HbQTZkaPo+YLqPu/94dNftw15S58OpQjcZE=
+github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240617143817-90d7bb77c86c h1:QuF1kEWBdCgDy6wqcLXMYzK7nUko/uA1S9I1uvhoKpg=
+github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240617143817-90d7bb77c86c/go.mod h1:fYNG/9X9HbQTZkaPo+YLqPu/94dNftw15S58OpQjcZE=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240617071814-4b53828cc9b0 h1:/nQdWwAE/qHonBXFQv57BNt0+ZGvqoaA2wkdKjLHcC4=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240617071814-4b53828cc9b0/go.mod h1:BaF3hWIIaZP8boIwhHdYV/Iz4vda7NQuIgh5l/RhXYo=
 github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240617072342-155b98fbba7f h1:DckJpHSko5A7ea15fq3HBsqLQYTtRHdCxVygHZWbIOI=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -4373,8 +4373,6 @@ spec:
                                     type: object
                                   type: object
                               type: object
-                            pvc:
-                              type: string
                             replicas:
                               default: 1
                               format: int32
@@ -4412,10 +4410,15 @@ spec:
                                     x-kubernetes-int-or-string: true
                                   type: object
                               type: object
-                            storageClass:
-                              type: string
-                            storageRequest:
-                              type: string
+                            storage:
+                              properties:
+                                external:
+                                  type: boolean
+                                storageClass:
+                                  type: string
+                                storageRequest:
+                                  type: string
+                              type: object
                             tls:
                               properties:
                                 api:
@@ -4443,7 +4446,6 @@ spec:
                               type: string
                           required:
                           - containerImage
-                          - storageRequest
                           type: object
                         type: object
                       imageCache:
@@ -4506,10 +4508,15 @@ spec:
                       serviceUser:
                         default: glance
                         type: string
-                      storageClass:
-                        type: string
-                      storageRequest:
-                        type: string
+                      storage:
+                        properties:
+                          external:
+                            type: boolean
+                          storageClass:
+                            type: string
+                          storageRequest:
+                            type: string
+                        type: object
                     required:
                     - databaseInstance
                     - glanceAPIs
@@ -4517,7 +4524,6 @@ spec:
                     - keystoneEndpoint
                     - memcachedInstance
                     - secret
-                    - storageRequest
                     type: object
                 type: object
               heat:

--- a/config/samples/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane.yaml
@@ -56,8 +56,9 @@ spec:
     template:
       secret: osp-secret
       databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       keystoneEndpoint: default
       glanceAPIs:
         default:

--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -46,8 +46,9 @@ spec:
     template:
       secret: osp-secret
       databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       keystoneEndpoint: default
       glanceAPIs:
         default:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -54,8 +54,9 @@ spec:
     template:
       secret: osp-secret
       databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       keystoneEndpoint: default
       glanceAPIs:
         default:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -53,8 +53,9 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       secret: osp-secret
       keystoneEndpoint: default
       glanceAPIs:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -55,8 +55,9 @@ spec:
         route: {}
     template:
       databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       secret: osp-secret
       keystoneEndpoint: default
       glanceAPIs:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -77,8 +77,9 @@ spec:
         route: {}
     template:
       databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       secret: osp-secret
       keystoneEndpoint: default
       glanceAPIs:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas_only_default_enabled_services.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas_only_default_enabled_services.yaml
@@ -77,8 +77,9 @@ spec:
         route: {}
     template:
       databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       secret: osp-secret
       keystoneEndpoint: default
       glanceAPIs:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -77,8 +77,9 @@ spec:
         route: {}
     template:
       databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       secret: osp-secret
       keystoneEndpoint: default
       glanceAPIs:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -122,8 +122,9 @@ spec:
         store_description = "RBD backend"
         rbd_store_pool = images
         rbd_store_user = openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       secret: osp-secret
       keystoneEndpoint: default
       glanceAPIs:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
@@ -80,8 +80,9 @@ spec:
         route: {}
     template:
       databaseInstance: openstack
-      storageClass: ""
-      storageRequest: 10G
+      storage:
+        storageClass: ""
+        storageRequest: 10G
       secret: osp-secret
       keystoneEndpoint: default
       glanceAPIs:

--- a/docs/assemblies/ctlplane_resources.adoc
+++ b/docs/assemblies/ctlplane_resources.adoc
@@ -161,6 +161,7 @@
 * <<apioverridespec,APIOverrideSpec>>
 * <<glanceapitemplate,GlanceAPITemplate>>
 * <<imagecache,ImageCache>>
+* <<storage,Storage>>
 * <<dbpurge,DBPurge>>
 * <<glance,Glance>>
 * <<glanceextravolmounts,GlanceExtraVolMounts>>
@@ -5266,11 +5267,6 @@ GlanceAPITemplate defines the desired state of GlanceAPI
 | map[string]string
 | false
 
-| pvc
-| Pvc - Storage claim for file-backed Glance
-| string
-| false
-
 | customServiceConfig
 | CustomServiceConfig - customize the service config using this parameter to change service defaults, or overwrite rendered information using raw OpenStack config format. The content gets added to to /etc/+++<service>+++/+++<service>+++.conf.d directory as custom.conf file.+++</service>++++++</service>+++
 | string
@@ -5296,15 +5292,10 @@ GlanceAPITemplate defines the desired state of GlanceAPI
 | <<apioverridespec,APIOverrideSpec>>
 | false
 
-| storageClass
-| StorageClass
-| string
+| storage
+| Storage -
+| <<storage,Storage>>
 | false
-
-| storageRequest
-| StorageRequest
-| string
-| true
 
 | type
 | Type - represents the layout of the glanceAPI deployment.
@@ -5351,6 +5342,30 @@ ImageCache - struct where the exposed imageCache params are defined
 | Schedule defines the crontab format string to schedule the Pruner cronJob
 | string
 | true
+|===
+
+<<custom-resources,Back to Custom Resources>>
+
+[#storage]
+==== Storage
+
+|===
+| Field | Description | Scheme | Required
+
+| storageClass
+| StorageClass -
+| string
+| false
+
+| storageRequest
+| StorageRequest -
+| string
+| false
+
+| external
+| External -
+| bool
+| false
 |===
 
 <<custom-resources,Back to Custom Resources>>
@@ -5523,15 +5538,10 @@ GlanceSpec defines the desired state of Glance
 | []string
 | false
 
-| storageClass
-| StorageClass
-| string
+| storage
+| Storage -
+| <<storage,Storage>>
 | false
-
-| storageRequest
-| StorageRequest
-| string
-| true
 
 | glanceAPIs
 | GlanceAPIs - Spec definition for the API service of this Glance deployment
@@ -15375,7 +15385,7 @@ PersistentStorage defines storage options used for persistent storage
 
 <<custom-resources,Back to Custom Resources>>
 
-[#storage]
+[#storage-2]
 ==== Storage
 
 Storage defines the options used for storage of metrics

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openstack-k8s-operators/barbican-operator/api v0.0.0-20240617164203-79f227e25054
 	github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240612161940-604036e71c7f
 	github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240617072628-d9a4e3570a7b
-	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240616104609-e296d336e2d0
+	github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240617143817-90d7bb77c86c
 	github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240617071814-4b53828cc9b0
 	github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240617072342-155b98fbba7f
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240617061457-9ce4f0e12b76

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240612161940-6
 github.com/openstack-k8s-operators/cinder-operator/api v0.3.1-0.20240612161940-604036e71c7f/go.mod h1:8Wn6ZAPaJshxozJVPI7uq4qrcUXZmECGAPJK7Ed+uGQ=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240617072628-d9a4e3570a7b h1:KodjRfVnaQt9tRztidjT9F3zpKWmRSc369Z7c1n556c=
 github.com/openstack-k8s-operators/designate-operator/api v0.0.0-20240617072628-d9a4e3570a7b/go.mod h1:sN6FNMjzbVZSuh1IzhnVLXwdKvi8LoxuRRGLGT8CRb4=
-github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240616104609-e296d336e2d0 h1:Wx4xa5Jh/Wa9pAsoCYROJKycesBAy3RBjf/2WnG1Da8=
-github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240616104609-e296d336e2d0/go.mod h1:fYNG/9X9HbQTZkaPo+YLqPu/94dNftw15S58OpQjcZE=
+github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240617143817-90d7bb77c86c h1:QuF1kEWBdCgDy6wqcLXMYzK7nUko/uA1S9I1uvhoKpg=
+github.com/openstack-k8s-operators/glance-operator/api v0.3.1-0.20240617143817-90d7bb77c86c/go.mod h1:fYNG/9X9HbQTZkaPo+YLqPu/94dNftw15S58OpQjcZE=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240617071814-4b53828cc9b0 h1:/nQdWwAE/qHonBXFQv57BNt0+ZGvqoaA2wkdKjLHcC4=
 github.com/openstack-k8s-operators/heat-operator/api v0.3.1-0.20240617071814-4b53828cc9b0/go.mod h1:BaF3hWIIaZP8boIwhHdYV/Iz4vda7NQuIgh5l/RhXYo=
 github.com/openstack-k8s-operators/horizon-operator/api v0.3.1-0.20240617072342-155b98fbba7f h1:DckJpHSko5A7ea15fq3HBsqLQYTtRHdCxVygHZWbIOI=

--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -154,8 +154,8 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		if glance.Spec.DatabaseInstance == "" {
 			glance.Spec.DatabaseInstance = "openstack"
 		}
-		if glance.Spec.StorageClass == "" {
-			glance.Spec.StorageClass = instance.Spec.StorageClass
+		if glance.Spec.Storage.StorageClass == "" {
+			glance.Spec.Storage.StorageClass = instance.Spec.StorageClass
 		}
 		// Append globally defined extraMounts to the service's own list.
 		for _, ev := range instance.Spec.ExtraMounts {

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -36,7 +36,6 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      storageRequest: 10G
       secret: osp-secret
       glanceAPIs:
         default:

--- a/tests/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
+++ b/tests/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
@@ -27,7 +27,6 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      storageRequest: 10G
       glanceAPIs:
         default:
           replicas: 1

--- a/tests/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
+++ b/tests/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
@@ -36,7 +36,6 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      storageRequest: 10G
       glanceAPIs:
         default:
           replicas: 1

--- a/tests/kuttl/tests/ctlplane-galera-basic/01-assert-galera.yaml
+++ b/tests/kuttl/tests/ctlplane-galera-basic/01-assert-galera.yaml
@@ -36,7 +36,6 @@ spec:
   glance:
     template:
       databaseInstance: openstack
-      storageRequest: 10G
       glanceAPIs:
         default:
           replicas: 1


### PR DESCRIPTION
We currently provide both `StorageClass` and `StorageRequest` that can be propagated to the `Glance` underlying instances.
However, it might be possible that operators use `extraMounts` to plug a `NFS` share mapped to  `/var/lib/glance/os_glance_staging_store`.
In this case the `API` should be updated to not provision any `PVC` and let the human operator take care about it via the `extraMounts` interface.

This patch updates the `Glance` bits to reflect the new behavior introduced in the `glance-operator`.

Jira: https://issues.redhat.com/browse/OSPRH-6719