### PR TITLE
Default to global spec.secret like other service do

### DIFF
--- a/pkg/openstack/heat.go
+++ b/pkg/openstack/heat.go
@@ -165,6 +165,10 @@ func ReconcileHeat(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		heat.Spec.HeatCfnAPI.ContainerImage = *version.Status.ContainerImages.HeatCfnapiImage
 		heat.Spec.HeatEngine.ContainerImage = *version.Status.ContainerImages.HeatEngineImage
 
+		if heat.Spec.Secret == "" {
+			heat.Spec.Secret = instance.Spec.Secret
+		}
+
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), heat, helper.GetScheme())
 		if err != nil {
 			return err

--- a/pkg/openstack/horizon.go
+++ b/pkg/openstack/horizon.go
@@ -141,6 +141,9 @@ func ReconcileHorizon(ctx context.Context, instance *corev1beta1.OpenStackContro
 
 		horizon.Spec.ContainerImage = *version.Status.ContainerImages.HorizonImage
 		horizon.Spec.Override.Service = ptr.To(serviceOverrides[service.EndpointPublic])
+		if horizon.Spec.Secret == "" {
+			horizon.Spec.Secret = instance.Spec.Secret
+		}
 
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), horizon, helper.GetScheme())
 		if err != nil {

--- a/pkg/openstack/ironic.go
+++ b/pkg/openstack/ironic.go
@@ -166,6 +166,10 @@ func ReconcileIronic(ctx context.Context, instance *corev1beta1.OpenStackControl
 		ironic.Spec.Images.Pxe = *version.Status.ContainerImages.IronicPxeImage
 		ironic.Spec.Images.IronicPythonAgent = *version.Status.ContainerImages.IronicPythonAgentImage
 
+		if ironic.Spec.Secret == "" {
+			ironic.Spec.Secret = instance.Spec.Secret
+		}
+
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), ironic, helper.GetScheme())
 		if err != nil {
 			return err

--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -341,6 +341,10 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		nova.Spec.NovaImages.SchedulerContainerImageURL = *version.Status.ContainerImages.NovaSchedulerImage
 		nova.Spec.NovaImages.NoVNCContainerImageURL = *version.Status.ContainerImages.NovaNovncImage
 
+		if nova.Spec.Secret == "" {
+			nova.Spec.Secret = instance.Spec.Secret
+		}
+
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), nova, helper.GetScheme())
 		if err != nil {
 			return err

--- a/pkg/openstack/octavia.go
+++ b/pkg/openstack/octavia.go
@@ -176,6 +176,10 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 		octavia.Spec.OctaviaHousekeeping.ContainerImage = *version.Status.ContainerImages.OctaviaHousekeepingImage
 		octavia.Spec.ApacheContainerImage = *version.Status.ContainerImages.ApacheImage
 
+		if octavia.Spec.Secret == "" {
+			octavia.Spec.Secret = instance.Spec.Secret
+		}
+
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), octavia, helper.GetScheme())
 		if err != nil {
 			return err

--- a/pkg/openstack/swift.go
+++ b/pkg/openstack/swift.go
@@ -120,6 +120,10 @@ func ReconcileSwift(ctx context.Context, instance *corev1beta1.OpenStackControlP
 		swift.Spec.SwiftStorage.ContainerImageProxy = *version.Status.ContainerImages.SwiftProxyImage
 		swift.Spec.SwiftProxy.ContainerImageProxy = *version.Status.ContainerImages.SwiftProxyImage
 
+		if swift.Spec.SwiftProxy.Secret == "" {
+			swift.Spec.SwiftProxy.Secret = instance.Spec.Secret
+		}
+
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), swift, helper.GetScheme())
 		if err != nil {
 			return err


### PR DESCRIPTION
Most of the service default to spec.secret if the service.spec.secret is not provided. This adds it to those services which not yet did that.

This should probably be moved to be done in the webhook, but for now this gets it in sync with the current implementation of the other services