### PR TITLE
[18.0.0-proposed]Use branch specific renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,12 @@
 {
   "extends": [
-    "github>openstack-k8s-operators/renovate-config:default.json5"
+    "github>openstack-k8s-operators/renovate-config:18.0.0-proposed.json5"
   ],
-  "baseBranches": ["main"],
   "useBaseBranchConfig": "merge",
   "packageRules": [
     {
       "matchPackageNames": ["github.com/openstack-k8s-operators/openstack-operator/apis"],
       "enabled": false
     }
-  ],
-  "postUpgradeTasks": {
-    "commands": ["make gowork", "make tidy", "make manifests generate"],
-    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
-    "executionMode": "update"
-  }
+  ]
 }


### PR DESCRIPTION
It depends on https://github.com/openstack-k8s-operators/renovate-config/pull/17 (but I cannot add a Depends-On as that hurts RDO zuul)
Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)