### PR TITLE
[rabbitmq] remove CommonName from tls cert

### DIFF
--- a/pkg/openstack/rabbitmq.go
+++ b/pkg/openstack/rabbitmq.go
@@ -272,13 +272,10 @@ func reconcileRabbitMQ(
 	}
 
 	tlsCert := ""
-	commonName := fmt.Sprintf("%s.%s", hostname, ClusterInternalDomain)
-
 	if instance.Spec.TLS.PodLevel.Enabled {
 		certRequest := certmanager.CertificateRequest{
 			IssuerName: instance.GetInternalIssuer(),
 			CertName:   fmt.Sprintf("%s-svc", rabbitmq.Name),
-			CommonName: &commonName,
 			Hostnames:  hostnames,
 			Subject: &certmgrv1.X509Subject{
 				Organizations: []string{fmt.Sprintf("%s.%s", rabbitmq.Namespace, ClusterInternalDomain)},


### PR DESCRIPTION
The CommonName has a max length of 64 bytes. Since the CommonName value is already in the DnsNames of the certificate it is not required.

Jira: https://issues.redhat.com/browse/OSPRH-8652