### PR TITLE
[validation] check cinderVolumes names are valid

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -67,6 +67,8 @@ const (
 
 	// GlanceName - Default Glance name
 	GlanceName = "glance"
+	// CinderName - Default Cinder name
+	CinderName = "cinder"
 )
 
 // OpenStackControlPlaneSpec defines the desired state of OpenStackControlPlane

--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -291,6 +291,12 @@ func (r *OpenStackControlPlane) ValidateCreateServices(basePath *field.Path) (ad
 	}
 
 	if r.Spec.Cinder.Enabled {
+		cinderName, _ := r.GetServiceName(CinderName, r.Spec.Cinder.UniquePodNames)
+		errs := common_webhook.ValidateDNS1123Label(
+			basePath.Child("cinder").Child("template").Child("cinderVolumes"),
+			maps.Keys(r.Spec.Cinder.Template.CinderVolumes),
+			cinderv1.GetCrMaxLengthCorrection(cinderName)) // omit issue with statefulset pod label "controller-revision-hash": "<statefulset_name>-<hash>"
+		errors = append(errors, errs...)
 		errors = append(errors, r.Spec.Cinder.Template.ValidateCreate(basePath.Child("cinder").Child("template"))...)
 	}
 
@@ -423,6 +429,12 @@ func (r *OpenStackControlPlane) ValidateUpdateServices(old OpenStackControlPlane
 		if old.Cinder.Template == nil {
 			old.Cinder.Template = &cinderv1.CinderSpecCore{}
 		}
+		cinderName, _ := r.GetServiceName(CinderName, r.Spec.Cinder.UniquePodNames)
+		errs := common_webhook.ValidateDNS1123Label(
+			basePath.Child("cinder").Child("template").Child("cinderVolumes"),
+			maps.Keys(r.Spec.Cinder.Template.CinderVolumes),
+			cinderv1.GetCrMaxLengthCorrection(cinderName)) // omit issue with statefulset pod label "controller-revision-hash": "<statefulset_name>-<hash>"
+		errors = append(errors, errs...)
 		errors = append(errors, r.Spec.Cinder.Template.ValidateUpdate(*old.Cinder.Template, basePath.Child("cinder").Child("template"))...)
 	}
 

--- a/pkg/openstack/cinder.go
+++ b/pkg/openstack/cinder.go
@@ -21,13 +21,7 @@ import (
 
 // ReconcileCinder -
 func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, version *corev1beta1.OpenStackVersion, helper *helper.Helper) (ctrl.Result, error) {
-	cinderName := "cinder"
-	altCinderName := fmt.Sprintf("cinder-%s", instance.UID[:5])
-
-	if instance.Spec.Cinder.UniquePodNames {
-		cinderName, altCinderName = altCinderName, cinderName
-	}
-
+	cinderName, altCinderName := instance.GetServiceName(corev1beta1.CinderName, instance.Spec.Cinder.UniquePodNames)
 	// Ensure the alternate cinder CR doesn't exist, as the ramdomPodNames flag may have been toggled
 	cinder := &cinderv1.Cinder{
 		ObjectMeta: metav1.ObjectMeta{

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -2219,4 +2219,130 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 				"Invalid value: \"foo_bar\": a lowercase RFC 1123 label must consist"),
 		)
 	})
+
+	It("Blocks creating ctlplane CRs with to long cinderVolume keys/names", func() {
+		spec := GetDefaultOpenStackControlPlaneSpec()
+
+		volumeList := map[string]interface{}{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{},
+		}
+		cinderTemplate := map[string]interface{}{
+			"databaseInstance": "openstack",
+			"secret":           "secret",
+			"databaseAccount":  "account",
+			"cinderVolumes":    volumeList,
+		}
+
+		spec["cinder"] = map[string]interface{}{
+			"enabled":        true,
+			"uniquePodNames": false,
+			"template":       cinderTemplate,
+		}
+
+		raw := map[string]interface{}{
+			"apiVersion": "core.openstack.org/v1beta1",
+			"kind":       "OpenStackControlPlane",
+			"metadata": map[string]interface{}{
+				"name":      "foo",
+				"namespace": namespace,
+			},
+			"spec": spec,
+		}
+
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
+		Expect(err).Should(HaveOccurred())
+		var statusError *k8s_errors.StatusError
+		Expect(errors.As(err, &statusError)).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("OpenStackControlPlane"))
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(
+				"Invalid value: \"foo-1234567890-1234567890-1234567890-1234567890-1234567890\": must be no more than 38 characters"),
+		)
+	})
+
+	It("Blocks creating ctlplane CRs with to long cinderVolume keys/names (uniquePodNames)", func() {
+		spec := GetDefaultOpenStackControlPlaneSpec()
+
+		volumeList := map[string]interface{}{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{},
+		}
+		cinderTemplate := map[string]interface{}{
+			"databaseInstance": "openstack",
+			"secret":           "secret",
+			"databaseAccount":  "account",
+			"cinderVolumes":    volumeList,
+		}
+
+		spec["cinder"] = map[string]interface{}{
+			"enabled":        true,
+			"uniquePodNames": true,
+			"template":       cinderTemplate,
+		}
+
+		raw := map[string]interface{}{
+			"apiVersion": "core.openstack.org/v1beta1",
+			"kind":       "OpenStackControlPlane",
+			"metadata": map[string]interface{}{
+				"name":      "foo",
+				"namespace": namespace,
+			},
+			"spec": spec,
+		}
+
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
+		Expect(err).Should(HaveOccurred())
+		var statusError *k8s_errors.StatusError
+		Expect(errors.As(err, &statusError)).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("OpenStackControlPlane"))
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(
+				"Invalid value: \"foo-1234567890-1234567890-1234567890-1234567890-1234567890\": must be no more than 32 characters"),
+		)
+	})
+
+	It("Blocks creating ctlplane CRs with wrong cinderVolume keys/names", func() {
+		spec := GetDefaultOpenStackControlPlaneSpec()
+
+		volumeList := map[string]interface{}{
+			"foo_bar": map[string]interface{}{},
+		}
+		cinderTemplate := map[string]interface{}{
+			"databaseInstance": "openstack",
+			"secret":           "secret",
+			"databaseAccount":  "account",
+			"cinderVolumes":    volumeList,
+		}
+
+		spec["cinder"] = map[string]interface{}{
+			"enabled":        true,
+			"uniquePodNames": true,
+			"template":       cinderTemplate,
+		}
+
+		raw := map[string]interface{}{
+			"apiVersion": "core.openstack.org/v1beta1",
+			"kind":       "OpenStackControlPlane",
+			"metadata": map[string]interface{}{
+				"name":      "foo",
+				"namespace": namespace,
+			},
+			"spec": spec,
+		}
+
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			th.Ctx, th.K8sClient, unstructuredObj, func() error { return nil })
+		Expect(err).Should(HaveOccurred())
+		var statusError *k8s_errors.StatusError
+		Expect(errors.As(err, &statusError)).To(BeTrue())
+		Expect(statusError.ErrStatus.Details.Kind).To(Equal("OpenStackControlPlane"))
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(
+				"Invalid value: \"foo_bar\": a lowercase RFC 1123 label must consist"),
+		)
+	})
 })


### PR DESCRIPTION
CinderVolume name is <cinder name>-volume-<volume name>
The CinderVolume controller creates StatefulSet for volume service to run.
This adds a StatefulSet pod's label
"controller-revision-hash": "<statefulset_name>-<hash>"
to the pod.
The kubernetes label is restricted under 63 char and the revision
hash is an int32, 10 chars + the hyphen. Which results in a default
statefulset max len of 52 chars. The statefulset name also
contain the cinder name and -volume-. So the max len also need to
be reduced bye the length of those.
    
Also the name of the created cinderVolume name match a lowercase RFC 1123.

Depends-On: openstack-k8s-operators/lib-common#532
Depends-On: https://github.com/openstack-k8s-operators/cinder-operator/pull/420
Jira: https://issues.redhat.com/browse/OSPRH-8063