### PR TITLE
Access telemetry Enabled values as pointers

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240610180318-22bca1cb3fd4
 	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240606155430-0863f223076f
 	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240604073634-259c9bde9cd1
-	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240605210308-c2077c1640ca
+	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240612165248-d0f83a47916c
 	github.com/rabbitmq/cluster-operator/v2 v2.6.0
 	github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.69.0-rhobs1 // indirect
 	github.com/rhobs/observability-operator v0.0.28 // indirect

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -115,8 +115,8 @@ github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.2024031
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20240313124519-961a0ee8bf7f/go.mod h1:Zryxg5YgbPUFcLSCcKpf10il8kIRAK5HloNo6khhdis=
 github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240604073634-259c9bde9cd1 h1:unkiHNm4ZncqYk/Fr22s7cgHCyio1P+7ZznaFoqUDAY=
 github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240604073634-259c9bde9cd1/go.mod h1:c1zUCO1JcfmHMtbWbq94xWz3yzcYAc49JvgGoy51UpE=
-github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240605210308-c2077c1640ca h1:B4e23o2oK8fMBvXzr/PuIInQ5F1oBnYnj6NjyhkyTxo=
-github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240605210308-c2077c1640ca/go.mod h1:EuzACoj5reBC4tvdsMkSsoIMcYmrPTC16gEb0qkR86Y=
+github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240612165248-d0f83a47916c h1:IWVWcLkUO+1T6DHJyOnIOD7WmGN9bHz7ZVaFItuyQ6g=
+github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240612165248-d0f83a47916c/go.mod h1:EuzACoj5reBC4tvdsMkSsoIMcYmrPTC16gEb0qkR86Y=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/openstack-k8s-operators/ovn-operator/api v0.3.1-0.20240610180318-22bca1cb3fd4
 	github.com/openstack-k8s-operators/placement-operator/api v0.3.1-0.20240606155430-0863f223076f
 	github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240604073634-259c9bde9cd1
-	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240605210308-c2077c1640ca
+	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240612165248-d0f83a47916c
 	github.com/openstack-k8s-operators/test-operator/api v0.0.0-20240607060532-91bef1029945
 	github.com/operator-framework/api v0.20.0
 	github.com/rabbitmq/cluster-operator/v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.2024031
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20240313124519-961a0ee8bf7f/go.mod h1:Zryxg5YgbPUFcLSCcKpf10il8kIRAK5HloNo6khhdis=
 github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240604073634-259c9bde9cd1 h1:unkiHNm4ZncqYk/Fr22s7cgHCyio1P+7ZznaFoqUDAY=
 github.com/openstack-k8s-operators/swift-operator/api v0.3.1-0.20240604073634-259c9bde9cd1/go.mod h1:c1zUCO1JcfmHMtbWbq94xWz3yzcYAc49JvgGoy51UpE=
-github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240605210308-c2077c1640ca h1:B4e23o2oK8fMBvXzr/PuIInQ5F1oBnYnj6NjyhkyTxo=
-github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240605210308-c2077c1640ca/go.mod h1:EuzACoj5reBC4tvdsMkSsoIMcYmrPTC16gEb0qkR86Y=
+github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240612165248-d0f83a47916c h1:IWVWcLkUO+1T6DHJyOnIOD7WmGN9bHz7ZVaFItuyQ6g=
+github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240612165248-d0f83a47916c/go.mod h1:EuzACoj5reBC4tvdsMkSsoIMcYmrPTC16gEb0qkR86Y=
 github.com/openstack-k8s-operators/test-operator/api v0.0.0-20240607060532-91bef1029945 h1:RYDpOusA94CdfzfC6EwYAGHaI9kOZ8e1HR6IobvwUIU=
 github.com/openstack-k8s-operators/test-operator/api v0.0.0-20240607060532-91bef1029945/go.mod h1:UgqzIVmPod3EOAwoaiB4nXSpyOO5NI2GJKAwjLi+VzU=
 github.com/operator-framework/api v0.20.0 h1:A2YCRhr+6s0k3pRJacnwjh1Ue8BqjIGuQ2jvPg9XCB4=

--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -16,6 +16,7 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -227,11 +228,8 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Spec.Telemetry.Template.Logging.DeepCopyInto(&telemetry.Spec.Logging)
 		instance.Spec.Telemetry.Template.MetricStorage.DeepCopyInto(&telemetry.Spec.MetricStorage)
 
-		// FIXME: need to switch telemetry operator enabled defaults to bool pointers to get around webhook defaulting issues
-		telemetry.Spec.Ceilometer.Enabled = instance.Spec.Telemetry.Template.Ceilometer.Enabled
-		telemetry.Spec.Autoscaling.Enabled = instance.Spec.Telemetry.Template.Autoscaling.Enabled
-		telemetry.Spec.Logging.Enabled = instance.Spec.Telemetry.Template.Logging.Enabled
-		telemetry.Spec.MetricStorage.Enabled = instance.Spec.Telemetry.Template.MetricStorage.Enabled
+		telemetry.Spec.Ceilometer.Enabled = ptr.To(*instance.Spec.Telemetry.Template.Ceilometer.Enabled)
+		telemetry.Spec.Autoscaling.Enabled = ptr.To(*instance.Spec.Telemetry.Template.Autoscaling.Enabled)
 
 		telemetry.Spec.Ceilometer.CentralImage = *version.Status.ContainerImages.CeilometerCentralImage
 		telemetry.Spec.Ceilometer.ComputeImage = *version.Status.ContainerImages.CeilometerComputeImage


### PR DESCRIPTION
This is updating telemetry-operator to newer version and it also updates the way Enabled values in telemetry are accessed, because they were changed from bool to *bool in a recent PR: https://github.com/openstack-k8s-operators/telemetry-operator/pull/404