### PR TITLE
[18.0.0-proposed] Fix rabbitmq IPv6 with TLS/FIPS

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -206,6 +206,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - networks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -111,6 +111,7 @@ func (r *OpenStackControlPlaneReconciler) GetLogger(ctx context.Context) logr.Lo
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;create;update;patch;delete;
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete;
+//+kubebuilder:rbac:groups=config.openshift.io,resources=networks,verbs=get;list;watch;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240624132705-6c8da3c0bbfd
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240709171418-83ff4f73c986
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240624132705-6c8da3c0bbfd
-	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240624132705-6c8da3c0bbfd
+	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240709171418-83ff4f73c986
 	github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240709222938-272b1b93e719
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240709194146-eb1cfc2518c5
 	github.com/openstack-k8s-operators/neutron-operator/api v0.3.1-0.20240710004943-45c853971543

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024062
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240624132705-6c8da3c0bbfd/go.mod h1:zuPcZ5Kopr15AdfxvA0xqKIIGCZ0XbSe/0VHNKuvbEE=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240624132705-6c8da3c0bbfd h1:MY3MDe11c9R/kp0ALVeaWHIdRpbQh9Xs3ym/Z/KBBlU=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240624132705-6c8da3c0bbfd/go.mod h1:v9iFrR8J5fZACS9W5pZau/4lwyWs/YmO4ezpDeoEFKU=
-github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240624132705-6c8da3c0bbfd h1:FDN/wK2+B+9IwIpuY8K1CCLjqrzSLVXuqn9PFWPX+LM=
-github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240624132705-6c8da3c0bbfd/go.mod h1:0h76CxD9g0z2Hk7fGFOZcjnzT1tQQ/yRNv3OXng+S/A=
+github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240709171418-83ff4f73c986 h1:DS6K5o+Mb3ghNsf/6als1+LjpqSAknvqetuDSUdxV9M=
+github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240709171418-83ff4f73c986/go.mod h1:0h76CxD9g0z2Hk7fGFOZcjnzT1tQQ/yRNv3OXng+S/A=
 github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240709222938-272b1b93e719 h1:SZqwffeJXG73gYiMab7yPtrMJkA2mtOatMw8hsSpjGg=
 github.com/openstack-k8s-operators/manila-operator/api v0.3.1-0.20240709222938-272b1b93e719/go.mod h1:Vc61/6I9y+fBCw6k0HVi29mStMEvq0G1IMquFQJfGhM=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240709194146-eb1cfc2518c5 h1:kRO+Q9xd4YChb4WZtGmbNoaU8dkYsAHNCqDsSWXAA5A=

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ import (
 	placementv1 "github.com/openstack-k8s-operators/placement-operator/api/v1beta1"
 	swiftv1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
+
 	// Note(lpiwowar): Please, do not remove! This import is necessary in order
 	// to make the test-operator part of the openstack-operator-index.
 	_ "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
@@ -75,6 +76,7 @@ import (
 	corev1 "github.com/openstack-k8s-operators/openstack-operator/apis/core/v1beta1"
 	dataplanev1 "github.com/openstack-k8s-operators/openstack-operator/apis/dataplane/v1beta1"
 
+	ocp_configv1 "github.com/openshift/api/config/v1"
 	clientcontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/client"
 	corecontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/core"
 	dataplanecontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/dataplane"
@@ -117,6 +119,7 @@ func init() {
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(certmgrv1.AddToScheme(scheme))
 	utilruntime.Must(barbicanv1.AddToScheme(scheme))
+	utilruntime.Must(ocp_configv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/tests/functional/ctlplane/suite_test.go
+++ b/tests/functional/ctlplane/suite_test.go
@@ -59,6 +59,7 @@ import (
 	client_ctrl "github.com/openstack-k8s-operators/openstack-operator/controllers/client"
 	core_ctrl "github.com/openstack-k8s-operators/openstack-operator/controllers/core"
 
+	ocp_configv1 "github.com/openshift/api/config/v1"
 	infra_test "github.com/openstack-k8s-operators/infra-operator/apis/test/helpers"
 	keystone_test "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	certmanager_test "github.com/openstack-k8s-operators/lib-common/modules/certmanager/test/helpers"
@@ -173,6 +174,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ShouldNot(HaveOccurred())
 	certmgrv1CRDs, err := test.GetOpenShiftCRDDir("cert-manager/v1", gomod)
 	Expect(err).ShouldNot(HaveOccurred())
+	ocpconfigv1CRDs, err := test.GetOpenShiftCRDDir("config/v1", gomod)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -199,6 +202,7 @@ var _ = BeforeSuite(func() {
 			barbicanv1CRDs,
 			rabbitmqv2CRDs,
 			certmgrv1CRDs,
+			ocpconfigv1CRDs,
 		},
 		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
@@ -265,6 +269,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	err = networkv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	err = ocp_configv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme
 
@@ -285,6 +291,8 @@ var _ = BeforeSuite(func() {
 	Expect(crtmgr).NotTo(BeNil())
 	ovn = ovn_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(ovn).NotTo(BeNil())
+
+	th.CreateClusterNetworkConfig()
 
 	// Start the controller-manager if goroutine
 	webhookInstallOptions := &testEnv.WebhookInstallOptions


### PR DESCRIPTION
Rabbitmq IPv6 config requires changes to RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS and RABBITMQ_CTL_ERL_ARGS which are clobbered by the TLS/FIPS config. Rework the logic that build the args to handle this.

Closes: [OSPRH-8372](https://issues.redhat.com//browse/OSPRH-8372)

(cherry-pick from e7136ae7f3dce0eb5cc5c6a4e25224e6e02d65de)