### PR TITLE
Configure rabbitmq inter-node TLS

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	openstackclientv1 "github.com/openstack-k8s-operators/openstack-operator/apis/client/v1beta1"
 	corev1 "github.com/openstack-k8s-operators/openstack-operator/apis/core/v1beta1"
+	rabbitmqv2 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 )
 
 type Names struct {
@@ -455,4 +456,12 @@ func CreateClusterConfigCM() client.Object {
 	}, timeout, interval).Should(Succeed())
 
 	return cm
+}
+
+func GetRabbitMQCluster(name types.NamespacedName) *rabbitmqv2.RabbitmqCluster {
+	instance := &rabbitmqv2.RabbitmqCluster{}
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, name, instance)).Should(Succeed())
+	}, timeout, interval).Should(Succeed())
+	return instance
 }


### PR DESCRIPTION
Based on the example in https://github.com/rabbitmq/cluster-operator/tree/0bc9a2a0d3b360021f02bd6386bbcee371c9d1fd/docs/examples/mtls-inter-node

Creates and mounts a configmap with the required config and sets the required args in the env vars.

Had to list the individual statefulset hostnames in the cert SAN, rabbitmqctl does not work when wildcards are used.

Closes: [OSPRH-7110](https://issues.redhat.com//browse/OSPRH-7110)