### PR TITLE
Remove the deployed attribute from deployment

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -108,8 +108,6 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
-              deployed:
-                type: boolean
               deployedVersion:
                 type: string
               nodeSetConditions:

--- a/apis/dataplane/v1beta1/openstackdataplanedeployment_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanedeployment_types.go
@@ -89,10 +89,6 @@ type OpenStackDataPlaneDeploymentStatus struct {
 
 	// DeployedVersion
 	DeployedVersion string `json:"deployedVersion,omitempty"`
-
-	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	// Deployed
-	Deployed bool `json:"deployed,omitempty" optional:"true"`
 }
 
 //+kubebuilder:object:root=true
@@ -151,6 +147,4 @@ func (instance *OpenStackDataPlaneDeployment) InitConditions() {
 
 		}
 	}
-
-	instance.Status.Deployed = false
 }

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -108,8 +108,6 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
-              deployed:
-                type: boolean
               deployedVersion:
                 type: string
               nodeSetConditions:

--- a/controllers/dataplane/openstackdataplanedeployment_controller.go
+++ b/controllers/dataplane/openstackdataplanedeployment_controller.go
@@ -98,12 +98,6 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 		Log,
 	)
 
-	// If the deploy is already done, return immediately.
-	if instance.Status.Deployed {
-		Log.Info("Already deployed", "instance.Status.Deployed", instance.Status.Deployed)
-		return ctrl.Result{}, nil
-	}
-
 	// initialize status if Conditions is nil, but do not reset if it already
 	// exists
 	isNewInstance := instance.Status.Conditions == nil
@@ -293,8 +287,6 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 	for _, nodeSet := range nodeSets.Items {
 
 		Log.Info(fmt.Sprintf("Deploying NodeSet: %s", nodeSet.Name))
-		Log.Info("Set Status.Deployed to false", "instance", instance)
-		instance.Status.Deployed = false
 		Log.Info("Set DeploymentReadyCondition false")
 		instance.Status.Conditions.MarkFalse(
 			condition.DeploymentReadyCondition, condition.RequestedReason,
@@ -387,7 +379,6 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 	Log.Info("Set DeploymentReadyCondition true")
 	instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	Log.Info("Set Status.Deployed to true", "instance", instance)
-	instance.Status.Deployed = true
 	if version != nil {
 		instance.Status.DeployedVersion = version.Spec.TargetVersion
 	}

--- a/docs/assemblies/dataplane_resources.adoc
+++ b/docs/assemblies/dataplane_resources.adoc
@@ -172,11 +172,6 @@ OpenStackDataPlaneDeploymentStatus defines the observed state of OpenStackDataPl
 | DeployedVersion
 | string
 | false
-
-| deployed
-| Deployed
-| bool
-| false
 |===
 
 <<custom-resources,Back to Custom Resources>>


### PR DESCRIPTION
We reset the conditions and `deployed: false` for every reconcile now and code to check the deployed flag during reconcile is not relevant and dead code.

We have also made the deployment spec immutable which won't allow for any changes to the spec.