### PR TITLE
[validation] check galera instance names are valid

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -334,6 +334,16 @@ func (r *OpenStackControlPlane) ValidateCreateServices(basePath *field.Path) (ad
 		}
 	}
 
+	if r.Spec.Galera.Enabled {
+		if r.Spec.Galera.Templates != nil {
+			err := common_webhook.ValidateDNS1123Label(
+				basePath.Child("galera").Child("templates"),
+				maps.Keys(*r.Spec.Galera.Templates),
+				mariadbv1.CrMaxLengthCorrection) // omit issue with statefulset pod label "controller-revision-hash": "<statefulset_name>-<hash>"
+			errors = append(errors, err...)
+		}
+	}
+
 	return warnings, errors
 }
 
@@ -451,6 +461,16 @@ func (r *OpenStackControlPlane) ValidateUpdateServices(old OpenStackControlPlane
 				basePath.Child("rabbitmq").Child("templates"),
 				maps.Keys(*r.Spec.Rabbitmq.Templates),
 				memcachedv1.CrMaxLengthCorrection) // omit issue with statefulset pod label "controller-revision-hash": "<statefulset_name>-<hash>"
+			errors = append(errors, err...)
+		}
+	}
+
+	if r.Spec.Galera.Enabled {
+		if r.Spec.Galera.Templates != nil {
+			err := common_webhook.ValidateDNS1123Label(
+				basePath.Child("galera").Child("templates"),
+				maps.Keys(*r.Spec.Galera.Templates),
+				mariadbv1.CrMaxLengthCorrection) // omit issue with statefulset pod label "controller-revision-hash": "<statefulset_name>-<hash>"
 			errors = append(errors, err...)
 		}
 	}

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -2011,4 +2011,78 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 				"Invalid value: \"foo_bar\": a lowercase RFC 1123 label must consist"),
 		)
 	})
+
+	It("Blocks creating ctlplane CRs with to long galera keys/names", func() {
+		spec := GetDefaultOpenStackControlPlaneSpec()
+
+		galeraTemplate := map[string]interface{}{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{
+				"storageRequest": "500M",
+			},
+		}
+
+		spec["galera"] = map[string]interface{}{
+			"enabled":   true,
+			"templates": galeraTemplate,
+		}
+
+		raw := map[string]interface{}{
+			"apiVersion": "core.openstack.org/v1beta1",
+			"kind":       "OpenStackControlPlane",
+			"metadata": map[string]interface{}{
+				"name":      "foo",
+				"namespace": namespace,
+			},
+			"spec": spec,
+		}
+
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
+		Expect(err).Should(HaveOccurred())
+		var statusError *k8s_errors.StatusError
+		Expect(errors.As(err, &statusError)).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("OpenStackControlPlane"))
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(
+				"Invalid value: \"foo-1234567890-1234567890-1234567890-1234567890-1234567890\": must be no more than 46 characters"),
+		)
+	})
+
+	It("Blocks creating ctlplane CRs with wrong galera keys/names", func() {
+		spec := GetDefaultOpenStackControlPlaneSpec()
+
+		galeraTemplate := map[string]interface{}{
+			"foo_bar": map[string]interface{}{
+				"storageRequest": "500M",
+			},
+		}
+
+		spec["galera"] = map[string]interface{}{
+			"enabled":   true,
+			"templates": galeraTemplate,
+		}
+
+		raw := map[string]interface{}{
+			"apiVersion": "core.openstack.org/v1beta1",
+			"kind":       "OpenStackControlPlane",
+			"metadata": map[string]interface{}{
+				"name":      "foo",
+				"namespace": namespace,
+			},
+			"spec": spec,
+		}
+
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
+		Expect(err).Should(HaveOccurred())
+		var statusError *k8s_errors.StatusError
+		Expect(errors.As(err, &statusError)).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("OpenStackControlPlane"))
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(
+				"Invalid value: \"foo_bar\": a lowercase RFC 1123 label must consist"),
+		)
+	})
 })


### PR DESCRIPTION
The galera controller creates StatefulSet for the db to run. This adds a StatefulSet pod's label
"controller-revision-hash": "<statefulset_name>-<hash>" to the pod. The kubernetes label is restricted under 63 char and the revision hash is an int32, 10 chars + the hyphen. The galera controller also adds a suffix '-galera' to the statefulset name. With this the max name must not exceed 46 chars.

Also the name of the created galera instance must match a lowercase RFC 1123.

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/532
Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/246

Jira: https://issues.redhat.com/browse/OSPRH-8063