### PR TITLE
Drop make docs from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,6 @@ repos:
       entry: make
       args: ['operator-lint']
       pass_filenames: false
-    - id: make-docs
-      name: make-docs
-      language: system
-      entry: make
-      args: ['docs']
-      pass_filenames: false
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0


### PR DESCRIPTION
Different versions of ruby/bundler may yield different outputs, removing it for now