### PR TITLE
Use non static name for the Cinder and Glance CRs

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -4528,6 +4528,9 @@ spec:
                     - memcachedInstance
                     - secret
                     type: object
+                  uniquePodNames:
+                    default: false
+                    type: boolean
                 type: object
               heat:
                 properties:

--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -1661,6 +1661,9 @@ spec:
                     - rabbitMqClusterName
                     - secret
                     type: object
+                  uniquePodNames:
+                    default: false
+                    type: boolean
                 type: object
               designate:
                 properties:

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -414,6 +414,13 @@ type GlanceSection struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// APIOverride, provides the ability to override the generated manifest of several child resources.
 	APIOverride map[string]Override `json:"apiOverrides,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// UniquePodNames - Use a unique prefix for glance CRs to have unique pod names.
+	// Convenient to avoid podname (and thus hostname) collision between different deployments.
+	// Useful for CI jobs as well as preproduction and production environments that use the same storage backend, etc.
+	UniquePodNames bool `json:"uniquePodNames"`
 }
 
 // CinderSection defines the desired state of Cinder service

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -433,6 +433,13 @@ type CinderSection struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// APIOverride, provides the ability to override the generated manifest of several child resources.
 	APIOverride Override `json:"apiOverride,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// UniquePodNames - Use a unique prefix for cinder CRs to have unique pod names.
+	// Convenient to avoid podname (and thus hostname) collision between different deployments.
+	// Useful for CI jobs as well as preproduction and production environments that use the same storage backend, etc.
+	UniquePodNames bool `json:"uniquePodNames"`
 }
 
 // GaleraSection defines the desired state of Galera services

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -4528,6 +4528,9 @@ spec:
                     - memcachedInstance
                     - secret
                     type: object
+                  uniquePodNames:
+                    default: false
+                    type: boolean
                 type: object
               heat:
                 properties:

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -1661,6 +1661,9 @@ spec:
                     - rabbitMqClusterName
                     - secret
                     type: object
+                  uniquePodNames:
+                    default: false
+                    type: boolean
                 type: object
               designate:
                 properties:


### PR DESCRIPTION
When the openstack operator creates the cinder CR it always uses the
"cinder" name and there is no way to change it.

This means that the names of the pods, and therefore the reported
hostname inside them, will always be the same for the backup service
(cinder-backup-0) and for the volume service in 2 deployments if they
have the same key in the volumes map.

This may be fine for some deployments, but it creates problems in
others, because many cinder drivers expect the hostnames of the hosts
attaching volumes to be unique.

Because they expect them to be unique they use the hostname as a key to
store information on the storage array such as the iSCSI initiator name
or the HBAs addresses.

If they are not unique there can be unexpected behavior like hosts being
unable to attach.

This is very common in CI systems, but is not limited to them as it can
also happen in production deployments using the same storage arrays.

A similar thing would happen when Glance is using Cinder as a backend.

With this PR the cinder and glance sections have a new field called
`randomPodNames` each so the openstack-operator can generate a non
static name for the `Cinder` and `Glance` CRs.

This new name is the same as before but with a suffix of a dash (`-`)
followed by the first 5 characters of the `OpenStackControlPlane` UID.

The is still a small chance to have duplicated pod names, but the chance
should be small enough to be safe to ignore.

Related PRs:
- https://github.com/openstack-k8s-operators/cinder-operator/pull/399
- https://github.com/openstack-k8s-operators/cinder-operator/pull/400
- https://github.com/openstack-k8s-operators/glance-operator/pull/555

Jira: [OSPRH-7396](https://issues.redhat.com//browse/OSPRH-7396)