### PR TITLE
Add labels and defaults to DataPlaneService from EnsureServices

### DIFF
--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -716,6 +716,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) deploymentWatcherFn(
 	ctx context.Context, //revive:disable-line
 	obj client.Object,
 ) []reconcile.Request {
+	Log := r.GetLogger(ctx)
 	namespace := obj.GetNamespace()
 	deployment := obj.(*dataplanev1.OpenStackDataPlaneDeployment)
 
@@ -727,6 +728,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) deploymentWatcherFn(
 				Name:      nodeSet,
 			},
 		})
+		Log.Info(fmt.Sprintf("Reconciling NodeSet %s due to watcher on %s/%s", nodeSet, obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName()))
 	}
 	return requests
 }

--- a/pkg/dataplane/service.go
+++ b/pkg/dataplane/service.go
@@ -140,6 +140,10 @@ func EnsureServices(ctx context.Context, helper *helper.Helper, instance *datapl
 		}
 		_, err = controllerutil.CreateOrPatch(ctx, helper.GetClient(), ensureService, func() error {
 			serviceObjSpec.DeepCopyInto(&ensureService.Spec)
+			ensureService.DefaultLabels()
+			if ensureService.Spec.EDPMServiceType == "" {
+				ensureService.Spec.EDPMServiceType = serviceObjMeta.Name
+			}
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
Fixes a reconcile loop by not modifying existing DataPlaneServices in
the CreateOrPatch call from EnsureService. If the webhook modifies the
service instead, that seems to trigger another NodeSet reconcile which
creates a loop.

Jira: [OSPRH-8811](https://issues.redhat.com//browse/OSPRH-8811)
Signed-off-by: James Slagle <jslagle@redhat.com>
