### PR TITLE
Mount under /var/lib/openstack/configs using EDPMServiceType

### DIFF
--- a/pkg/dataplane/deployment.go
+++ b/pkg/dataplane/deployment.go
@@ -368,7 +368,7 @@ func (d *Deployer) addCertMounts(
 func (d *Deployer) addServiceExtraMounts(
 	service dataplanev1.OpenStackDataPlaneService,
 ) (*dataplanev1.AnsibleEESpec, error) {
-	baseMountPath := path.Join(ConfigPaths, service.Name)
+	baseMountPath := path.Join(ConfigPaths, service.Spec.EDPMServiceType)
 
 	var configMaps []*corev1.ConfigMap
 	var secrets []*corev1.Secret


### PR DESCRIPTION
Instead of using the service name when creating the mount path under
/var/lib/openstack/configs, use the value of EDPMServiceType, which
defaults to the service name, but would be overridden for custom
services. The roles in edpm-ansible can then rely on a consistent path
that doesn't change when using a custom service.

Jira: https://issues.redhat.com/browse/OSPRH-8651
Signed-off-by: James Slagle <jslagle@redhat.com>
