### PR TITLE
Use oc kustomize instead of kustomize to build the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,8 @@ docs-clean:
 	rm -r docs_build
 
 .PHONY: docs-examples
-docs-kustomize-examples: export KUSTOMIZE_VERSION=v5.0.1
-docs-kustomize-examples: yq kustomize ## Generate updated docs from examples using kustomize
-	KUSTOMIZE=$(KUSTOMIZE) LOCALBIN=$(LOCALBIN) ./docs/kustomize_to_docs.sh
+docs-kustomize-examples: oc yq ## Generate updated docs from examples using kustomize
+	LOCALBIN=$(LOCALBIN) ./docs/kustomize_to_docs.sh
 
 ##@ General
 
@@ -270,6 +269,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.11.1
 CRD_MARKDOWN_VERSION ?= v0.0.3
 KUTTL_VERSION ?= 0.17.0
 GOTOOLCHAIN_VERSION ?= go1.21.0
+OC_VERSION ?= 4.14.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -363,10 +363,16 @@ endif
 endif
 
 .PHONY: yq
-yq: ## Download and install yq in local env
+yq: $(LOCALBIN) ## Download and install yq in local env
 	test -s $(LOCALBIN)/yq || ( cd $(LOCALBIN) &&\
 	wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64.tar.gz -O - |\
 	tar xz && mv yq_linux_amd64 $(LOCALBIN)/yq )
+
+.PHONY: oc
+oc: $(LOCALBIN) ## Download and install oc in local env
+	test -s $(LOCALBIN)/oc || ( cd $(LOCALBIN) &&\
+	wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$(OC_VERSION)/openshift-client-linux-$(OC_VERSION).tar.gz -O - |\
+	tar xz)
 
 # Build make variables to export for shell
 MAKE_ENV := $(shell echo '$(.VARIABLES)' | awk -v RS=' ' '/^(IMAGE)|.*?(REGISTRY)$$/')

--- a/docs/kustomize_to_docs.sh
+++ b/docs/kustomize_to_docs.sh
@@ -5,7 +5,7 @@ BAREMETAL=docs/assemblies/ref_example-OpenStackDataPlaneNodeSet-CR-for-bare-meta
 FOOTER=$(sed '0,/----/d' $BAREMETAL | sed -e '0,/----/d')
 sed -i '/----/q' $BAREMETAL
 sed -i 's/preprovisioned/baremetal/' config/samples/dataplane/no_vars_from/kustomization.yaml
-$KUSTOMIZE --load-restrictor LoadRestrictionsNone build config/samples/dataplane/no_vars_from | $LOCALBIN/yq ' select(.kind == "OpenStackDataPlaneNodeSet")' >> $BAREMETAL
+$LOCALBIN/oc kustomize --load-restrictor LoadRestrictionsNone config/samples/dataplane/no_vars_from | $LOCALBIN/yq ' select(.kind == "OpenStackDataPlaneNodeSet")' >> $BAREMETAL
 sed -i 's/\/baremetal/\/preprovisioned/' config/samples/dataplane/no_vars_from/kustomization.yaml
 echo -e "----\n$FOOTER" >> $BAREMETAL
 
@@ -32,7 +32,7 @@ done
 PREPROVISIONED=docs/assemblies/ref_example-OpenStackDataPlaneNodeSet-CR-for-preprovisioned-nodes.adoc
 FOOTER=$(sed '0,/----/d' $PREPROVISIONED | sed -e '0,/----/d')
 sed -i '/----/q' $PREPROVISIONED
-$KUSTOMIZE --load-restrictor LoadRestrictionsNone build config/samples/dataplane/no_vars_from | $LOCALBIN/yq ' select(.kind == "OpenStackDataPlaneNodeSet")' >> $PREPROVISIONED
+$LOCALBIN/oc kustomize --load-restrictor LoadRestrictionsNone config/samples/dataplane/no_vars_from | $LOCALBIN/yq ' select(.kind == "OpenStackDataPlaneNodeSet")' >> $PREPROVISIONED
 echo -e "----\n$FOOTER" >> $PREPROVISIONED
 
 COUNT=1


### PR DESCRIPTION
For not mixing the kustomize versions (CRDs and docs), use oc kustomize for docs


