### PR TITLE
Cinder: Fix `cinderVolumes` changes

### DIFF
--- a/pkg/openstack/cinder.go
+++ b/pkg/openstack/cinder.go
@@ -122,9 +122,8 @@ func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControl
 			return errors.New("default Cinder Volume images is unset")
 		}
 
-		if cinder.Spec.CinderVolumes == nil {
-			cinder.Spec.CinderVolumes = make(map[string]cinderv1.CinderVolumeTemplate)
-		}
+		// Discard old list of volume services and rebuild it
+		cinder.Spec.CinderVolumes = make(map[string]cinderv1.CinderVolumeTemplate)
 
 		for name, volume := range instance.Spec.Cinder.Template.CinderVolumes {
 			cinderCore := cinderv1.CinderVolumeTemplate{}


### PR DESCRIPTION
A regression was introduced on the handling of the `cinderVolumes` on commit 4930eed3380bc945279173c989d1a4c95cdda90e.

The current code is not able to remove entries from the `cinderVolumes` section so backends cannot be removed and they cannot be renamed.

When we try to remove a volume backend, the volume remains in the existing `Cinder` CR.  And when we try to rename a volume backend, we end up with 2 backends in the `Cinder` CR, one with the old name and one with the new name.