### PR TITLE
Don't mount on /runner/env/ssh_key

### DIFF
--- a/pkg/dataplane/util/ansible_execution.go
+++ b/pkg/dataplane/util/ansible_execution.go
@@ -142,18 +142,12 @@ func AnsibleExecution(
 
 		for _, sshKeyNodeName := range sshKeys {
 			sshKeySecret := sshKeySecrets[sshKeyNodeName]
-			if service.Spec.DeployOnAllNodeSets {
-				sshKeyName = fmt.Sprintf("ssh-key-%s", sshKeyNodeName)
-				sshKeyMountSubPath = fmt.Sprintf("ssh_key_%s", sshKeyNodeName)
-				sshKeyMountPath = fmt.Sprintf("/runner/env/ssh_key/%s", sshKeyMountSubPath)
-			} else {
-				if sshKeyNodeName != nodeSet.GetName() {
-					continue
-				}
-				sshKeyName = "ssh-key"
-				sshKeyMountSubPath = "ssh_key"
-				sshKeyMountPath = "/runner/env/ssh_key"
+			if !service.Spec.DeployOnAllNodeSets && sshKeyNodeName != nodeSet.GetName() {
+				continue
 			}
+			sshKeyName = fmt.Sprintf("ssh-key-%s", sshKeyNodeName)
+			sshKeyMountSubPath = fmt.Sprintf("ssh_key_%s", sshKeyNodeName)
+			sshKeyMountPath = fmt.Sprintf("/runner/env/ssh_key/%s", sshKeyMountSubPath)
 			sshKeyVolume := corev1.Volume{
 				Name: sshKeyName,
 				VolumeSource: corev1.VolumeSource{

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -150,18 +150,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -200,18 +200,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -251,18 +251,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -301,18 +301,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -351,18 +351,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -402,18 +402,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -452,18 +452,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -502,18 +502,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -564,18 +564,18 @@ spec:
         name: ovncontroller-config
       name: ovncontroller-config-0
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -655,18 +655,18 @@ spec:
           path: nova-metadata-config.json
         secretName: nova-metadata-neutron-config
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -717,18 +717,18 @@ spec:
         secretName: neutron-ovn-agent-neutron-config
       name: neutron-ovn-agent-neutron-config-0
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -779,18 +779,18 @@ spec:
         secretName: neutron-sriov-agent-neutron-config
       name: neutron-sriov-agent-neutron-config-0
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -841,18 +841,18 @@ spec:
         secretName: neutron-dhcp-agent-neutron-config
       name: neutron-dhcp-agent-neutron-config-0
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -903,18 +903,18 @@ spec:
           path: LibvirtPassword
         secretName: libvirt-secret
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -989,18 +989,18 @@ spec:
           path: ssh-publickey
         secretName: nova-migration-ssh-key
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
+      name: ssh-key-edpm-compute-global
+      subPath: ssh_key_edpm-compute-global
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-global
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-global
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
@@ -88,18 +88,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-beta-nodeset
+      name: ssh-key-edpm-compute-beta-nodeset
+      subPath: ssh_key_edpm-compute-beta-nodeset
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-beta-nodeset
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-beta-nodeset
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -138,18 +138,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-beta-nodeset
+      name: ssh-key-edpm-compute-beta-nodeset
+      subPath: ssh_key_edpm-compute-beta-nodeset
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-beta-nodeset
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-beta-nodeset
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
@@ -138,18 +138,18 @@ spec:
       secret:
         secretName: combined-ca-bundle
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_openstack-edpm-tls
+      name: ssh-key-openstack-edpm-tls
+      subPath: ssh_key_openstack-edpm-tls
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-openstack-edpm-tls
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_openstack-edpm-tls
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -185,18 +185,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_openstack-edpm-tls
+      name: ssh-key-openstack-edpm-tls
+      subPath: ssh_key_openstack-edpm-tls
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-openstack-edpm-tls
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_openstack-edpm-tls
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -81,18 +81,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -133,18 +133,18 @@ spec:
     foo: bar
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -184,18 +184,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -234,18 +234,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -284,18 +284,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -335,18 +335,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -385,18 +385,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -435,18 +435,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -497,18 +497,18 @@ spec:
         name: ovncontroller-config
       name: ovncontroller-config-0
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -588,18 +588,18 @@ spec:
           path: nova-metadata-config.json
         secretName: nova-metadata-neutron-config
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -650,18 +650,18 @@ spec:
         secretName: neutron-ovn-agent-neutron-config
       name: neutron-ovn-agent-neutron-config-0
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -712,18 +712,18 @@ spec:
         secretName: neutron-sriov-agent-neutron-config
       name: neutron-sriov-agent-neutron-config-0
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -774,18 +774,18 @@ spec:
         secretName: neutron-dhcp-agent-neutron-config
       name: neutron-dhcp-agent-neutron-config-0
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -836,18 +836,18 @@ spec:
           path: LibvirtPassword
         secretName: libvirt-secret
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -922,18 +922,18 @@ spec:
           path: ssh-publickey
         secretName: nova-migration-ssh-key
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
@@ -26,18 +26,18 @@ spec:
   envConfigMapName: openstack-aee-default-env
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -93,18 +93,18 @@ spec:
         name: ovncontroller-config
       name: ovncontroller-config-0
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
@@ -86,18 +86,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-beta-nodeset
+      name: ssh-key-edpm-compute-beta-nodeset
+      subPath: ssh_key_edpm-compute-beta-nodeset
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-beta-nodeset
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-beta-nodeset
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -136,18 +136,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-beta-nodeset
+      name: ssh-key-edpm-compute-beta-nodeset
+      subPath: ssh_key_edpm-compute-beta-nodeset
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-beta-nodeset
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-beta-nodeset
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -173,18 +173,18 @@ spec:
       secret:
         secretName: combined-ca-bundle
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_openstack-edpm-tls
+      name: ssh-key-openstack-edpm-tls
+      subPath: ssh_key_openstack-edpm-tls
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-openstack-edpm-tls
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_openstack-edpm-tls
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -220,18 +220,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_openstack-edpm-tls
+      name: ssh-key-openstack-edpm-tls
+      subPath: ssh_key_openstack-edpm-tls
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-openstack-edpm-tls
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_openstack-edpm-tls
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -186,18 +186,18 @@ spec:
       secret:
         secretName: combined-ca-bundle
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_openstack-edpm-tls
+      name: ssh-key-openstack-edpm-tls
+      subPath: ssh_key_openstack-edpm-tls
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-openstack-edpm-tls
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_openstack-edpm-tls
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -233,18 +233,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_openstack-edpm-tls
+      name: ssh-key-openstack-edpm-tls
+      subPath: ssh_key_openstack-edpm-tls
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-openstack-edpm-tls
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_openstack-edpm-tls
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:
@@ -280,18 +280,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_openstack-edpm-tls
+      name: ssh-key-openstack-edpm-tls
+      subPath: ssh_key_openstack-edpm-tls
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-openstack-edpm-tls
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_openstack-edpm-tls
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
@@ -50,18 +50,18 @@ spec:
         claimName: edpm-ansible
         readOnly: true
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-extramounts
+      name: ssh-key-edpm-extramounts
+      subPath: ssh_key_edpm-extramounts
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-extramounts
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-extramounts
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
@@ -80,18 +80,18 @@ spec:
           path: 30-kuttl-service.conf
         name: kuttl-service-cm-2
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -69,18 +69,18 @@ spec:
   backoffLimit: 6
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-no-nodes-custom-svc
+      name: ssh-key-edpm-no-nodes-custom-svc
+      subPath: ssh_key_edpm-no-nodes-custom-svc
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-no-nodes-custom-svc
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-no-nodes-custom-svc
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:

--- a/tests/kuttl/tests/dataplane-service-failure/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-failure/00-assert.yaml
@@ -30,18 +30,18 @@ spec:
   envConfigMapName: openstack-aee-default-env
   extraMounts:
   - mounts:
-    - mountPath: /runner/env/ssh_key
-      name: ssh-key
-      subPath: ssh_key
+    - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-no-nodes
+      name: ssh-key-edpm-compute-no-nodes
+      subPath: ssh_key_edpm-compute-no-nodes
     - mountPath: /runner/inventory/hosts
       name: inventory
       subPath: inventory
     volumes:
-    - name: ssh-key
+    - name: ssh-key-edpm-compute-no-nodes
       secret:
         items:
         - key: ssh-privatekey
-          path: ssh_key
+          path: ssh_key_edpm-compute-no-nodes
         secretName: dataplane-ansible-ssh-private-key-secret
     - name: inventory
       secret:


### PR DESCRIPTION
Though this is the default from which ansible-runner uses the ssh_key, it does not match with `ansible_ssh_private_key_file` var in the inventrory. This results in ambiguous error when ssh_key is not valid as it looks for `ansible_ssh_private_key_file` as fallback and the location does not exist.

Let's not mount on the default runner location and instead in location that matches with `ansible_ssh_private_key_file`.

Related Jira: https://issues.redhat.com/browse/OSPRH-8085
Related Jira: https://issues.redhat.com/browse/OSPRH-8057
Signed-off-by: rabi <ramishra@redhat.com>