### PR TITLE
Introducing spec level validation of dataplane/controlplane TLS consistency

### DIFF
--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -17,9 +17,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 
 	"golang.org/x/exp/slices"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -289,4 +291,48 @@ func (r *OpenStackDataPlaneNodeSetSpec) duplicateNodeCheck(nodeSetList *OpenStac
 	}
 
 	return
+}
+
+// Compare TLS settings of control plane and data plane
+// if control plane name is specified attempt to retrieve it
+// otherwise get any control plane in the namespace
+func (r *OpenStackDataPlaneNodeSetSpec) ValidateTLS(namespace string, reconcilerClient client.Client, ctx context.Context) error {
+	var err error
+	controlPlanes := openstackv1.OpenStackControlPlaneList{}
+	opts := client.ListOptions{
+		Namespace: namespace,
+	}
+
+	// Attempt to get list of all ControlPlanes fail if that isn't possible
+	if err = reconcilerClient.List(ctx, &controlPlanes, &opts); err != nil {
+		return err
+	}
+	// Verify TLS status of control plane only if there is a single one
+	// otherwise proceed without verification
+	if len(controlPlanes.Items) == 1 {
+		controlPlane := controlPlanes.Items[0]
+		fieldErr := r.TLSMatch(controlPlane)
+		if fieldErr != nil {
+			err = fmt.Errorf("%s", fieldErr.Error())
+		}
+	}
+
+	return err
+}
+
+// Do TLS flags match in control plane ingress, pods and data plane
+func (r *OpenStackDataPlaneNodeSetSpec) TLSMatch(controlPlane openstackv1.OpenStackControlPlane) *field.Error {
+
+	if controlPlane.Spec.TLS.Ingress.Enabled != r.TLSEnabled || controlPlane.Spec.TLS.PodLevel.Enabled != r.TLSEnabled {
+
+		return field.Forbidden(
+			field.NewPath("spec.tlsEnabled"),
+			fmt.Sprintf(
+				"TLS settings on Data Plane node set and Control Plane %s do not match, Node set: %t Control Plane Ingress: %t Control Plane PodLevel: %t",
+				controlPlane.Name,
+				r.TLSEnabled,
+				controlPlane.Spec.TLS.Ingress.Enabled,
+				controlPlane.Spec.TLS.PodLevel.Enabled))
+	}
+	return nil
 }

--- a/controllers/dataplane/openstackdataplanedeployment_controller.go
+++ b/controllers/dataplane/openstackdataplanedeployment_controller.go
@@ -62,6 +62,7 @@ func (r *OpenStackDataPlaneDeploymentReconciler) GetLogger(ctx context.Context) 
 //+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups=core.openstack.org,resources=openstackcontrolplanes,verbs=get;list;watch;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -175,6 +176,16 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 				dataplanev1.DataPlaneNodeSetErrorMessage,
 				err.Error())
 			// Error reading the object - requeue the request.
+			return ctrl.Result{}, err
+		}
+		if err = nodeSetInstance.Spec.ValidateTLS(instance.GetNamespace(), r.Client, ctx); err != nil {
+			Log.Info("error while comparing TLS settings of nodeset %s with control plane: %w", nodeSet, err)
+			instance.Status.Conditions.MarkFalse(
+				dataplanev1.SetupReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityError,
+				dataplanev1.DataPlaneNodeSetErrorMessage,
+				err.Error())
 			return ctrl.Result{}, err
 		}
 		nodeSets.Items = append(nodeSets.Items, *nodeSetInstance)

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -340,6 +341,101 @@ func DefaultDataplaneGlobalService(name types.NamespacedName) map[string]interfa
 		},
 		"spec": map[string]interface{}{
 			"deployOnAllNodeSets": true,
+		},
+	}
+}
+
+func CreateOpenStackControlPlane(name types.NamespacedName, spec map[string]interface{}) client.Object {
+
+	raw := map[string]interface{}{
+		"apiVersion": "core.openstack.org/v1beta1",
+		"kind":       "OpenStackControlPlane",
+		"metadata": map[string]interface{}{
+			"name":      name.Name,
+			"namespace": name.Namespace,
+		},
+		"spec": spec,
+	}
+	return th.CreateUnstructured(raw)
+}
+
+func GetDefaultOpenStackControlPlaneSpec(enableTLS bool) map[string]interface{} {
+	memcachedTemplate := map[string]interface{}{
+		"memcached": map[string]interface{}{
+			"replicas": 1,
+		},
+	}
+	rabbitTemplate := map[string]interface{}{
+		"rabbitmq": map[string]interface{}{
+			"replicas": 1,
+		},
+		"rabbitmq-cell1": map[string]interface{}{
+			"replicas": 1,
+		},
+	}
+	galeraTemplate := map[string]interface{}{
+		"openstack": map[string]interface{}{
+			"storageRequest": "500M",
+		},
+		"openstack-cell1": map[string]interface{}{
+			"storageRequest": "500M",
+		},
+	}
+	keystoneTemplate := map[string]interface{}{
+		"databaseInstance": "keystone",
+		"secret":           "osp-secret",
+	}
+
+	return map[string]interface{}{
+		"secret":       "osp-secret",
+		"storageClass": "local-storage",
+		"galera": map[string]interface{}{
+			"enabled":   true,
+			"templates": galeraTemplate,
+		},
+		"rabbitmq": map[string]interface{}{
+			"enabled":   true,
+			"templates": rabbitTemplate,
+		},
+		"memcached": map[string]interface{}{
+			"enabled":   true,
+			"templates": memcachedTemplate,
+		},
+		"keystone": map[string]interface{}{
+			"enabled":  true,
+			"template": keystoneTemplate,
+		},
+		"tls": map[string]interface{}{
+			"ingress": map[string]interface{}{
+				"enabled": enableTLS,
+
+				"ca": map[string]interface{}{
+					"customIssuer": "custom-issuer",
+					"duration":     "100h",
+				},
+				"cert": map[string]interface{}{
+					"duration": "10h",
+				},
+			},
+			"podLevel": map[string]interface{}{
+				"enabled": enableTLS,
+				"internal": map[string]interface{}{
+					"ca": map[string]interface{}{
+						"duration": "100h",
+					},
+					"cert": map[string]interface{}{
+						"duration": "10h",
+					},
+				},
+				"ovn": map[string]interface{}{
+					"ca": map[string]interface{}{
+						"duration": "100h",
+					},
+					"cert": map[string]interface{}{
+						"duration": "10h",
+					},
+				},
+			},
 		},
 	}
 }

--- a/tests/functional/dataplane/suite_test.go
+++ b/tests/functional/dataplane/suite_test.go
@@ -98,6 +98,9 @@ var _ = BeforeSuite(func() {
 	infraCRDs, err := test.GetCRDDirFromModule(
 		"github.com/openstack-k8s-operators/infra-operator/apis", gomod, "bases")
 	Expect(err).ShouldNot(HaveOccurred())
+	openstackCRDs, err := test.GetCRDDirFromModule(
+		"github.com/openstack-k8s-operators/openstack-operator/apis", gomod, "bases")
+	Expect(err).ShouldNot(HaveOccurred())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -106,6 +109,7 @@ var _ = BeforeSuite(func() {
 			aeeCRDs,
 			baremetalCRDs,
 			infraCRDs,
+			openstackCRDs,
 		},
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -175,6 +179,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&dataplanev1.OpenStackDataPlaneService{}).SetupWebhookWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&openstackv1.OpenStackControlPlane{}).SetupWebhookWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	kclient, err := kubernetes.NewForConfig(cfg)


### PR DESCRIPTION

Verifies that TLS settings for nodeset are consistent with those of existing control plane, if there is one and only one.

If there are multiple control planes the process will result in error, same if it isn't possible to retrieve list of control planes.

Tests are included

I'm porting this now to the joint repo.