### PR TITLE
Share ApacheImage with baremetal, octavia, and telemetry

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17527,6 +17527,8 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
+                  ceilometerProxyImage:
+                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:

--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17627,6 +17627,8 @@ spec:
                     type: string
                   octaviaAPIImage:
                     type: string
+                  octaviaApacheImage:
+                    type: string
                   octaviaHealthmanagerImage:
                     type: string
                   octaviaHousekeepingImage:

--- a/apis/bases/core.openstack.org_openstackversions.yaml
+++ b/apis/bases/core.openstack.org_openstackversions.yaml
@@ -67,6 +67,8 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
+                  ceilometerProxyImage:
+                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:
@@ -270,6 +272,8 @@ spec:
                       type: string
                     ceilometerNotificationImage:
                       type: string
+                    ceilometerProxyImage:
+                      type: string
                     ceilometerSgcoreImage:
                       type: string
                     cinderAPIImage:
@@ -437,6 +441,8 @@ spec:
                   ceilometerIpmiImage:
                     type: string
                   ceilometerNotificationImage:
+                    type: string
+                  ceilometerProxyImage:
                     type: string
                   ceilometerSgcoreImage:
                     type: string

--- a/apis/bases/core.openstack.org_openstackversions.yaml
+++ b/apis/bases/core.openstack.org_openstackversions.yaml
@@ -67,8 +67,6 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
-                  ceilometerProxyImage:
-                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:
@@ -271,8 +269,6 @@ spec:
                     ceilometerIpmiImage:
                       type: string
                     ceilometerNotificationImage:
-                      type: string
-                    ceilometerProxyImage:
                       type: string
                     ceilometerSgcoreImage:
                       type: string
@@ -541,6 +537,8 @@ spec:
                   novaSchedulerImage:
                     type: string
                   octaviaAPIImage:
+                    type: string
+                  octaviaApacheImage:
                     type: string
                   octaviaHealthmanagerImage:
                     type: string

--- a/apis/core/v1beta1/openstackversion_types.go
+++ b/apis/core/v1beta1/openstackversion_types.go
@@ -57,23 +57,26 @@ type ContainerDefaults struct {
 
 // ContainerImages - struct acts as the source of truth for container image URLs to be deployed
 type ContainerImages struct {
-	ContainerTemplate `json:",inline"`
+	ContainerTemplate    `json:",inline"`
+	OctaviaApacheImage   *string `json:"octaviaApacheImage,omitempty"`   // gets set to ApacheImage once applied
+	CeilometerProxyImage *string `json:"ceilometerProxyImage,omitempty"` // gets set to ApacheImage once applied
 	// CinderVolumeImages custom Cinder Volume images for each backend (default Cinder volume image is stored 'default' key)
 	// TODO: add validation to cinder-operator to prevent backend being named 'default'
 	CinderVolumeImages map[string]*string `json:"cinderVolumeImages,omitempty"`
 	// ManilaShareImages custom Manila Share images for each backend (default Manila share image is stored 'default' key)
-	// TODO: add validation to cinder-operator to prevent backend being named 'default'
+	// TODO: add validation to manila-operator to prevent backend being named 'default'
 	ManilaShareImages map[string]*string `json:"manilaShareImages,omitempty"`
 }
 
 // ContainerTemplate - struct that contains container image URLs for each service in OpenStackControlplane
 type ContainerTemplate struct {
-	AgentImage                    *string `json:"agentImage,omitempty"`
-	AnsibleeeImage                *string `json:"ansibleeeImage,omitempty"`
-	AodhAPIImage                  *string `json:"aodhAPIImage,omitempty"`
-	AodhEvaluatorImage            *string `json:"aodhEvaluatorImage,omitempty"`
-	AodhListenerImage             *string `json:"aodhListenerImage,omitempty"`
-	AodhNotifierImage             *string `json:"aodhNotifierImage,omitempty"`
+	AgentImage         *string `json:"agentImage,omitempty"`
+	AnsibleeeImage     *string `json:"ansibleeeImage,omitempty"`
+	AodhAPIImage       *string `json:"aodhAPIImage,omitempty"`
+	AodhEvaluatorImage *string `json:"aodhEvaluatorImage,omitempty"`
+	AodhListenerImage  *string `json:"aodhListenerImage,omitempty"`
+	AodhNotifierImage  *string `json:"aodhNotifierImage,omitempty"`
+	// this is shared by BaremetalOperator, OctaviaOperator, and TelemetryOperator
 	ApacheImage                   *string `json:"apacheImage,omitempty"`
 	BarbicanAPIImage              *string `json:"barbicanAPIImage,omitempty"`
 	BarbicanKeystoneListenerImage *string `json:"barbicanKeystoneListenerImage,omitempty"`
@@ -83,7 +86,6 @@ type ContainerTemplate struct {
 	CeilometerIpmiImage           *string `json:"ceilometerIpmiImage,omitempty"`
 	CeilometerNotificationImage   *string `json:"ceilometerNotificationImage,omitempty"`
 	CeilometerSgcoreImage         *string `json:"ceilometerSgcoreImage,omitempty"`
-	CeilometerProxyImage          *string `json:"ceilometerProxyImage,omitempty"`
 	CinderAPIImage                *string `json:"cinderAPIImage,omitempty"`
 	CinderBackupImage             *string `json:"cinderBackupImage,omitempty"`
 	CinderSchedulerImage          *string `json:"cinderSchedulerImage,omitempty"`

--- a/apis/core/v1beta1/openstackversion_types.go
+++ b/apis/core/v1beta1/openstackversion_types.go
@@ -83,6 +83,7 @@ type ContainerTemplate struct {
 	CeilometerIpmiImage           *string `json:"ceilometerIpmiImage,omitempty"`
 	CeilometerNotificationImage   *string `json:"ceilometerNotificationImage,omitempty"`
 	CeilometerSgcoreImage         *string `json:"ceilometerSgcoreImage,omitempty"`
+	CeilometerProxyImage          *string `json:"ceilometerProxyImage,omitempty"`
 	CinderAPIImage                *string `json:"cinderAPIImage,omitempty"`
 	CinderBackupImage             *string `json:"cinderBackupImage,omitempty"`
 	CinderSchedulerImage          *string `json:"cinderSchedulerImage,omitempty"`

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -312,6 +312,11 @@ func (in *ContainerTemplate) DeepCopyInto(out *ContainerTemplate) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.CeilometerProxyImage != nil {
+		in, out := &in.CeilometerProxyImage, &out.CeilometerProxyImage
+		*out = new(string)
+		**out = **in
+	}
 	if in.CinderAPIImage != nil {
 		in, out := &in.CinderAPIImage, &out.CinderAPIImage
 		*out = new(string)

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -192,6 +192,16 @@ func (in *ContainerDefaults) DeepCopy() *ContainerDefaults {
 func (in *ContainerImages) DeepCopyInto(out *ContainerImages) {
 	*out = *in
 	in.ContainerTemplate.DeepCopyInto(&out.ContainerTemplate)
+	if in.OctaviaApacheImage != nil {
+		in, out := &in.OctaviaApacheImage, &out.OctaviaApacheImage
+		*out = new(string)
+		**out = **in
+	}
+	if in.CeilometerProxyImage != nil {
+		in, out := &in.CeilometerProxyImage, &out.CeilometerProxyImage
+		*out = new(string)
+		**out = **in
+	}
 	if in.CinderVolumeImages != nil {
 		in, out := &in.CinderVolumeImages, &out.CinderVolumeImages
 		*out = make(map[string]*string, len(*in))
@@ -309,11 +319,6 @@ func (in *ContainerTemplate) DeepCopyInto(out *ContainerTemplate) {
 	}
 	if in.CeilometerSgcoreImage != nil {
 		in, out := &in.CeilometerSgcoreImage, &out.CeilometerSgcoreImage
-		*out = new(string)
-		**out = **in
-	}
-	if in.CeilometerProxyImage != nil {
-		in, out := &in.CeilometerProxyImage, &out.CeilometerProxyImage
 		*out = new(string)
 		**out = **in
 	}

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17527,6 +17527,8 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
+                  ceilometerProxyImage:
+                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17627,6 +17627,8 @@ spec:
                     type: string
                   octaviaAPIImage:
                     type: string
+                  octaviaApacheImage:
+                    type: string
                   octaviaHealthmanagerImage:
                     type: string
                   octaviaHousekeepingImage:

--- a/config/crd/bases/core.openstack.org_openstackversions.yaml
+++ b/config/crd/bases/core.openstack.org_openstackversions.yaml
@@ -67,6 +67,8 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
+                  ceilometerProxyImage:
+                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:
@@ -270,6 +272,8 @@ spec:
                       type: string
                     ceilometerNotificationImage:
                       type: string
+                    ceilometerProxyImage:
+                      type: string
                     ceilometerSgcoreImage:
                       type: string
                     cinderAPIImage:
@@ -437,6 +441,8 @@ spec:
                   ceilometerIpmiImage:
                     type: string
                   ceilometerNotificationImage:
+                    type: string
+                  ceilometerProxyImage:
                     type: string
                   ceilometerSgcoreImage:
                     type: string

--- a/config/crd/bases/core.openstack.org_openstackversions.yaml
+++ b/config/crd/bases/core.openstack.org_openstackversions.yaml
@@ -67,8 +67,6 @@ spec:
                     type: string
                   ceilometerNotificationImage:
                     type: string
-                  ceilometerProxyImage:
-                    type: string
                   ceilometerSgcoreImage:
                     type: string
                   cinderAPIImage:
@@ -271,8 +269,6 @@ spec:
                     ceilometerIpmiImage:
                       type: string
                     ceilometerNotificationImage:
-                      type: string
-                    ceilometerProxyImage:
                       type: string
                     ceilometerSgcoreImage:
                       type: string
@@ -541,6 +537,8 @@ spec:
                   novaSchedulerImage:
                     type: string
                   octaviaAPIImage:
+                    type: string
+                  octaviaApacheImage:
                     type: string
                   octaviaHealthmanagerImage:
                     type: string

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -34,7 +34,6 @@ export RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT=quay.io/podified-antel
 export RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
 export RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
 export RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT=quay.io/infrawatch/sg-core:v5.2.0-nextgen
-export RELATED_IMAGE_CEILOMETER_PROXY_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
 export RELATED_IMAGE_AODH_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
 export RELATED_IMAGE_AODH_EVALUATOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-evaluator:current-podified
 export RELATED_IMAGE_AODH_NOTIFIER_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-notifier:current-podified

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -34,6 +34,7 @@ export RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT=quay.io/podified-antel
 export RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
 export RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
 export RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT=quay.io/infrawatch/sg-core:v5.2.0-nextgen
+export RELATED_IMAGE_CEILOMETER_PROXY_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
 export RELATED_IMAGE_AODH_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
 export RELATED_IMAGE_AODH_EVALUATOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-evaluator:current-podified
 export RELATED_IMAGE_AODH_NOTIFIER_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-notifier:current-podified

--- a/pkg/openstack/octavia.go
+++ b/pkg/openstack/octavia.go
@@ -56,8 +56,7 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 		instance.Status.ContainerImages.OctaviaWorkerImage = nil
 		instance.Status.ContainerImages.OctaviaHealthmanagerImage = nil
 		instance.Status.ContainerImages.OctaviaHousekeepingImage = nil
-		//FIXME: (dprince) Octavia should have its own parameter for the apache image (it can share the same image in OpenStackVersion though)
-		instance.Status.ContainerImages.ApacheImage = nil
+		instance.Status.ContainerImages.OctaviaApacheImage = nil
 		return ctrl.Result{}, nil
 	}
 
@@ -174,7 +173,7 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 		octavia.Spec.OctaviaWorker.ContainerImage = *version.Status.ContainerImages.OctaviaWorkerImage
 		octavia.Spec.OctaviaHealthManager.ContainerImage = *version.Status.ContainerImages.OctaviaHealthmanagerImage
 		octavia.Spec.OctaviaHousekeeping.ContainerImage = *version.Status.ContainerImages.OctaviaHousekeepingImage
-		octavia.Spec.ApacheContainerImage = *version.Status.ContainerImages.ApacheImage
+		octavia.Spec.ApacheContainerImage = *version.Status.ContainerImages.OctaviaApacheImage
 
 		if octavia.Spec.Secret == "" {
 			octavia.Spec.Secret = instance.Spec.Secret
@@ -205,7 +204,7 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 		instance.Status.ContainerImages.OctaviaWorkerImage = version.Status.ContainerImages.OctaviaWorkerImage
 		instance.Status.ContainerImages.OctaviaHealthmanagerImage = version.Status.ContainerImages.OctaviaHealthmanagerImage
 		instance.Status.ContainerImages.OctaviaHousekeepingImage = version.Status.ContainerImages.OctaviaHousekeepingImage
-		instance.Status.ContainerImages.ApacheImage = version.Status.ContainerImages.ApacheImage
+		instance.Status.ContainerImages.OctaviaApacheImage = version.Status.ContainerImages.ApacheImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneOctaviaReadyCondition, corev1beta1.OpenStackControlPlaneOctaviaReadyMessage)
 	} else {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -226,7 +225,7 @@ func OctaviaImageMatch(controlPlane *corev1beta1.OpenStackControlPlane, version 
 			!stringPointersEqual(controlPlane.Status.ContainerImages.OctaviaWorkerImage, version.Status.ContainerImages.OctaviaWorkerImage) ||
 			!stringPointersEqual(controlPlane.Status.ContainerImages.OctaviaHealthmanagerImage, version.Status.ContainerImages.OctaviaHealthmanagerImage) ||
 			!stringPointersEqual(controlPlane.Status.ContainerImages.OctaviaHousekeepingImage, version.Status.ContainerImages.OctaviaHousekeepingImage) ||
-			!stringPointersEqual(controlPlane.Status.ContainerImages.ApacheImage, version.Status.ContainerImages.ApacheImage) {
+			!stringPointersEqual(controlPlane.Status.ContainerImages.OctaviaApacheImage, version.Status.ContainerImages.ApacheImage) {
 			return false
 		}
 	}

--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -46,7 +46,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Status.ContainerImages.CeilometerIpmiImage = nil
 		instance.Status.ContainerImages.CeilometerNotificationImage = nil
 		instance.Status.ContainerImages.CeilometerSgcoreImage = nil
-		instance.Status.ContainerImages.ApacheImage = nil
+		instance.Status.ContainerImages.CeilometerProxyImage = nil
 		instance.Status.ContainerImages.AodhAPIImage = nil
 		instance.Status.ContainerImages.AodhEvaluatorImage = nil
 		instance.Status.ContainerImages.AodhNotifierImage = nil
@@ -250,7 +250,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		telemetry.Spec.Ceilometer.IpmiImage = *version.Status.ContainerImages.CeilometerIpmiImage
 		telemetry.Spec.Ceilometer.NotificationImage = *version.Status.ContainerImages.CeilometerNotificationImage
 		telemetry.Spec.Ceilometer.SgCoreImage = *version.Status.ContainerImages.CeilometerSgcoreImage
-		telemetry.Spec.Ceilometer.ProxyImage = *version.Status.ContainerImages.ApacheImage
+		telemetry.Spec.Ceilometer.ProxyImage = *version.Status.ContainerImages.CeilometerProxyImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.APIImage = *version.Status.ContainerImages.AodhAPIImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.EvaluatorImage = *version.Status.ContainerImages.AodhEvaluatorImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.NotifierImage = *version.Status.ContainerImages.AodhNotifierImage
@@ -297,7 +297,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Status.ContainerImages.CeilometerIpmiImage = version.Status.ContainerImages.CeilometerIpmiImage
 		instance.Status.ContainerImages.CeilometerNotificationImage = version.Status.ContainerImages.CeilometerNotificationImage
 		instance.Status.ContainerImages.CeilometerSgcoreImage = version.Status.ContainerImages.CeilometerSgcoreImage
-		instance.Status.ContainerImages.ApacheImage = version.Status.ContainerImages.ApacheImage
+		instance.Status.ContainerImages.CeilometerProxyImage = version.Status.ContainerImages.CeilometerProxyImage
 		instance.Status.ContainerImages.AodhAPIImage = version.Status.ContainerImages.AodhAPIImage
 		instance.Status.ContainerImages.AodhEvaluatorImage = version.Status.ContainerImages.AodhEvaluatorImage
 		instance.Status.ContainerImages.AodhNotifierImage = version.Status.ContainerImages.AodhNotifierImage
@@ -323,7 +323,7 @@ func TelemetryImageMatch(controlPlane *corev1beta1.OpenStackControlPlane, versio
 			!stringPointersEqual(controlPlane.Status.ContainerImages.CeilometerIpmiImage, version.Status.ContainerImages.CeilometerIpmiImage) ||
 			!stringPointersEqual(controlPlane.Status.ContainerImages.CeilometerNotificationImage, version.Status.ContainerImages.CeilometerNotificationImage) ||
 			!stringPointersEqual(controlPlane.Status.ContainerImages.CeilometerSgcoreImage, version.Status.ContainerImages.CeilometerSgcoreImage) ||
-			!stringPointersEqual(controlPlane.Status.ContainerImages.ApacheImage, version.Status.ContainerImages.ApacheImage) ||
+			!stringPointersEqual(controlPlane.Status.ContainerImages.CeilometerProxyImage, version.Status.ContainerImages.CeilometerProxyImage) ||
 			!stringPointersEqual(controlPlane.Status.ContainerImages.AodhAPIImage, version.Status.ContainerImages.AodhAPIImage) ||
 			!stringPointersEqual(controlPlane.Status.ContainerImages.AodhEvaluatorImage, version.Status.ContainerImages.AodhEvaluatorImage) ||
 			!stringPointersEqual(controlPlane.Status.ContainerImages.AodhNotifierImage, version.Status.ContainerImages.AodhNotifierImage) ||

--- a/pkg/openstack/version.go
+++ b/pkg/openstack/version.go
@@ -91,6 +91,7 @@ func GetContainerImages(defaults *corev1beta1.ContainerDefaults, instance corev1
 			CeilometerIpmiImage:           getImg(instance.Spec.CustomContainerImages.CeilometerIpmiImage, defaults.CeilometerIpmiImage),
 			CeilometerNotificationImage:   getImg(instance.Spec.CustomContainerImages.CeilometerNotificationImage, defaults.CeilometerNotificationImage),
 			CeilometerSgcoreImage:         getImg(instance.Spec.CustomContainerImages.CeilometerSgcoreImage, defaults.CeilometerSgcoreImage),
+			CeilometerProxyImage:          getImg(instance.Spec.CustomContainerImages.CeilometerProxyImage, defaults.CeilometerProxyImage),
 			CinderAPIImage:                getImg(instance.Spec.CustomContainerImages.CinderAPIImage, defaults.CinderAPIImage),
 			CinderBackupImage:             getImg(instance.Spec.CustomContainerImages.CinderBackupImage, defaults.CinderBackupImage),
 			CinderSchedulerImage:          getImg(instance.Spec.CustomContainerImages.CinderSchedulerImage, defaults.CinderSchedulerImage),

--- a/pkg/openstack/version.go
+++ b/pkg/openstack/version.go
@@ -73,8 +73,10 @@ func getImg(val1 *string, val2 *string) *string {
 func GetContainerImages(defaults *corev1beta1.ContainerDefaults, instance corev1beta1.OpenStackVersion) corev1beta1.ContainerImages {
 
 	containerImages := corev1beta1.ContainerImages{
-		CinderVolumeImages: instance.Spec.CustomContainerImages.CinderVolumeImages,
-		ManilaShareImages:  instance.Spec.CustomContainerImages.ManilaShareImages,
+		CinderVolumeImages:   instance.Spec.CustomContainerImages.CinderVolumeImages,
+		ManilaShareImages:    instance.Spec.CustomContainerImages.ManilaShareImages,
+		CeilometerProxyImage: getImg(instance.Spec.CustomContainerImages.ApacheImage, defaults.ApacheImage),
+		OctaviaApacheImage:   getImg(instance.Spec.CustomContainerImages.ApacheImage, defaults.ApacheImage),
 		ContainerTemplate: corev1beta1.ContainerTemplate{
 			AgentImage:                    getImg(instance.Spec.CustomContainerImages.AgentImage, defaults.AgentImage),
 			AnsibleeeImage:                getImg(instance.Spec.CustomContainerImages.AnsibleeeImage, defaults.AnsibleeeImage),
@@ -91,7 +93,6 @@ func GetContainerImages(defaults *corev1beta1.ContainerDefaults, instance corev1
 			CeilometerIpmiImage:           getImg(instance.Spec.CustomContainerImages.CeilometerIpmiImage, defaults.CeilometerIpmiImage),
 			CeilometerNotificationImage:   getImg(instance.Spec.CustomContainerImages.CeilometerNotificationImage, defaults.CeilometerNotificationImage),
 			CeilometerSgcoreImage:         getImg(instance.Spec.CustomContainerImages.CeilometerSgcoreImage, defaults.CeilometerSgcoreImage),
-			CeilometerProxyImage:          getImg(instance.Spec.CustomContainerImages.CeilometerProxyImage, defaults.CeilometerProxyImage),
 			CinderAPIImage:                getImg(instance.Spec.CustomContainerImages.CinderAPIImage, defaults.CinderAPIImage),
 			CinderBackupImage:             getImg(instance.Spec.CustomContainerImages.CinderBackupImage, defaults.CinderBackupImage),
 			CinderSchedulerImage:          getImg(instance.Spec.CustomContainerImages.CinderSchedulerImage, defaults.CinderSchedulerImage),

--- a/tests/functional/ctlplane/openstackversion_controller_test.go
+++ b/tests/functional/ctlplane/openstackversion_controller_test.go
@@ -154,6 +154,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(version.Status.ContainerImages.NovaConductorImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.NovaNovncImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.NovaSchedulerImage).ShouldNot(BeNil())
+				g.Expect(version.Status.ContainerImages.OctaviaApacheImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.OctaviaAPIImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.OctaviaHealthmanagerImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.OctaviaHousekeepingImage).ShouldNot(BeNil())

--- a/tests/functional/ctlplane/openstackversion_controller_test.go
+++ b/tests/functional/ctlplane/openstackversion_controller_test.go
@@ -113,6 +113,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(version.Status.ContainerImages.CeilometerComputeImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CeilometerNotificationImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CeilometerSgcoreImage).ShouldNot(BeNil())
+				g.Expect(version.Status.ContainerImages.CeilometerProxyImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CinderAPIImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CinderBackupImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CinderSchedulerImage).ShouldNot(BeNil())


### PR DESCRIPTION
The same http image is already used for these services but is causing bundle warnings at build time. This change updates the OpenStackVersion resource so that a single Apache parameter is shared by Baremetal, Octavia, and Telemetry.