### PR TITLE
Create cloudrc file in `openstackclient` pod

### DIFF
--- a/pkg/openstackclient/funcs.go
+++ b/pkg/openstackclient/funcs.go
@@ -106,6 +106,11 @@ func clientPodVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/home/cloud-admin/.config/openstack/secure.yaml",
 			SubPath:   "secure.yaml",
 		},
+		{
+			Name:      "openstack-config-secret",
+			MountPath: "/home/cloud-admin/cloudrc",
+			SubPath:   "cloudrc",
+		},
 	}
 }
 

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -700,13 +700,13 @@ var _ = Describe("OpenStackOperator controller", func() {
 				}
 				g.Expect(vols).To(ContainElements("combined-ca-bundle", "openstack-config", "openstack-config-secret"))
 
-				volMounts := map[string]string{}
+				volMounts := map[string][]string{}
 				for _, x := range pod.Spec.Containers[0].VolumeMounts {
-					volMounts[x.Name] = x.MountPath
+					volMounts[x.Name] = append(volMounts[x.Name], x.MountPath)
 				}
-				g.Expect(volMounts).To(HaveKeyWithValue("combined-ca-bundle", "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"))
-				g.Expect(volMounts).To(HaveKeyWithValue("openstack-config", "/home/cloud-admin/.config/openstack/clouds.yaml"))
-				g.Expect(volMounts).To(HaveKeyWithValue("openstack-config-secret", "/home/cloud-admin/.config/openstack/secure.yaml"))
+				g.Expect(volMounts).To(HaveKeyWithValue("combined-ca-bundle", []string{"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"}))
+				g.Expect(volMounts).To(HaveKeyWithValue("openstack-config", []string{"/home/cloud-admin/.config/openstack/clouds.yaml"}))
+				g.Expect(volMounts).To(HaveKeyWithValue("openstack-config-secret", []string{"/home/cloud-admin/.config/openstack/secure.yaml", "/home/cloud-admin/cloudrc"}))
 
 				// simulate pod being in the ready state
 				th.SimulatePodReady(names.OpenStackClientName)
@@ -985,13 +985,13 @@ var _ = Describe("OpenStackOperator controller", func() {
 				}
 				g.Expect(vols).To(ContainElements("combined-ca-bundle", "openstack-config", "openstack-config-secret"))
 
-				volMounts := map[string]string{}
+				volMounts := map[string][]string{}
 				for _, x := range pod.Spec.Containers[0].VolumeMounts {
-					volMounts[x.Name] = x.MountPath
+					volMounts[x.Name] = append(volMounts[x.Name], x.MountPath)
 				}
-				g.Expect(volMounts).To(HaveKeyWithValue("combined-ca-bundle", "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"))
-				g.Expect(volMounts).To(HaveKeyWithValue("openstack-config", "/home/cloud-admin/.config/openstack/clouds.yaml"))
-				g.Expect(volMounts).To(HaveKeyWithValue("openstack-config-secret", "/home/cloud-admin/.config/openstack/secure.yaml"))
+				g.Expect(volMounts).To(HaveKeyWithValue("combined-ca-bundle", []string{"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"}))
+				g.Expect(volMounts).To(HaveKeyWithValue("openstack-config", []string{"/home/cloud-admin/.config/openstack/clouds.yaml"}))
+				g.Expect(volMounts).To(HaveKeyWithValue("openstack-config-secret", []string{"/home/cloud-admin/.config/openstack/secure.yaml", "/home/cloud-admin/cloudrc"}))
 
 				// simulate pod being in the ready state
 				th.SimulatePodReady(names.OpenStackClientName)


### PR DESCRIPTION
We are currently only creating the `clouds.yaml` and `secure.yaml` in the `openstackclient` pod, and that is enough for the openstack client, but unfortunately this is not enough since there is no parity between that client and the individual clients.

For example it is missing (though it has upstream patches in progress):

- The `openstack volume service list` cannot show the cluster.
- The `openstack volume service list` cannot show the backend state.
- There is no support for any of the default volume type commands: set, show, list, unset.

These are some of the ones we know about, but there could still be some other missing.

Users will need to use the old `cinder` client, so we should make it convenient for them by having the `cloudrc` available in the `openstackclient` pod.

Depends-On: https://github.com/openstack-k8s-operators/keystone-operator/pull/432