### PR TITLE
[18.0.0-proposed] Add watcher for cert changes

### DIFF
--- a/pkg/dataplane/cert.go
+++ b/pkg/dataplane/cert.go
@@ -146,6 +146,7 @@ func EnsureTLSCerts(ctx context.Context, helper *helper.Helper,
 				}
 			}
 		}
+		sort.Strings(ips)
 
 		if service.Spec.TLSCerts[certKey].Issuer == "" {
 			// by default, use the internal root CA

--- a/tests/functional/dataplane/suite_test.go
+++ b/tests/functional/dataplane/suite_test.go
@@ -48,6 +48,8 @@ import (
 	dataplanev1 "github.com/openstack-k8s-operators/openstack-operator/apis/dataplane/v1beta1"
 	dataplanecontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/dataplane"
 
+	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+
 	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	test "github.com/openstack-k8s-operators/lib-common/modules/test"
@@ -98,6 +100,8 @@ var _ = BeforeSuite(func() {
 	infraCRDs, err := test.GetCRDDirFromModule(
 		"github.com/openstack-k8s-operators/infra-operator/apis", gomod, "bases")
 	Expect(err).ShouldNot(HaveOccurred())
+	certmgrv1CRDs, err := test.GetOpenShiftCRDDir("cert-manager/v1", gomod)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -106,6 +110,7 @@ var _ = BeforeSuite(func() {
 			aeeCRDs,
 			baremetalCRDs,
 			infraCRDs,
+			certmgrv1CRDs,
 		},
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -140,6 +145,8 @@ var _ = BeforeSuite(func() {
 	err = infrav1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = openstackv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = certmgrv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	//+kubebuilder:scaffold:scheme
 


### PR DESCRIPTION
The deployment manages certs and needs to watch them for changes during the initial deployment.

Also made sure to sort the ips before requesting the certs to prevent unneeded cert updates

(cherry picked from commit d484c31eb6fd33988f81da8f27fab72b19bce347)

Jira: https://issues.redhat.com//browse/OSPRH-9089