### PR TITLE
[dataplane] Use short hostname for CommonName in node cert

### DIFF
--- a/pkg/dataplane/cert.go
+++ b/pkg/dataplane/cert.go
@@ -170,8 +170,10 @@ func EnsureTLSCerts(ctx context.Context, helper *helper.Helper,
 				nodeName)
 		}
 
+		commonName := strings.Split(baseName, ".")[0]
+
 		certSecret, result, err = GetTLSNodeCert(ctx, helper, instance, certName,
-			issuer, labels, baseName, hosts, ips, service.Spec.TLSCerts[certKey].KeyUsages)
+			issuer, labels, commonName, hosts, ips, service.Spec.TLSCerts[certKey].KeyUsages)
 
 		// handle cert request errors
 		if (err != nil) || (result != ctrl.Result{}) {


### PR DESCRIPTION
CommonName is limited to 64bytes so not safe to use the fqdn.

QEMU/libvirt actaully expect CN to be the short hostname:

$ virt-pki-validate
...
The server certificate does not seem to match the host name hostname: "edpm-compute-0"
Server certificate CN: "edpm-compute-0.ctlplane.example.com"

Related: [OSPRH-8652](https://issues.redhat.com//browse/OSPRH-8652)