### PR TITLE
Adding UI descriptors to select bool flags

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -654,6 +654,7 @@ type HorizonSection struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// Enabled - Whether Horizon services should be deployed and managed
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
 
 	// +kubebuilder:validation:Optional

--- a/apis/dataplane/v1beta1/openstackdataplaneservice_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplaneservice_types.go
@@ -95,6 +95,7 @@ type OpenStackDataPlaneServiceSpec struct {
 	// DeployOnAllNodeSets - should the service be deploy across all nodesets
 	// This will override default target of a service play, setting it to 'all'.
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	DeployOnAllNodeSets bool `json:"deployOnAllNodeSets,omitempty" yaml:"deployOnAllNodeSets,omitempty"`
 
 	// ContainerImageFields - list of container image fields names that this


### PR DESCRIPTION
The `booleanSwitch` descriptor [0] gives us easy way to make our resources more responsive through Console UI. 
We are already using it for other component sections, so setting it for Horizon only normalizes the use.

The  `DeployOnAllNodeSets` field of the service is a trickier case. But I can imagine situations when fast switch to global could be useful for debugging. That being said, I don't feel that strongly about it.

[0] https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md#4-booleanswitch 