### PR TITLE
Pass context based on signal handlers to managers

### DIFF
--- a/controllers/client/openstackclient_controller.go
+++ b/controllers/client/openstackclient_controller.go
@@ -436,9 +436,10 @@ var allWatchFields = []string{
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpenStackClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpenStackClientReconciler) SetupWithManager(
+	ctx context.Context, mgr ctrl.Manager) error {
 	// index caBundleSecretNameField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &clientv1.OpenStackClient{}, caBundleSecretNameField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &clientv1.OpenStackClient{}, caBundleSecretNameField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*clientv1.OpenStackClient)
 		if cr.Spec.CaBundleSecretName == "" {
@@ -449,7 +450,7 @@ func (r *OpenStackClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 	// index openStackConfigMap
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &clientv1.OpenStackClient{}, openStackConfigMapField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &clientv1.OpenStackClient{}, openStackConfigMapField, func(rawObj client.Object) []string {
 		// Extract the configmap name from the spec, if one is provided
 		cr := rawObj.(*clientv1.OpenStackClient)
 		if cr.Spec.OpenStackConfigMap == nil {
@@ -463,7 +464,7 @@ func (r *OpenStackClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 	// index openStackConfigSecret
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &clientv1.OpenStackClient{}, openStackConfigSecretField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &clientv1.OpenStackClient{}, openStackConfigSecretField, func(rawObj client.Object) []string {
 		// Extract the configmap name from the spec, if one is provided
 		cr := rawObj.(*clientv1.OpenStackClient)
 		if cr.Spec.OpenStackConfigSecret == nil {
@@ -477,7 +478,7 @@ func (r *OpenStackClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	Log := r.GetLogger(context.Background())
+	Log := r.GetLogger(ctx)
 	metricStorageFn := func(ctx context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 
@@ -486,7 +487,7 @@ func (r *OpenStackClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(context.Background(), openstackclients, listOpts...); err != nil {
+		if err := r.Client.List(ctx, openstackclients, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve OpenstackClient CRs %v")
 			return nil
 		}

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -473,9 +473,10 @@ var allWatchFields = []string{
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OpenStackControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *OpenStackControlPlaneReconciler) SetupWithManager(
+	ctx context.Context, mgr ctrl.Manager) error {
 	// index passwordSecretField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1beta1.OpenStackControlPlane{}, passwordSecretField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1beta1.OpenStackControlPlane{}, passwordSecretField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*corev1beta1.OpenStackControlPlane)
 		if cr.Spec.Secret == "" {
@@ -487,7 +488,7 @@ func (r *OpenStackControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) err
 	}
 
 	// index caBundleSecretNameField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1beta1.OpenStackControlPlane{}, tlsCABundleSecretNameField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1beta1.OpenStackControlPlane{}, tlsCABundleSecretNameField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*corev1beta1.OpenStackControlPlane)
 		if cr.Spec.TLS.CaBundleSecretName == "" {
@@ -499,7 +500,7 @@ func (r *OpenStackControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) err
 	}
 
 	// index tlsIngressCACustomIssuer
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1beta1.OpenStackControlPlane{}, tlsIngressCACustomIssuer, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1beta1.OpenStackControlPlane{}, tlsIngressCACustomIssuer, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*corev1beta1.OpenStackControlPlane)
 		if cr.Spec.TLS.Ingress.Ca.CustomIssuer == nil {
@@ -511,7 +512,7 @@ func (r *OpenStackControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) err
 	}
 
 	// index tlsPodLevelInternalCACustomIssuer
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1beta1.OpenStackControlPlane{}, tlsPodLevelInternalCACustomIssuer, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1beta1.OpenStackControlPlane{}, tlsPodLevelInternalCACustomIssuer, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*corev1beta1.OpenStackControlPlane)
 		if cr.Spec.TLS.PodLevel.Internal.Ca.CustomIssuer == nil {
@@ -523,7 +524,7 @@ func (r *OpenStackControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) err
 	}
 
 	// index tlsPodLevelOvnCACustomIssuer
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1beta1.OpenStackControlPlane{}, tlsPodLevelOvnCACustomIssuer, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1beta1.OpenStackControlPlane{}, tlsPodLevelOvnCACustomIssuer, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*corev1beta1.OpenStackControlPlane)
 		if cr.Spec.TLS.PodLevel.Ovn.Ca.CustomIssuer == nil {

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ import (
 	placementv1 "github.com/openstack-k8s-operators/placement-operator/api/v1beta1"
 	swiftv1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
+
 	// Note(lpiwowar): Please, do not remove! This import is necessary in order
 	// to make the test-operator part of the openstack-operator-index.
 	_ "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
@@ -180,6 +181,8 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+	// Setup the context that's going to be used in controllers and for the manager.
+	ctx := ctrl.SetupSignalHandler()
 
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -196,7 +199,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackControlPlane")
 		os.Exit(1)
 	}
@@ -205,7 +208,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackClient")
 		os.Exit(1)
 	}
@@ -223,7 +226,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenStackDataPlaneNodeSet")
 		os.Exit(1)
 	}
@@ -293,7 +296,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/pkg/dataplane/hashes.go
+++ b/pkg/dataplane/hashes.go
@@ -44,7 +44,7 @@ func GetDeploymentHashesForService(
 		Namespace: namespace,
 	}
 	service := &dataplanev1.OpenStackDataPlaneService{}
-	err := helper.GetClient().Get(context.Background(), namespacedName, service)
+	err := helper.GetClient().Get(ctx, namespacedName, service)
 	if err != nil {
 		helper.GetLogger().Error(err, "Unable to retrieve OpenStackDataPlaneService %v")
 		return err

--- a/tests/functional/ctlplane/suite_test.go
+++ b/tests/functional/ctlplane/suite_test.go
@@ -322,7 +322,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&core_ctrl.OpenStackVersionReconciler{
@@ -336,7 +336,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/tests/functional/dataplane/suite_test.go
+++ b/tests/functional/dataplane/suite_test.go
@@ -186,7 +186,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&dataplanecontrollers.OpenStackDataPlaneDeploymentReconciler{


### PR DESCRIPTION
And don't use context.Background() which is an empty context when context is available.