### PR TITLE
[OSPRH-9371] Fix VerifySecret so it requeues when necessary

### DIFF
--- a/apis/core/v1beta1/conditions.go
+++ b/apis/core/v1beta1/conditions.go
@@ -427,8 +427,11 @@ const (
 	// OpenStackControlPlaneCAReadyErrorMessage
 	OpenStackControlPlaneCAReadyErrorMessage = "OpenStackControlPlane CAs %s %s error occured %s"
 
-	// OpenStackControlPlaneCAReadyMessage
+	// OpenStackControlPlaneCustomTLSReadyMessage
 	OpenStackControlPlaneCustomTLSReadyMessage = "OpenStackControlPlane custom TLS cert secret available"
+
+	// OpenStackControlPlaneCustomTLSReadyWaitingMessage
+	OpenStackControlPlaneCustomTLSReadyWaitingMessage = "OpenStackControlPlane custom TLS cert secret %s not yet available"
 
 	// OpenStackControlPlaneCAReadyErrorMessage
 	OpenStackControlPlaneCustomTLSReadyErrorMessage = "OpenStackControlPlane custom TLS cert secret %s error occured %s"

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240805122347-7ed6e2796be0
 	github.com/openstack-k8s-operators/ironic-operator/api v0.4.1-0.20240805122907-c97ca3906d6c
 	github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240805122623-7ce0cb635485
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240805121733-1c08e6b7e260
 	github.com/openstack-k8s-operators/manila-operator/api v0.4.1-0.20240805133854-2d296dfc5ac5
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.4.1-0.20240805141244-ff694b3aaeda

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -108,8 +108,8 @@ github.com/openstack-k8s-operators/ironic-operator/api v0.4.1-0.20240805122907-c
 github.com/openstack-k8s-operators/ironic-operator/api v0.4.1-0.20240805122907-c97ca3906d6c/go.mod h1:HLh/riB1ZkQVGytb81uUYz+icJPpvFaMs6Be5nD4CZk=
 github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240805122623-7ce0cb635485 h1:CcvNLbAITTf6wwHP99/0D5fK+9icriIrLzsEOLvyQtM=
 github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240805122623-7ce0cb635485/go.mod h1:FYvTIksYHKE7aYDsO0GOGJa+8WQ7zPNwt0YkoHbXQsw=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260 h1:kPGmAc65HRBbezF3u1t01Q1XcSLTzSPoxeoRSMIFZsE=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6 h1:QrqPZPnJuJoYRFXL3aE4b+onLjjEUq8b3JjuptUkOoE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.4.1-0.20240805121733-1c08e6b7e260 h1:K+2TH5If/WR+ls92EYH6IcbWcLY15wlR1adGq/prA30=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:Z9QhWZexP9fYcZrBRI5rrcRwTh6LSsd5XB7NWzdphaE=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240805121733-1c08e6b7e260 h1:XR07nUmhH9s+22qhzo0XOp2HfS9FFi9qIn8CNL8JVVQ=

--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -265,21 +265,20 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 		time.Second*5,
 	)
 	if err != nil {
-		if (result != ctrl.Result{}) {
-			instance.Status.Conditions.MarkFalse(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				dataplanev1.InputReadyWaitingMessage,
-				"secret/"+ansibleSSHPrivateKeySecret)
-		} else {
-			instance.Status.Conditions.MarkFalse(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityError,
-				err.Error())
-		}
+		instance.Status.Conditions.MarkFalse(
+			condition.InputReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityError,
+			err.Error())
 		return result, err
+	} else if (result != ctrl.Result{}) {
+		instance.Status.Conditions.MarkFalse(
+			condition.InputReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			dataplanev1.InputReadyWaitingMessage,
+			"secret/"+ansibleSSHPrivateKeySecret)
+		return result, nil
 	}
 
 	// all our input checks out so report InputReady

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240805122623-7ce0cb635485
 	github.com/openstack-k8s-operators/lib-common/modules/ansible v0.4.1-0.20240805121733-1c08e6b7e260
 	github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.4.1-0.20240805121733-1c08e6b7e260
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240805121733-1c08e6b7e260
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.4.1-0.20240805121733-1c08e6b7e260
 	github.com/openstack-k8s-operators/manila-operator/api v0.4.1-0.20240805133854-2d296dfc5ac5

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/openstack-k8s-operators/lib-common/modules/ansible v0.4.1-0.202408051
 github.com/openstack-k8s-operators/lib-common/modules/ansible v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:tP+nxk95PisCKJaXE/an2igG9lluxuOVhdmV9WtkR2s=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.4.1-0.20240805121733-1c08e6b7e260 h1:plTcwQO7zhGREGKrIyc6IHfNvQuiAq1jOl0ljvoEcPg=
 github.com/openstack-k8s-operators/lib-common/modules/certmanager v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:1zjtu8i5b5Kudhu1GO/O7mFEHFTuHGjyEdkHfwJ0eQI=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260 h1:kPGmAc65HRBbezF3u1t01Q1XcSLTzSPoxeoRSMIFZsE=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6 h1:QrqPZPnJuJoYRFXL3aE4b+onLjjEUq8b3JjuptUkOoE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.4.1-0.20240805121733-1c08e6b7e260 h1:K+2TH5If/WR+ls92EYH6IcbWcLY15wlR1adGq/prA30=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:Z9QhWZexP9fYcZrBRI5rrcRwTh6LSsd5XB7NWzdphaE=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240805121733-1c08e6b7e260 h1:XR07nUmhH9s+22qhzo0XOp2HfS9FFi9qIn8CNL8JVVQ=

--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -260,6 +260,12 @@ func EnsureEndpointConfig(
 
 						return endpoints, ctrlResult, err
 					} else if (ctrlResult != ctrl.Result{}) {
+						instance.Status.Conditions.Set(condition.FalseCondition(
+							corev1.OpenStackControlPlaneCustomTLSReadyCondition,
+							condition.RequestedReason,
+							condition.SeverityInfo,
+							corev1.OpenStackControlPlaneCustomTLSReadyWaitingMessage,
+							ingressOverride.TLS.SecretName))
 						return endpoints, ctrlResult, nil
 					}
 					instance.Status.Conditions.MarkTrue(corev1.OpenStackControlPlaneCustomTLSReadyCondition,

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -1354,8 +1354,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 					ConditionGetterFunc(OpenStackControlPlaneConditionGetter),
 					corev1.OpenStackControlPlaneCustomTLSReadyCondition,
 					k8s_corev1.ConditionFalse,
-					condition.ErrorReason,
-					fmt.Sprintf("OpenStackControlPlane custom TLS cert secret custom-service-cert error occured Secret %s/custom-service-cert not found", namespace),
+					condition.RequestedReason,
+					fmt.Sprintf(corev1.OpenStackControlPlaneCustomTLSReadyWaitingMessage, names.CustomServiceCertSecretName.Name),
 				)
 			})
 


### PR DESCRIPTION
We've come to realize three things recently:

1. Returning an error to the reconciler along with a `RequeueAfter` will cause the reconciler to abandon the explicit requeue and only consider the error [1].
2. The `VerifySecret` function in `lib-common` was returning an error along with a requeue, thus contributing to the problem listed in item 1. [2]
3. Also, the error `VerifySecret` was returning was _not_ a "not found" error, but a generic k8s error -- so it wouldn't be properly handled by callers looking for a "not found" error. [3]

Now `VerifySecret` only returns a non-empty `ctrl.Result{}` if the `Secret` is missing. [4]

Jira: https://issues.redhat.com/browse/OSPRH-9371

[1] https://github.com/openstack-k8s-operators/keystone-operator/pull/459
[2] https://github.com/openstack-k8s-operators/lib-common/blob/ad3edb6e67ab738cfdbf4e2e78ac403784a08ab7/modules/common/secret/secret.go#L423-L425
[3] https://github.com/openstack-k8s-operators/lib-common/blob/ad3edb6e67ab738cfdbf4e2e78ac403784a08ab7/modules/common/secret/secret.go#L425
[4] https://github.com/openstack-k8s-operators/lib-common/blob/579da98fa7a62b70b43cdba92e82d6497afe8835/modules/common/secret/secret.go#L425-L427