### PR TITLE
fix cert.CreateOrPatch returns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/openstack-k8s-operators/ironic-operator/api v0.3.1-0.20240731082121-80290e3ec6af
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240731084038-2251de08ce56
 	github.com/openstack-k8s-operators/lib-common/modules/ansible v0.3.1-0.20240730154700-e526dc22c2bf
-	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240730154700-e526dc22c2bf
+	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240801155104-32cc1b1d93da
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240730154700-e526dc22c2bf
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240730154700-e526dc22c2bf
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240730154700-e526dc22c2bf

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240731084038
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240731084038-2251de08ce56/go.mod h1:A9Q/22ZCJm/uvnnaAHQzAsZTZ0vlTwmz/IZIWy5vrhs=
 github.com/openstack-k8s-operators/lib-common/modules/ansible v0.3.1-0.20240730154700-e526dc22c2bf h1:boELXNuvA2BZGt3TJmcKGMeVOmDXKumDIsEcWIoZHFM=
 github.com/openstack-k8s-operators/lib-common/modules/ansible v0.3.1-0.20240730154700-e526dc22c2bf/go.mod h1:tP+nxk95PisCKJaXE/an2igG9lluxuOVhdmV9WtkR2s=
-github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240730154700-e526dc22c2bf h1:mXToLdT1UztfecNDSnx3EXhzmvs3Wd7nIZu7YhQkgvI=
-github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240730154700-e526dc22c2bf/go.mod h1:GooNi6hM78cOUMjhBy0fXsZIcDTK1dUb1rlay170IJo=
+github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240801155104-32cc1b1d93da h1:VQ+1buVOee3XLlR0ZfA0b8p+5Wb9C+YD/uTzPFyFCFs=
+github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.0.0-20240801155104-32cc1b1d93da/go.mod h1:GooNi6hM78cOUMjhBy0fXsZIcDTK1dUb1rlay170IJo=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240730154700-e526dc22c2bf h1:VDxaGely5T2NBt7HtCMYMMd7yR6w7tKrHFdQgAus/wY=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240730154700-e526dc22c2bf/go.mod h1:k9KuWN2LBtLbKHgcyh/0lrwk3Kr0cOAhiR3hi/mrwOQ=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240730154700-e526dc22c2bf h1:5IxujAEi+Fk3DyOY83CegcNe+Lcqg/RwEPaPEhQiQ3E=

--- a/pkg/openstack/ca.go
+++ b/pkg/openstack/ca.go
@@ -606,7 +606,7 @@ func createRootCACertAndIssuer(
 		})
 	cert := certmanager.NewCertificate(caCertReq, 5)
 
-	ctrlResult, err := cert.CreateOrPatch(ctx, helper, nil)
+	ctrlResult, _, err := cert.CreateOrPatch(ctx, helper, nil)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			corev1.OpenStackControlPlaneCAReadyCondition,


### PR DESCRIPTION
also bumps lib-common/certmanager to pick up 918be86197a86882197d0aa51e7b17918fb9978f
(https://github.com/openstack-k8s-operators/lib-common/commit/918be86197a86882197d0aa51e7b17918fb9978f)

Jira: [OSPRH-9089](https://issues.redhat.com//browse/OSPRH-9089)
(cherry picked from commit 59cde420d7501d2f4658dddc16f9487d9b6992d9)
