### PR TITLE
Check for Ceilometer and Autoscaling dependencies

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -227,6 +227,14 @@ func (r *OpenStackControlPlane) checkDepsEnabled(name string) string {
 			r.Spec.Ovn.Enabled) {
 			reqs = "Galera, Memcached, RabbitMQ, Keystone, Glance, Neutron, Nova, OVN"
 		}
+	case "Telemetry.Autoscaling":
+		if !(r.Spec.Galera.Enabled && r.Spec.Heat.Enabled && r.Spec.Rabbitmq.Enabled && r.Spec.Keystone.Enabled) {
+			reqs = "Galera, Heat, RabbitMQ, Keystone"
+		}
+	case "Telemetry.Ceilometer":
+		if !(r.Spec.Rabbitmq.Enabled && r.Spec.Keystone.Enabled) {
+			reqs = "RabbitMQ, Keystone"
+		}
 	}
 
 	// If "reqs" is not the empty string, we have missing requirements
@@ -480,6 +488,26 @@ func (r *OpenStackControlPlane) ValidateServiceDependencies(basePath *field.Path
 	if r.Spec.Barbican.Enabled {
 		if depErrorMsg := r.checkDepsEnabled("Barbican"); depErrorMsg != "" {
 			err := field.Invalid(basePath.Child("barbican").Child("enabled"), r.Spec.Barbican.Enabled, depErrorMsg)
+			allErrs = append(allErrs, err)
+		}
+	}
+	if r.Spec.Telemetry.Enabled &&
+		r.Spec.Telemetry.Template.Ceilometer.Enabled != nil &&
+		*r.Spec.Telemetry.Template.Ceilometer.Enabled {
+
+		if depErrorMsg := r.checkDepsEnabled("Telemetry.Ceilometer"); depErrorMsg != "" {
+			err := field.Invalid(basePath.Child("telemetry").Child("template").Child("ceilometer").Child("enabled"),
+					     *r.Spec.Telemetry.Template.Ceilometer.Enabled, depErrorMsg)
+			allErrs = append(allErrs, err)
+		}
+	}
+	if r.Spec.Telemetry.Enabled &&
+		r.Spec.Telemetry.Template.Autoscaling.Enabled != nil &&
+		*r.Spec.Telemetry.Template.Autoscaling.Enabled {
+
+		if depErrorMsg := r.checkDepsEnabled("Telemetry.Autoscaling"); depErrorMsg != "" {
+			err := field.Invalid(basePath.Child("telemetry").Child("template").Child("autoscaling").Child("enabled"),
+					     *r.Spec.Telemetry.Template.Autoscaling.Enabled, depErrorMsg)
 			allErrs = append(allErrs, err)
 		}
 	}


### PR DESCRIPTION
The functionality is the same as in the reverted https://github.com/openstack-k8s-operators/openstack-operator/pull/837 . But this time it takes into account recent switch of "enabled" fields in telemetry to pointers.