### PR TITLE
[nova] use short service name for CommonName vencrypt cert

### DIFF
--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -270,10 +270,15 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 				// create novncproxy vencrypt cert
 				if instance.Spec.TLS.PodLevel.Enabled {
 					serviceName := endpointDetails.EndpointDetails[service.EndpointPublic].Service.Spec.Name
+					hostname := fmt.Sprintf("%s.%s.svc", serviceName, instance.Namespace)
 					certRequest := certmanager.CertificateRequest{
 						IssuerName: instance.GetLibvirtIssuer(),
 						CertName:   nova.Name + "-novncproxy-" + cellName + "-vencrypt",
-						CommonName: ptr.To(fmt.Sprintf("%s.%s.svc", serviceName, instance.Namespace)),
+						CommonName: ptr.To(serviceName), // common name has a max length of 64bytes, therefore just set the short name
+						Hostnames: []string{
+							hostname,
+							fmt.Sprintf("%s.%s", hostname, ClusterInternalDomain),
+						},
 						Subject: &certmgrv1.X509Subject{
 							Organizations: []string{fmt.Sprintf("%s.%s", instance.Namespace, ClusterInternalDomain)},
 						},


### PR DESCRIPTION
The CommonName has a max length of 64 bytes.

From https://docs.openstack.org/nova/latest/admin/remote-console-access.html#vnc-proxy-security

~~~
An x509 certificate to be presented to the VNC server. While libvirt/QEMU will not currently do any validation of the CommonName field, future versions will allow for setting up access controls based on the CommonName. The CommonName field should match the primary hostname of the controller node.
~~~

Related: https://issues.redhat.com/browse/OSPRH-8652