### PR TITLE
Fix OpenStackClient display name

### DIFF
--- a/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ spec:
   customresourcedefinitions:
     owned:
     - description: OpenStackClient is the Schema for the openstackclients API
-      displayName: Open Stack Client
+      displayName: OpenStack Client
       kind: OpenStackClient
       name: openstackclients.client.openstack.org
       version: v1beta1
@@ -167,6 +167,11 @@ spec:
       - description: TLS - overrides tls parameters for public endpoint
         displayName: TLS
         path: horizon.apiOverride.tls
+      - description: Enabled - Whether Horizon services should be deployed and managed
+        displayName: Enabled
+        path: horizon.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Template - Overrides to use when creating the Horizon services
         displayName: Template
         path: horizon.template
@@ -311,7 +316,7 @@ spec:
         displayName: Template
         path: octavia.template
       - description: OpenStackClient - Parameters related to the OpenStackClient
-        displayName: Open Stack Client
+        displayName: OpenStack Client
         path: openstackclient
       - description: Template - Overrides to use when creating the OpenStackClient
           Resource
@@ -518,6 +523,11 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: Deployed
+        displayName: Deployed
+        path: deployed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       version: v1beta1
     - description: OpenStackDataPlaneNodeSet is the Schema for the openstackdataplanenodesets
         API OpenStackDataPlaneNodeSet name must be a valid RFC1123 as it is used in
@@ -571,6 +581,13 @@ spec:
       - description: AddCertMounts - Whether to add cert mounts
         displayName: Add Cert Mounts
         path: addCertMounts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: DeployOnAllNodeSets - should the service be deploy across all
+          nodesets This will override default target of a service play, setting it
+          to 'all'.
+        displayName: Deploy On All Node Sets
+        path: deployOnAllNodeSets
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:


### PR DESCRIPTION
In addition to fixing the `OpenStackClient` display name, apparently we also needed to run `make manifests` to get some other updates.  I can put those in a separate PR if it's a deal-breaker.