### PR TITLE
Moving to checkout v4 as the nodejs v16 has reached EoL

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: check for replace lines in go.mod files
         run: |
           ! egrep --invert-match -e '^replace.*/apis => \./apis|^replace.*//allow-merging$'  `find . -name 'go.mod'` | egrep -e 'go.mod:replace'


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/