### PR TITLE
Don't ignore ctlplane vlan

### DIFF
--- a/pkg/dataplane/inventory.go
+++ b/pkg/dataplane/inventory.go
@@ -213,7 +213,7 @@ func populateInventoryFromIPAM(
 			netCidr, _ := ipnet.Mask.Size()
 			host.Vars[entry+"_cidr"] = netCidr
 		}
-		if res.Vlan != nil || entry != dataplanev1.CtlPlaneNetwork {
+		if res.Vlan != nil {
 			host.Vars[entry+"_vlan_id"] = res.Vlan
 		}
 		host.Vars[entry+"_mtu"] = res.MTU


### PR DESCRIPTION
We ignored that before assuming that ctlplane won't be vlan tagged, but that's not always correct. When
using vlan for ctlplane `edpm_network_config` has to be changed accordingly.

jira: https://issues.redhat.com/browse/OSPRH-10126