### PR TITLE
Trim RFC1123 non-compliant chars from pod name

### DIFF
--- a/pkg/dataplane/util/ansible_execution.go
+++ b/pkg/dataplane/util/ansible_execution.go
@@ -299,7 +299,7 @@ func GetAnsibleExecutionNameAndLabels(service *dataplanev1.OpenStackDataPlaneSer
 	}
 
 	if len(executionName) > apimachineryvalidation.DNS1123LabelMaxLength {
-		executionName = executionName[:apimachineryvalidation.DNS1123LabelMaxLength]
+		executionName = strings.TrimRight(executionName[:apimachineryvalidation.DNS1123LabelMaxLength], "-.")
 	}
 
 	labels := map[string]string{


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OSPRH-8692