### PR TITLE
Set NodeSet.Status.DeployedVersion when update service is complete

### DIFF
--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -112,7 +112,30 @@ func CreateSSHSecret(name types.NamespacedName) *corev1.Secret {
 	)
 }
 
+// Create OpenStackVersion
+func CreateOpenStackVersion(name types.NamespacedName) *unstructured.Unstructured {
+	raw := DefaultOpenStackVersion(name)
+	return th.CreateUnstructured(raw)
+}
+
 // Struct initialization
+
+func DefaultOpenStackVersion(name types.NamespacedName) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "core.openstack.org/v1beta1",
+		"kind":       "OpenStackVersion",
+		"metadata": map[string]interface{}{
+			"name":      name.Name,
+			"namespace": name.Namespace,
+		},
+		"spec": map[string]interface{}{
+			"targetVersion": "0.0.1",
+		},
+		"status": map[string]interface{}{
+			"availableVersion": "0.0.1",
+		},
+	}
+}
 
 // Build OpenStackDataPlaneNodeSetSpec struct and fill it with preset values
 func DefaultDataPlaneNodeSetSpec(nodeSetName string) map[string]interface{} {
@@ -177,6 +200,16 @@ func DefaultDataPlaneDeploymentSpec() map[string]interface{} {
 			"edpm-compute-nodeset",
 		},
 		"servicesOverride": []string{},
+	}
+}
+
+func MinorUpdateDataPlaneDeploymentSpec() map[string]interface{} {
+
+	return map[string]interface{}{
+		"nodeSets": []string{
+			"edpm-compute-nodeset",
+		},
+		"servicesOverride": []string{"update"},
 	}
 }
 

--- a/tests/functional/dataplane/suite_test.go
+++ b/tests/functional/dataplane/suite_test.go
@@ -177,6 +177,9 @@ var _ = BeforeSuite(func() {
 	err = (&dataplanev1.OpenStackDataPlaneService{}).SetupWebhookWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&openstackv1.OpenStackVersion{}).SetupWebhookWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
 	kclient, err := kubernetes.NewForConfig(cfg)
 	Expect(err).ToNot(HaveOccurred(), "failed to create kclient")
 	err = (&dataplanecontrollers.OpenStackDataPlaneNodeSetReconciler{


### PR DESCRIPTION
Set NodeSet.Status.DeployedVersion when update service is complete

Changes setting NodeSet.Status.DeployedVersion to be only when a
Deployment has completed that contains a service where EDPMServiceType
== 'update'. When satisfied, the Deployment's Status.DeployedVersion
will be copied to NodeSet.Status.DeployedVersion.

Jira: https://issues.redhat.com/browse/OSPRH-8176
Signed-off-by: James Slagle <jslagle@redhat.com>
