### PR TITLE
Revert "Remove the deployed attribute from deployment"

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -108,6 +108,8 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              deployed:
+                type: boolean
               deployedVersion:
                 type: string
               nodeSetConditions:

--- a/apis/dataplane/v1beta1/openstackdataplanedeployment_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanedeployment_types.go
@@ -89,6 +89,10 @@ type OpenStackDataPlaneDeploymentStatus struct {
 
 	// DeployedVersion
 	DeployedVersion string `json:"deployedVersion,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	// Deployed
+	Deployed bool `json:"deployed,omitempty" optional:"true"`
 }
 
 //+kubebuilder:object:root=true
@@ -147,6 +151,8 @@ func (instance *OpenStackDataPlaneDeployment) InitConditions() {
 
 		}
 	}
+
+	instance.Status.Deployed = false
 }
 
 // InitHashesAndImages - Initialize ConfigHashes and Images

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -108,6 +108,8 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              deployed:
+                type: boolean
               deployedVersion:
                 type: string
               nodeSetConditions:

--- a/controllers/dataplane/openstackdataplanedeployment_controller.go
+++ b/controllers/dataplane/openstackdataplanedeployment_controller.go
@@ -97,6 +97,12 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 		Log,
 	)
 
+	// If the deploy is already done, return immediately.
+	if instance.Status.Deployed {
+		Log.Info("Already deployed", "instance.Status.Deployed", instance.Status.Deployed)
+		return ctrl.Result{}, nil
+	}
+
 	// initialize status if Conditions is nil, but do not reset if it already
 	// exists
 	isNewInstance := instance.Status.Conditions == nil
@@ -274,6 +280,8 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 	for _, nodeSet := range nodeSets.Items {
 
 		Log.Info(fmt.Sprintf("Deploying NodeSet: %s", nodeSet.Name))
+		Log.Info("Set Status.Deployed to false", "instance", instance)
+		instance.Status.Deployed = false
 		Log.Info("Set DeploymentReadyCondition false")
 		instance.Status.Conditions.MarkFalse(
 			condition.DeploymentReadyCondition, condition.RequestedReason,
@@ -366,6 +374,7 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 	Log.Info("Set DeploymentReadyCondition true")
 	instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	Log.Info("Set Status.Deployed to true", "instance", instance)
+	instance.Status.Deployed = true
 	if version != nil {
 		instance.Status.DeployedVersion = version.Spec.TargetVersion
 	}

--- a/docs/assemblies/dataplane_resources.adoc
+++ b/docs/assemblies/dataplane_resources.adoc
@@ -172,6 +172,11 @@ OpenStackDataPlaneDeploymentStatus defines the observed state of OpenStackDataPl
 | DeployedVersion
 | string
 | false
+
+| deployed
+| Deployed
+| bool
+| false
 |===
 
 <<custom-resources,Back to Custom Resources>>


### PR DESCRIPTION
This reverts commit 5a55c47a24fca6ac76ca08c72f9a0c69913379d9.

Without the status.Deployed boolean flag on OpenStackDataPlaneDeployment
there is no mechanism in place to prevert the full reconcile of a
Deployment. While the immutable annotation prevents user edits to the
spec, other changes could still trigger Deployment reconciles.

In the case of testing minor updates, it was discovered that when the
ansible runner image as specified by the
RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT env var in the
openstack-operator csv is changed, it will re-execute the ansible for
all existing Deployments. This breaks the minor update workflow as
things are done out of order, and breaks the expectation that it is the
user who starts ansible executions as opposed to automatically.

Jira: [OSPRH-8923](https://issues.redhat.com//browse/OSPRH-8923)
Signed-off-by: James Slagle <jslagle@redhat.com>
