### PR TITLE
Enable renovate on 18.0.0-proposed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "github>openstack-k8s-operators/renovate-config:default.json5"
   ],
-  "baseBranches": ["main"],
+  "baseBranches": ["main", "18.0.0-proposed"],
   "useBaseBranchConfig": "merge",
   "packageRules": [
     {


### PR DESCRIPTION
I uses  openstack-k8s-operators/renovate-config#17 (but cannot add Depends-On as that hurts RDO zuul)
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/919 
Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)
