### PR TITLE
Add support for KSM

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -16864,6 +16864,8 @@ spec:
                     type: string
                   keystoneAPIImage:
                     type: string
+                  ksmImage:
+                    type: string
                   manilaAPIImage:
                     type: string
                   manilaSchedulerImage:

--- a/apis/bases/core.openstack.org_openstackversions.yaml
+++ b/apis/bases/core.openstack.org_openstackversions.yaml
@@ -146,6 +146,8 @@ spec:
                     type: string
                   keystoneAPIImage:
                     type: string
+                  ksmImage:
+                    type: string
                   manilaAPIImage:
                     type: string
                   manilaSchedulerImage:
@@ -353,6 +355,8 @@ spec:
                       type: string
                     keystoneAPIImage:
                       type: string
+                    ksmImage:
+                      type: string
                     manilaAPIImage:
                       type: string
                     manilaSchedulerImage:
@@ -530,6 +534,8 @@ spec:
                   ironicPythonAgentImage:
                     type: string
                   keystoneAPIImage:
+                    type: string
+                  ksmImage:
                     type: string
                   manilaAPIImage:
                     type: string

--- a/apis/core/v1beta1/openstackversion_types.go
+++ b/apis/core/v1beta1/openstackversion_types.go
@@ -126,6 +126,7 @@ type ContainerTemplate struct {
 	IronicPxeImage                *string `json:"ironicPxeImage,omitempty"`
 	IronicPythonAgentImage        *string `json:"ironicPythonAgentImage,omitempty"`
 	KeystoneAPIImage              *string `json:"keystoneAPIImage,omitempty"`
+	KsmImage                      *string `json:"ksmImage,omitempty"`
 	ManilaAPIImage                *string `json:"manilaAPIImage,omitempty"`
 	ManilaSchedulerImage          *string `json:"manilaSchedulerImage,omitempty"`
 	MariadbImage                  *string `json:"mariadbImage,omitempty"`

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -509,6 +509,11 @@ func (in *ContainerTemplate) DeepCopyInto(out *ContainerTemplate) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.KsmImage != nil {
+		in, out := &in.KsmImage, &out.KsmImage
+		*out = new(string)
+		**out = **in
+	}
 	if in.ManilaAPIImage != nil {
 		in, out := &in.ManilaAPIImage, &out.ManilaAPIImage
 		*out = new(string)

--- a/bindata/crds/crds.yaml
+++ b/bindata/crds/crds.yaml
@@ -16961,6 +16961,8 @@ spec:
                     type: string
                   keystoneAPIImage:
                     type: string
+                  ksmImage:
+                    type: string
                   manilaAPIImage:
                     type: string
                   manilaSchedulerImage:
@@ -18524,6 +18526,8 @@ spec:
                     type: string
                   keystoneAPIImage:
                     type: string
+                  ksmImage:
+                    type: string
                   manilaAPIImage:
                     type: string
                   manilaSchedulerImage:
@@ -18731,6 +18735,8 @@ spec:
                       type: string
                     keystoneAPIImage:
                       type: string
+                    ksmImage:
+                      type: string
                     manilaAPIImage:
                       type: string
                     manilaSchedulerImage:
@@ -18908,6 +18914,8 @@ spec:
                   ironicPythonAgentImage:
                     type: string
                   keystoneAPIImage:
+                    type: string
+                  ksmImage:
                     type: string
                   manilaAPIImage:
                     type: string

--- a/bindata/operator/operator.yaml
+++ b/bindata/operator/operator.yaml
@@ -106,6 +106,8 @@ spec:
           value: quay.io/prometheus/mysqld-exporter:v0.16.0
         - name: RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT
           value: quay.io/openstack-k8s-operators/sg-core:v6.0.0
+        - name: RELATED_IMAGE_KSM_IMAGE_URL_DEFAULT
+          value: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0
         - name: RELATED_IMAGE_CINDER_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-cinder-api:current-podified
         - name: RELATED_IMAGE_CINDER_BACKUP_IMAGE_URL_DEFAULT

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -16864,6 +16864,8 @@ spec:
                     type: string
                   keystoneAPIImage:
                     type: string
+                  ksmImage:
+                    type: string
                   manilaAPIImage:
                     type: string
                   manilaSchedulerImage:

--- a/config/crd/bases/core.openstack.org_openstackversions.yaml
+++ b/config/crd/bases/core.openstack.org_openstackversions.yaml
@@ -146,6 +146,8 @@ spec:
                     type: string
                   keystoneAPIImage:
                     type: string
+                  ksmImage:
+                    type: string
                   manilaAPIImage:
                     type: string
                   manilaSchedulerImage:
@@ -353,6 +355,8 @@ spec:
                       type: string
                     keystoneAPIImage:
                       type: string
+                    ksmImage:
+                      type: string
                     manilaAPIImage:
                       type: string
                     manilaSchedulerImage:
@@ -530,6 +534,8 @@ spec:
                   ironicPythonAgentImage:
                     type: string
                   keystoneAPIImage:
+                    type: string
+                  ksmImage:
                     type: string
                   manilaAPIImage:
                     type: string

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -43,6 +43,8 @@ spec:
           value: quay.io/prometheus/mysqld-exporter:v0.16.0
         - name: RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT
           value: quay.io/openstack-k8s-operators/sg-core:v6.0.0
+        - name: RELATED_IMAGE_KSM_IMAGE_URL_DEFAULT
+          value: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0
         - name: RELATED_IMAGE_CINDER_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-cinder-api:current-podified
         - name: RELATED_IMAGE_CINDER_BACKUP_IMAGE_URL_DEFAULT

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -35,6 +35,7 @@ export RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT=quay.io/podified-
 export RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
 export RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT=quay.io/openstack-k8s-operators/sg-core:v6.0.0
 export RELATED_IMAGE_CEILOMETER_MYSQLD_EXPORTER_IMAGE_URL_DEFAULT=quay.io/prometheus/mysqld-exporter:v0.16.0
+export RELATED_IMAGE_KSM_IMAGE_URL_DEFAULT=registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0
 export RELATED_IMAGE_AODH_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
 export RELATED_IMAGE_AODH_EVALUATOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-evaluator:current-podified
 export RELATED_IMAGE_AODH_NOTIFIER_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-notifier:current-podified

--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -324,11 +324,16 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		telemetry.Spec.Ceilometer.NotificationImage = *version.Status.ContainerImages.CeilometerNotificationImage
 		telemetry.Spec.Ceilometer.SgCoreImage = *version.Status.ContainerImages.CeilometerSgcoreImage
 		telemetry.Spec.Ceilometer.ProxyImage = *version.Status.ContainerImages.CeilometerProxyImage
-		telemetry.Spec.Ceilometer.KSMImage = *version.Status.ContainerImages.KsmImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.APIImage = *version.Status.ContainerImages.AodhAPIImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.EvaluatorImage = *version.Status.ContainerImages.AodhEvaluatorImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.NotifierImage = *version.Status.ContainerImages.AodhNotifierImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.ListenerImage = *version.Status.ContainerImages.AodhListenerImage
+
+		if version.Status.ContainerImages.KsmImage != nil {
+			telemetry.Spec.Ceilometer.KSMImage = *version.Status.ContainerImages.KsmImage
+		} else {
+			telemetry.Spec.Ceilometer.KSMImage = ""
+		}
 
 		if version.Status.ContainerImages.CeilometerMysqldExporterImage != nil {
 			telemetry.Spec.Ceilometer.MysqldExporterImage = *version.Status.ContainerImages.CeilometerMysqldExporterImage

--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -86,10 +86,12 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Spec.Telemetry.Template.MetricStorage.PrometheusTLS = telemetry.Spec.MetricStorage.PrometheusTLS
 		instance.Spec.Telemetry.Template.Ceilometer.TLS = telemetry.Spec.Ceilometer.TLS
 		instance.Spec.Telemetry.Template.Ceilometer.MysqldExporterTLS = telemetry.Spec.Ceilometer.MysqldExporterTLS
+		instance.Spec.Telemetry.Template.Ceilometer.KSMTLS = telemetry.Spec.Ceilometer.KSMTLS
 	}
 	instance.Spec.Telemetry.Template.Autoscaling.Aodh.TLS.CaBundleSecretName = instance.Status.TLS.CaBundleSecretName
 	instance.Spec.Telemetry.Template.Ceilometer.TLS.CaBundleSecretName = instance.Status.TLS.CaBundleSecretName
 	instance.Spec.Telemetry.Template.Ceilometer.MysqldExporterTLS.CaBundleSecretName = instance.Status.TLS.CaBundleSecretName
+	instance.Spec.Telemetry.Template.Ceilometer.KSMTLS.CaBundleSecretName = instance.Status.TLS.CaBundleSecretName
 	instance.Spec.Telemetry.Template.MetricStorage.PrometheusTLS.CaBundleSecretName = instance.Status.TLS.CaBundleSecretName
 
 	aodhSvcs, err := service.GetServicesListWithLabel(
@@ -126,6 +128,15 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		helper,
 		instance.Namespace,
 		map[string]string{common.AppSelector: "ceilometer"},
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	ksmSvcs, err := service.GetServicesListWithLabel(
+		ctx,
+		helper,
+		instance.Namespace,
+		map[string]string{common.AppSelector: "kube-state-metrics"},
 	)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -272,6 +283,27 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 			// update TLS settings with cert secret
 			instance.Spec.Telemetry.Template.Ceilometer.MysqldExporterTLS.SecretName = endpointDetails.GetEndptCertSecret(service.EndpointInternal)
 		}
+
+		// NOTE: We don't have svc overrides for KSM objects too.
+		ksmEpDetails, ctrlResult, err := EnsureEndpointConfig(
+			ctx,
+			instance,
+			helper,
+			telemetry,
+			ksmSvcs,
+			nil,
+			corev1beta1.Override{},
+			corev1beta1.OpenStackControlPlaneExposeTelemetryReadyCondition,
+			false, // TODO (mschuppert) could be removed when all integrated service support TLS
+			tls.API{},
+		)
+		if err != nil {
+			return ctrlResult, err
+		} else if (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, nil
+		}
+		// update TLS settings with cert secret
+		instance.Spec.Telemetry.Template.Ceilometer.KSMTLS.SecretName = ksmEpDetails.GetEndptCertSecret(service.EndpointInternal)
 	}
 
 	helper.GetLogger().Info("Reconciling Telemetry", telemetryNamespaceLabel, instance.Namespace, telemetryNameLabel, telemetryName)
@@ -292,6 +324,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		telemetry.Spec.Ceilometer.NotificationImage = *version.Status.ContainerImages.CeilometerNotificationImage
 		telemetry.Spec.Ceilometer.SgCoreImage = *version.Status.ContainerImages.CeilometerSgcoreImage
 		telemetry.Spec.Ceilometer.ProxyImage = *version.Status.ContainerImages.CeilometerProxyImage
+		telemetry.Spec.Ceilometer.KSMImage = *version.Status.ContainerImages.KsmImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.APIImage = *version.Status.ContainerImages.AodhAPIImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.EvaluatorImage = *version.Status.ContainerImages.AodhEvaluatorImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.NotifierImage = *version.Status.ContainerImages.AodhNotifierImage
@@ -346,6 +379,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Status.ContainerImages.CeilometerSgcoreImage = version.Status.ContainerImages.CeilometerSgcoreImage
 		instance.Status.ContainerImages.CeilometerProxyImage = version.Status.ContainerImages.CeilometerProxyImage
 		instance.Status.ContainerImages.CeilometerMysqldExporterImage = version.Status.ContainerImages.CeilometerMysqldExporterImage
+		instance.Status.ContainerImages.KsmImage = version.Status.ContainerImages.KsmImage
 		instance.Status.ContainerImages.AodhAPIImage = version.Status.ContainerImages.AodhAPIImage
 		instance.Status.ContainerImages.AodhEvaluatorImage = version.Status.ContainerImages.AodhEvaluatorImage
 		instance.Status.ContainerImages.AodhNotifierImage = version.Status.ContainerImages.AodhNotifierImage

--- a/pkg/openstack/version.go
+++ b/pkg/openstack/version.go
@@ -135,6 +135,7 @@ func GetContainerImages(defaults *corev1beta1.ContainerDefaults, instance corev1
 			IronicPxeImage:                getImg(instance.Spec.CustomContainerImages.IronicPxeImage, defaults.IronicPxeImage),
 			IronicPythonAgentImage:        getImg(instance.Spec.CustomContainerImages.IronicPythonAgentImage, defaults.IronicPythonAgentImage),
 			KeystoneAPIImage:              getImg(instance.Spec.CustomContainerImages.KeystoneAPIImage, defaults.KeystoneAPIImage),
+			KsmImage:                      getImg(instance.Spec.CustomContainerImages.KsmImage, defaults.KsmImage),
 			ManilaAPIImage:                getImg(instance.Spec.CustomContainerImages.ManilaAPIImage, defaults.ManilaAPIImage),
 			ManilaSchedulerImage:          getImg(instance.Spec.CustomContainerImages.ManilaSchedulerImage, defaults.ManilaSchedulerImage),
 			MariadbImage:                  getImg(instance.Spec.CustomContainerImages.MariadbImage, defaults.MariadbImage),


### PR DESCRIPTION
This patch add default image and TLS support for kube-state-metrics, a new component of Telemetry/Ceilometer resource.

Related: [OBSDA-574](https://issues.redhat.com/browse/OBSDA-574)
Related: [OSPRH-1052](https://issues.redhat.com/browse/OSPRH-1052)
Closes: [OSPRH-11115](https://issues.redhat.com/browse/OSPRH-11115)