### PR TITLE
Fix DataPlaneNodeSet tls verification

### DIFF
--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -335,15 +335,14 @@ func (r *OpenStackDataPlaneNodeSetSpec) ValidateTLS(namespace string, reconciler
 // Do TLS flags match in control plane ingress, pods and data plane
 func (r *OpenStackDataPlaneNodeSetSpec) TLSMatch(controlPlane openstackv1.OpenStackControlPlane) *field.Error {
 
-	if controlPlane.Spec.TLS.Ingress.Enabled != r.TLSEnabled || controlPlane.Spec.TLS.PodLevel.Enabled != r.TLSEnabled {
+	if controlPlane.Spec.TLS.PodLevel.Enabled != r.TLSEnabled {
 
 		return field.Forbidden(
 			field.NewPath("spec.tlsEnabled"),
 			fmt.Sprintf(
-				"TLS settings on Data Plane node set and Control Plane %s do not match, Node set: %t Control Plane Ingress: %t Control Plane PodLevel: %t",
+				"TLS settings on Data Plane node set and Control Plane %s do not match, Node set: %t Control Plane PodLevel: %t",
 				controlPlane.Name,
 				r.TLSEnabled,
-				controlPlane.Spec.TLS.Ingress.Enabled,
 				controlPlane.Spec.TLS.PodLevel.Enabled))
 	}
 	return nil

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -465,7 +465,7 @@ func CreateOpenStackControlPlane(name types.NamespacedName, spec map[string]inte
 	return th.CreateUnstructured(raw)
 }
 
-func GetDefaultOpenStackControlPlaneSpec(enableTLS bool) map[string]interface{} {
+func GetDefaultOpenStackControlPlaneSpec(tlsIngress bool, tlsPodlevel bool) map[string]interface{} {
 	memcachedTemplate := map[string]interface{}{
 		"memcached": map[string]interface{}{
 			"replicas": 1,
@@ -513,7 +513,7 @@ func GetDefaultOpenStackControlPlaneSpec(enableTLS bool) map[string]interface{} 
 		},
 		"tls": map[string]interface{}{
 			"ingress": map[string]interface{}{
-				"enabled": enableTLS,
+				"enabled": tlsIngress,
 
 				"ca": map[string]interface{}{
 					"customIssuer": "custom-issuer",
@@ -524,7 +524,7 @@ func GetDefaultOpenStackControlPlaneSpec(enableTLS bool) map[string]interface{} 
 				},
 			},
 			"podLevel": map[string]interface{}{
-				"enabled": enableTLS,
+				"enabled": tlsPodlevel,
 				"internal": map[string]interface{}{
 					"ca": map[string]interface{}{
 						"duration": "100h",

--- a/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
@@ -1563,7 +1563,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 		})
 	})
 
-	When("A user sets TLSEnabled to true with control plane TLS disabled", func() {
+	When("A user sets TLSEnabled to true with control plane with PodLevel TLS disabled", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
@@ -1596,7 +1596,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			SimulateIPSetComplete(dataplaneNodeName)
 			SimulateDNSDataComplete(dataplaneNodeSetName)
 
-			DeferCleanup(th.DeleteInstance, CreateOpenStackControlPlane(controlPlaneName, GetDefaultOpenStackControlPlaneSpec(false)))
+			DeferCleanup(th.DeleteInstance, CreateOpenStackControlPlane(controlPlaneName, GetDefaultOpenStackControlPlaneSpec(true, false)))
 		})
 
 		It("Should have Spec fields initialized", func() {
@@ -1661,7 +1661,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 
 	})
 
-	When("A user sets TLSEnabled to true with control plane TLS enabled", func() {
+	When("A user sets TLSEnabled to true with control plane PodLevel TLS enabled", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
@@ -1695,7 +1695,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			SimulateIPSetComplete(dataplaneNodeName)
 			SimulateDNSDataComplete(dataplaneNodeSetName)
 
-			DeferCleanup(th.DeleteInstance, CreateOpenStackControlPlane(controlPlaneName, GetDefaultOpenStackControlPlaneSpec(true)))
+			DeferCleanup(th.DeleteInstance, CreateOpenStackControlPlane(controlPlaneName, GetDefaultOpenStackControlPlaneSpec(true, true)))
 		})
 
 		It("Should have Spec fields initialized", func() {


### PR DESCRIPTION
The dataplane connects vi the metallb loadbalancer k8s service to the pods exposed to them. If TLS is configured for those is controlled via the tls.podLevel configuraturation of the ctlplane.

Right now the implementation checks for both tls.ingress and tls.podLevel configuration. With this it is not possible to deploy edpm nodes with tls.podLevel disabled. This change updates the verification to just check that spec.tlsEnabled of the DataPlaneNodeSet matches tls.podLevel of the ctlplane.