### PR TITLE
Don't reconcile for status updates

### DIFF
--- a/controllers/dataplane/openstackdataplanedeployment_controller.go
+++ b/controllers/dataplane/openstackdataplanedeployment_controller.go
@@ -28,8 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/go-logr/logr"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -426,7 +428,11 @@ func (r *OpenStackDataPlaneDeploymentReconciler) setHashes(
 // SetupWithManager sets up the controller with the Manager.
 func (r *OpenStackDataPlaneDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&dataplanev1.OpenStackDataPlaneDeployment{}).
+		For(&dataplanev1.OpenStackDataPlaneDeployment{},
+			builder.WithPredicates(predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.AnnotationChangedPredicate{},
+				predicate.LabelChangedPredicate{}))).
 		Owns(&ansibleeev1.OpenStackAnsibleEE{}).
 		Complete(r)
 }

--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -628,7 +628,11 @@ func (r *OpenStackDataPlaneNodeSetReconciler) SetupWithManager(
 		return err
 	}
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&dataplanev1.OpenStackDataPlaneNodeSet{}).
+		For(&dataplanev1.OpenStackDataPlaneNodeSet{},
+			builder.WithPredicates(predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.AnnotationChangedPredicate{},
+				predicate.LabelChangedPredicate{}))).
 		Owns(&ansibleeev1.OpenStackAnsibleEE{}).
 		Owns(&baremetalv1.OpenStackBaremetalSet{}).
 		Owns(&infranetworkv1.IPSet{}).
@@ -655,7 +659,6 @@ func (r *OpenStackDataPlaneNodeSetReconciler) secretWatcherFn(
 	Log := r.GetLogger(ctx)
 	nodeSets := &dataplanev1.OpenStackDataPlaneNodeSetList{}
 	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
-
 	selector := "spec.ansibleVarsFrom.ansible.configMaps"
 	if kind == "secret" {
 		selector = "spec.ansibleVarsFrom.ansible.secrets"
@@ -690,7 +693,6 @@ func (r *OpenStackDataPlaneNodeSetReconciler) genericWatcherFn(
 ) []reconcile.Request {
 	Log := r.GetLogger(ctx)
 	nodeSets := &dataplanev1.OpenStackDataPlaneNodeSetList{}
-
 	listOpts := []client.ListOption{
 		client.InNamespace(obj.GetNamespace()),
 	}

--- a/pkg/dataplane/service.go
+++ b/pkg/dataplane/service.go
@@ -140,10 +140,6 @@ func EnsureServices(ctx context.Context, helper *helper.Helper, instance *datapl
 		}
 		_, err = controllerutil.CreateOrPatch(ctx, helper.GetClient(), ensureService, func() error {
 			serviceObjSpec.DeepCopyInto(&ensureService.Spec)
-			ensureService.DefaultLabels()
-			if ensureService.Spec.EDPMServiceType == "" {
-				ensureService.Spec.EDPMServiceType = serviceObjMeta.Name
-			}
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
We do nodeset/deployment status update very frequently and reconciling them again after every status update is expensive. This also sometimes leads to infinite loops and results in very verbose controller logs.

Also removes the changes to duplicate multating webhook logic when calling CreateOrPatch() from EnsureServices().