### PR TITLE
Restore LastTransitionTime after setting Ready Condition

### DIFF
--- a/controllers/dataplane/openstackdataplanedeployment_controller.go
+++ b/controllers/dataplane/openstackdataplanedeployment_controller.go
@@ -124,8 +124,6 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() { // update the Ready condition based on the sub conditions
-		condition.RestoreLastTransitionTimes(
-			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, condition.ReadyMessage)
@@ -135,6 +133,8 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
 
+		condition.RestoreLastTransitionTimes(
+			&instance.Status.Conditions, savedConditions)
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			Log.Error(err, "Error updating instance status conditions")

--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -176,8 +176,6 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() { // update the Ready condition based on the sub conditions
-		condition.RestoreLastTransitionTimes(
-			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, dataplanev1.NodeSetReadyMessage)
@@ -186,6 +184,8 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 			instance.Status.Conditions.Set(
 				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
+		condition.RestoreLastTransitionTimes(
+			&instance.Status.Conditions, savedConditions)
 
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {


### PR DESCRIPTION
instance.Status.Conditions.MarkTrue() always sets the current time as the LastTransitionTime and this results in infinite loop as the LastTransitionTime changes after every reconcile.

I think this issue is there in many other operator controllers, but we don't see the issue as the next reconcile is probably too quick to not change the LastTransitionTime(precision for which is in seconds). The issue showed up in dataplane controllers as we reconcile a number of services in a loop for every reconcile of nodeset.

This seems to have been changed in other controllers of this operator with
https://github.com/openstack-k8s-operators/openstack-operator/pull/768.

Jira: [OSPRH-8811](https://issues.redhat.com//browse/OSPRH-8811)