### PR TITLE
Handle errors in pin-bundle-images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,7 @@ SHELL_EXPORT = $(foreach v,$(MAKE_ENV),$(v)='$($(v))')
 .PHONY: catalog-prep
 catalog-prep:
 # These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS = "$(BUNDLE_IMG)$(shell $(SHELL_EXPORT) /bin/bash hack/pin-bundle-images.sh)"
+BUNDLE_IMGS = "$(BUNDLE_IMG)$(shell $(SHELL_EXPORT) /bin/bash hack/pin-bundle-images.sh || echo bundle-fail-tag)"
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-index:v$(VERSION)


### PR DESCRIPTION
Even if there are errors in pin-bundle-image a broken index image get build and pushed to registry. Handle such errors to avoid push for broken index image.

Resolves: [OSPRH-5354](https://issues.redhat.com//browse/OSPRH-5354)