### PR TITLE
Add missing OpenStackClient operator-sdk annoation

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -196,7 +196,8 @@ type OpenStackControlPlaneSpec struct {
 	Barbican BarbicanSection `json:"barbican,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenStack Client"
+
 	// OpenStackClient - Parameters related to the OpenStackClient
 	OpenStackClient OpenStackClientSection `json:"openstackclient,omitempty"`
 


### PR DESCRIPTION
Without this 'make bundle' reverts the default CSV in the tree to 'Open Stack Client'.