### PR TITLE
Swap download-cache and bootstrap services

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1176,8 +1176,8 @@ spec:
                 type: integer
               services:
                 default:
-                - download-cache
                 - bootstrap
+                - download-cache
                 - configure-network
                 - validate-network
                 - install-os

--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -61,7 +61,7 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={download-cache,bootstrap,configure-network,validate-network,install-os,configure-os,ssh-known-hosts,run-os,reboot-os,install-certs,ovn,neutron-metadata,libvirt,nova,telemetry}
+	// +kubebuilder:default={bootstrap,download-cache,configure-network,validate-network,install-os,configure-os,ssh-known-hosts,run-os,reboot-os,install-certs,ovn,neutron-metadata,libvirt,nova,telemetry}
 	// Services list
 	Services []string `json:"services"`
 

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -1176,8 +1176,8 @@ spec:
                 type: integer
               services:
                 default:
-                - download-cache
                 - bootstrap
+                - download-cache
                 - configure-network
                 - validate-network
                 - install-os

--- a/config/samples/dataplane/bgp/values.yaml
+++ b/config/samples/dataplane/bgp/values.yaml
@@ -85,8 +85,8 @@ data:
           edpm_frr_bgp_ipv6_src_network: bgpmainnet6
           edpm_ovn_bgp_agent_expose_tenant_networks: true
     services:
-    - download-cache
     - bootstrap
+    - download-cache
     - configure-network
     - validate-network
     - frr

--- a/config/samples/dataplane/bgp_ovn_cluster/values.yaml
+++ b/config/samples/dataplane/bgp_ovn_cluster/values.yaml
@@ -109,8 +109,8 @@ data:
           edpm_ovn_bgp_agent_exposing_method: ovn
           edpm_ovn_bgp_agent_provider_networks_pool_prefixes: '172.16.0.0/16'
     services:
-    - download-cache
     - bootstrap
+    - download-cache
     - configure-network
     - validate-network
     - frr

--- a/config/samples/dataplane/networker/values.yaml
+++ b/config/samples/dataplane/networker/values.yaml
@@ -47,8 +47,8 @@ data:
           - name: tenant
             subnetName: subnet1
     services:
-    - download-cache
     - bootstrap
+    - download-cache
     - configure-network
     - validate-network
     - install-os

--- a/docs/assemblies/con_data-plane-services.adoc
+++ b/docs/assemblies/con_data-plane-services.adoc
@@ -30,8 +30,8 @@ The default list of services as they will appear on the `services` field on an
 
 ----
 services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/docs/assemblies/proc_creating-a-custom-service.adoc
+++ b/docs/assemblies/proc_creating-a-custom-service.adoc
@@ -153,8 +153,8 @@ service to execute for the `edpm-compute` `NodeSet`.
  spec:
    services:
      - hello-world
-     - download-cache
      - bootstrap
+     - download-cache
      - configure-network
      - validate-network
      - install-os

--- a/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
@@ -314,8 +314,8 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 						},
 					},
 					Services: []string{
-						"download-cache",
 						"bootstrap",
+						"download-cache",
 						"configure-network",
 						"validate-network",
 						"install-os",
@@ -363,8 +363,8 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			BeforeEach(func() {
 				nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(tlsEnabled)
 				nodeSetSpec["services"] = []string{
-					"download-cache",
 					"bootstrap",
+					"download-cache",
 					"configure-network",
 					"validate-network",
 					"install-os",
@@ -452,8 +452,8 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 						},
 					},
 					Services: []string{
-						"download-cache",
 						"bootstrap",
+						"download-cache",
 						"configure-network",
 						"validate-network",
 						"install-os",
@@ -898,8 +898,8 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 						},
 					},
 					Services: []string{
-						"download-cache",
 						"bootstrap",
+						"download-cache",
 						"configure-network",
 						"validate-network",
 						"install-os",

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -51,8 +51,8 @@ spec:
     ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
   preProvisioned: true
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
@@ -45,8 +45,8 @@ spec:
     - name: ANSIBLE_FORCE_COLOR
       value: "True"
   services:
-    - download-cache
     - bootstrap
+    - download-cache
     - configure-network
     - validate-network
     - install-os

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
@@ -17,8 +17,8 @@ metadata:
 spec:
   preProvisioned: true
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
@@ -143,8 +143,8 @@ spec:
   preProvisioned: true
   tlsEnabled: false
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -16,8 +16,8 @@ metadata:
   namespace: openstack-kuttl-tests
 spec:
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/02-add-nodeset.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/02-add-nodeset.yaml
@@ -21,8 +21,8 @@ spec:
         gbReq: {}
   preProvisioned: true
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   env:
   - name: ANSIBLE_FORCE_COLOR
     value: "True"

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
@@ -13,8 +13,8 @@ metadata:
   namespace: openstack-kuttl-tests
 spec:
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   env:
   - name: ANSIBLE_FORCE_COLOR
     value: "True"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -14,8 +14,8 @@ metadata:
 spec:
   preProvisioned: true
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-dataplane-create.yaml
@@ -74,8 +74,8 @@ spec:
   preProvisioned: true
   tlsEnabled: false
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -13,8 +13,8 @@ metadata:
   namespace: openstack-kuttl-tests
 spec:
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/03-assert.yaml
@@ -13,8 +13,8 @@ metadata:
   namespace: openstack-kuttl-tests
 spec:
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -13,8 +13,8 @@ metadata:
   namespace: openstack-kuttl-tests
 spec:
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/05-assert.yaml
@@ -13,8 +13,8 @@ metadata:
   namespace: openstack-kuttl-tests
 spec:
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   - configure-network
   - validate-network
   - install-os

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-add-nodeset.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-add-nodeset.yaml
@@ -21,8 +21,8 @@ spec:
         gbReq: {}
   preProvisioned: true
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   env:
   - name: ANSIBLE_FORCE_COLOR
     value: "True"

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
@@ -13,8 +13,8 @@ metadata:
   namespace: openstack-kuttl-tests
 spec:
   services:
-  - download-cache
   - bootstrap
+  - download-cache
   env:
   - name: ANSIBLE_FORCE_COLOR
     value: "True"

--- a/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-dataplane-create.yaml
@@ -45,8 +45,8 @@ spec:
     - name: ANSIBLE_FORCE_COLOR
       value: "True"
   services:
-    - download-cache
     - bootstrap
+    - download-cache
     - configure-network
     - validate-network
     - install-os


### PR DESCRIPTION
For `download-cache` to work, it needs to have access to the remote container registry and a RPM repository. This necessitates that we execute subscription-manager prior to trying to download anything.

This change swaps the `bootstrap` and `download-cache` services so that `bootstrap` is executed first before trying to download anything.

This allows users to register their nodes leveraging the `edpm_bootstrap_command` variable defined on the NodeSet prior to any attempts to download content.