### PR TITLE
[OSPRH-8705] Fix SwiftStorage replicas update nil pointer

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.4.1-0.20240710123341-f09e275d360e
 	github.com/openstack-k8s-operators/ovn-operator/api v0.4.1-0.20240710183926-15f69cfd799a
 	github.com/openstack-k8s-operators/placement-operator/api v0.4.1-0.20240709175959-67b6081903f2
-	github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240710110546-d0117f2a5b92
+	github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240717150057-d6192b1064bd
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.4.1-0.20240712144913-8bcb24b382fe
 	github.com/rabbitmq/cluster-operator/v2 v2.9.0
 	github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.69.0-rhobs1 // indirect

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -132,8 +132,8 @@ github.com/openstack-k8s-operators/placement-operator/api v0.4.1-0.2024070917595
 github.com/openstack-k8s-operators/placement-operator/api v0.4.1-0.20240709175959-67b6081903f2/go.mod h1:pr+okOgpWbT+7vhZyZiO/Fh6Rj+QH1/gurF3W0kK2YQ=
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20240711055119-1e6b9b8d9bd0 h1:xtcdlh6o8xhzrv3BvEK79Y8b/CJhBZvp6Fqt8TBV6RA=
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20240711055119-1e6b9b8d9bd0/go.mod h1:Zryxg5YgbPUFcLSCcKpf10il8kIRAK5HloNo6khhdis=
-github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240710110546-d0117f2a5b92 h1:OISnM0Xt52dMU5tkS/mfHr0ZNbaRtiW/Y5UMavRk29c=
-github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240710110546-d0117f2a5b92/go.mod h1:mHGv3pUbgwVHIhgDmks5lQwiKbZyrK1zDEqaUf/TdIU=
+github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240717150057-d6192b1064bd h1:lLruN31HOe5q7Q2mC9sP1VLJ/kjvg4+q81wOk2cRFmI=
+github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240717150057-d6192b1064bd/go.mod h1:mHGv3pUbgwVHIhgDmks5lQwiKbZyrK1zDEqaUf/TdIU=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.4.1-0.20240712144913-8bcb24b382fe h1:/4y1RFld8Y0mXE4ODvcDtjyiTIBU5exuoL7oy0x94JI=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.4.1-0.20240712144913-8bcb24b382fe/go.mod h1:r6uN2OCZpvA1/zvGCsTXRWSiLLEpxAzpINXgkQpe8pI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20240531084739-3b4c0451297c
 	github.com/openstack-k8s-operators/ovn-operator/api v0.4.1-0.20240710183926-15f69cfd799a
 	github.com/openstack-k8s-operators/placement-operator/api v0.4.1-0.20240709175959-67b6081903f2
-	github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240710110546-d0117f2a5b92
+	github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240717150057-d6192b1064bd
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.4.1-0.20240712144913-8bcb24b382fe
 	github.com/openstack-k8s-operators/test-operator/api v0.0.0-20240711145030-9a9d003dd8c3
 	github.com/operator-framework/api v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/openstack-k8s-operators/placement-operator/api v0.4.1-0.2024070917595
 github.com/openstack-k8s-operators/placement-operator/api v0.4.1-0.20240709175959-67b6081903f2/go.mod h1:pr+okOgpWbT+7vhZyZiO/Fh6Rj+QH1/gurF3W0kK2YQ=
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20240711055119-1e6b9b8d9bd0 h1:xtcdlh6o8xhzrv3BvEK79Y8b/CJhBZvp6Fqt8TBV6RA=
 github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20240711055119-1e6b9b8d9bd0/go.mod h1:Zryxg5YgbPUFcLSCcKpf10il8kIRAK5HloNo6khhdis=
-github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240710110546-d0117f2a5b92 h1:OISnM0Xt52dMU5tkS/mfHr0ZNbaRtiW/Y5UMavRk29c=
-github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240710110546-d0117f2a5b92/go.mod h1:mHGv3pUbgwVHIhgDmks5lQwiKbZyrK1zDEqaUf/TdIU=
+github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240717150057-d6192b1064bd h1:lLruN31HOe5q7Q2mC9sP1VLJ/kjvg4+q81wOk2cRFmI=
+github.com/openstack-k8s-operators/swift-operator/api v0.4.1-0.20240717150057-d6192b1064bd/go.mod h1:mHGv3pUbgwVHIhgDmks5lQwiKbZyrK1zDEqaUf/TdIU=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.4.1-0.20240712144913-8bcb24b382fe h1:/4y1RFld8Y0mXE4ODvcDtjyiTIBU5exuoL7oy0x94JI=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.4.1-0.20240712144913-8bcb24b382fe/go.mod h1:r6uN2OCZpvA1/zvGCsTXRWSiLLEpxAzpINXgkQpe8pI=
 github.com/openstack-k8s-operators/test-operator/api v0.0.0-20240711145030-9a9d003dd8c3 h1:+jhYgLjfDg2gq9OrEFHWxNHCAK98XZsCkvwzTuuFi5g=


### PR DESCRIPTION
If the `OpenStackControlPlane` CR's `spec.swift.template` section is missing, trying to `oc patch` it fails due to a nil-pointer on the server side.

Depends-on: https://github.com/openstack-k8s-operators/swift-operator/pull/248

Jira: https://issues.redhat.com/browse/OSPRH-8705
