### PR TITLE
Add configuration of --procs for ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,9 @@ golangci-lint:
 .PHONY: test
 test: manifests generate gowork fmt vet envtest ginkgo ginkgo-run ## Run ginkgo tests with dependencies.
 
+PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)
+PROC_CMD = --procs ${PROCS}
+
 .PHONY: ginkgo-run
 ginkgo-run: ## Run ginkgo.
 	source hack/export_related_images.sh && \


### PR DESCRIPTION
${PROC_CMD} is used in the call to ginkgo, but never set anywhere.

Signed-off-by: James Slagle <jslagle@redhat.com>
