### PR TITLE
Add edpm_service_types

### DIFF
--- a/pkg/dataplane/inventory.go
+++ b/pkg/dataplane/inventory.go
@@ -105,6 +105,19 @@ func GenerateNodeSetInventory(ctx context.Context, helper *helper.Helper,
 	// add services list
 	nodeSetGroup.Vars["edpm_services"] = instance.Spec.Services
 
+	// add service types list
+	serviceTypes := []string{}
+	for _, serviceName := range instance.Spec.Services {
+		service, err := GetService(ctx, helper, serviceName)
+		if err != nil {
+			helper.GetLogger().Error(err, fmt.Sprintf("could not get service %s, using name as EDPMServiceType", serviceName))
+			serviceTypes = append(serviceTypes, serviceName)
+		} else {
+			serviceTypes = append(serviceTypes, service.Spec.EDPMServiceType)
+		}
+	}
+	nodeSetGroup.Vars["edpm_service_types"] = serviceTypes
+
 	nodeSetGroup.Vars["ansible_ssh_private_key_file"] = fmt.Sprintf("/runner/env/ssh_key/ssh_key_%s", instance.Name)
 
 	for _, node := range instance.Spec.Nodes {


### PR DESCRIPTION
The list of service types is added as an ansible variable to the
inventory as edpm_service_types. This will be used instead of
edpm_services since service names could be any customer values.

edpm-ansible roles such as edpm_update, need a list of consistent
service identifiers (types instead of names), so it knows which other
roles to include for update tasks.

Jira: https://issues.redhat.com/browse/OSPRH-8107
Signed-off-by: James Slagle <jslagle@redhat.com>
