### PR TITLE
Rename InstanceHA to InstanceHa and add image to configmap

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17611,6 +17611,8 @@ spec:
                     type: string
                   infraDnsmasqImage:
                     type: string
+                  infraInstanceHaImage:
+                    type: string
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:

--- a/apis/bases/core.openstack.org_openstackversions.yaml
+++ b/apis/bases/core.openstack.org_openstackversions.yaml
@@ -125,6 +125,8 @@ spec:
                     type: string
                   infraDnsmasqImage:
                     type: string
+                  infraInstanceHaImage:
+                    type: string
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:
@@ -328,6 +330,8 @@ spec:
                       type: string
                     infraDnsmasqImage:
                       type: string
+                    infraInstanceHaImage:
+                      type: string
                     infraMemcachedImage:
                       type: string
                     infraRedisImage:
@@ -501,6 +505,8 @@ spec:
                   horizonImage:
                     type: string
                   infraDnsmasqImage:
+                    type: string
+                  infraInstanceHaImage:
                     type: string
                   infraMemcachedImage:
                     type: string

--- a/apis/core/v1beta1/conditions.go
+++ b/apis/core/v1beta1/conditions.go
@@ -146,6 +146,9 @@ const (
 
 	// OpenStackControlPlaneTestCMReadyCondition Status=True condition which indicates if Test operator CM is ready
 	OpenStackControlPlaneTestCMReadyCondition condition.Type = "OpenStackControlPlaneTestCMReadyCondition"
+
+	// OpenStackControlPlaneInstanceHaCMReadyCondition Status=True condition which indicates if InstanceHa CM is ready
+	OpenStackControlPlaneInstanceHaCMReadyCondition condition.Type = "OpenStackControlPlaneInstanceHaCMReadyCondition"
 )
 
 // Common Messages used by API objects.
@@ -456,6 +459,12 @@ const (
 
 	// OpenStackControlPlaneTestCMReadyMessage
 	OpenStackControlPlaneTestCMReadyMessage = "OpenStackControlPlane Test Operator CM is available"
+
+	// OpenStackControlPlaneInstanceHaCMReadyErrorMessage
+	OpenStackControlPlaneInstanceHaCMReadyErrorMessage = "OpenStackControlPlane InstanceHa CM error occured %s"
+
+	// OpenStackControlPlaneInstanceHaCMReadyMessage
+	OpenStackControlPlaneInstanceHaCMReadyMessage = "OpenStackControlPlane InstanceHa CM is available"
 )
 
 // Version Conditions used by API objects.

--- a/apis/core/v1beta1/openstackversion_types.go
+++ b/apis/core/v1beta1/openstackversion_types.go
@@ -114,6 +114,7 @@ type ContainerTemplate struct {
 	InfraDnsmasqImage             *string `json:"infraDnsmasqImage,omitempty"`
 	InfraMemcachedImage           *string `json:"infraMemcachedImage,omitempty"`
 	InfraRedisImage               *string `json:"infraRedisImage,omitempty"`
+	InfraInstanceHaImage          *string `json:"infraInstanceHaImage,omitempty"`
 	IronicAPIImage                *string `json:"ironicAPIImage,omitempty"`
 	IronicConductorImage          *string `json:"ironicConductorImage,omitempty"`
 	IronicInspectorImage          *string `json:"ironicInspectorImage,omitempty"`

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -463,6 +463,11 @@ func (in *ContainerTemplate) DeepCopyInto(out *ContainerTemplate) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.InfraInstanceHaImage != nil {
+		in, out := &in.InfraInstanceHaImage, &out.InfraInstanceHaImage
+		*out = new(string)
+		**out = **in
+	}
 	if in.IronicAPIImage != nil {
 		in, out := &in.IronicAPIImage, &out.IronicAPIImage
 		*out = new(string)

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openstack-k8s-operators/glance-operator/api v0.4.1-0.20240909180656-33fe3c05a637
 	github.com/openstack-k8s-operators/heat-operator/api v0.4.1-0.20240909065043-d5b093777de2
 	github.com/openstack-k8s-operators/horizon-operator/api v0.4.1-0.20240906120219-9c3e4ba4077b
-	github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240910085802-31f905cfe219
+	github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240912140341-4066f2ead41d
 	github.com/openstack-k8s-operators/ironic-operator/api v0.4.1-0.20240909085220-4736023a2e4f
 	github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240906103150-990fe66f2e5d
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240905123813-174296c09ec6

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -102,8 +102,8 @@ github.com/openstack-k8s-operators/heat-operator/api v0.4.1-0.20240909065043-d5b
 github.com/openstack-k8s-operators/heat-operator/api v0.4.1-0.20240909065043-d5b093777de2/go.mod h1:w+8OpHuUfk4nEUSQfFZbYGPZEkn0c1xe3fyZ062fkDA=
 github.com/openstack-k8s-operators/horizon-operator/api v0.4.1-0.20240906120219-9c3e4ba4077b h1:B4kw/FovC+mKMRA8dahi2k3x751iOuBwglu9DBz0iX4=
 github.com/openstack-k8s-operators/horizon-operator/api v0.4.1-0.20240906120219-9c3e4ba4077b/go.mod h1:Q9/AUCUCA959gIq3DxzUdTWvkwqDp0lz3ujW0vTPdWg=
-github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240910085802-31f905cfe219 h1:o0epGu5XkImn5pggs/eyZMBS2Iok8wSaaTXRBwybDCk=
-github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240910085802-31f905cfe219/go.mod h1:TFh01OyR/NP5Sy7vikMIpQc80AKl0WWPyYDaJBfFiGc=
+github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240912140341-4066f2ead41d h1:GbkbsL89plNNnyQI06VzDyJ1xe8DhDky3wAPL5g6LBs=
+github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240912140341-4066f2ead41d/go.mod h1:TFh01OyR/NP5Sy7vikMIpQc80AKl0WWPyYDaJBfFiGc=
 github.com/openstack-k8s-operators/ironic-operator/api v0.4.1-0.20240909085220-4736023a2e4f h1:Dj1KlPwlXzLyLaEDReJg3sHyo/TMN62pKH3X0L5bsZQ=
 github.com/openstack-k8s-operators/ironic-operator/api v0.4.1-0.20240909085220-4736023a2e4f/go.mod h1:iQq0r9XaY6+AN9LaJIvhoetuOwnaGIhU0XkQvHLFT9M=
 github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240906103150-990fe66f2e5d h1:PbTZo4RCo+RFiGZ0q/rllUXoUtxgtWAh4V0IUe3aW5k=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17611,6 +17611,8 @@ spec:
                     type: string
                   infraDnsmasqImage:
                     type: string
+                  infraInstanceHaImage:
+                    type: string
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:

--- a/config/crd/bases/core.openstack.org_openstackversions.yaml
+++ b/config/crd/bases/core.openstack.org_openstackversions.yaml
@@ -125,6 +125,8 @@ spec:
                     type: string
                   infraDnsmasqImage:
                     type: string
+                  infraInstanceHaImage:
+                    type: string
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:
@@ -328,6 +330,8 @@ spec:
                       type: string
                     infraDnsmasqImage:
                       type: string
+                    infraInstanceHaImage:
+                      type: string
                     infraMemcachedImage:
                       type: string
                     infraRedisImage:
@@ -501,6 +505,8 @@ spec:
                   horizonImage:
                     type: string
                   infraDnsmasqImage:
+                    type: string
+                  infraInstanceHaImage:
                     type: string
                   infraMemcachedImage:
                     type: string

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -97,6 +97,8 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-memcached:current-podified
         - name: RELATED_IMAGE_INFRA_REDIS_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-redis:current-podified
+        - name: RELATED_IMAGE_INFRA_INSTANCE_HA_IMAGE_URL_DEFAULT
+          value: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
         - name: RELATED_IMAGE_IRONIC_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
         - name: RELATED_IMAGE_IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -452,6 +452,13 @@ func (r *OpenStackControlPlaneReconciler) reconcileNormal(ctx context.Context, i
 		return ctrlResult, nil
 	}
 
+	ctrlResult, err = openstack.ReconcileInstanceHa(ctx, instance, version, helper)
+	if err != nil {
+		return ctrl.Result{}, err
+	} else if (ctrlResult != ctrl.Result{}) {
+		return ctrlResult, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openstack-k8s-operators/glance-operator/api v0.4.1-0.20240909180656-33fe3c05a637
 	github.com/openstack-k8s-operators/heat-operator/api v0.4.1-0.20240909065043-d5b093777de2
 	github.com/openstack-k8s-operators/horizon-operator/api v0.4.1-0.20240906120219-9c3e4ba4077b
-	github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240910085802-31f905cfe219
+	github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240912140341-4066f2ead41d
 	github.com/openstack-k8s-operators/ironic-operator/api v0.4.1-0.20240909085220-4736023a2e4f
 	github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240906103150-990fe66f2e5d
 	github.com/openstack-k8s-operators/lib-common/modules/ansible v0.4.1-0.20240905123813-174296c09ec6

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/openstack-k8s-operators/heat-operator/api v0.4.1-0.20240909065043-d5b
 github.com/openstack-k8s-operators/heat-operator/api v0.4.1-0.20240909065043-d5b093777de2/go.mod h1:w+8OpHuUfk4nEUSQfFZbYGPZEkn0c1xe3fyZ062fkDA=
 github.com/openstack-k8s-operators/horizon-operator/api v0.4.1-0.20240906120219-9c3e4ba4077b h1:B4kw/FovC+mKMRA8dahi2k3x751iOuBwglu9DBz0iX4=
 github.com/openstack-k8s-operators/horizon-operator/api v0.4.1-0.20240906120219-9c3e4ba4077b/go.mod h1:Q9/AUCUCA959gIq3DxzUdTWvkwqDp0lz3ujW0vTPdWg=
-github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240910085802-31f905cfe219 h1:o0epGu5XkImn5pggs/eyZMBS2Iok8wSaaTXRBwybDCk=
-github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240910085802-31f905cfe219/go.mod h1:TFh01OyR/NP5Sy7vikMIpQc80AKl0WWPyYDaJBfFiGc=
+github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240912140341-4066f2ead41d h1:GbkbsL89plNNnyQI06VzDyJ1xe8DhDky3wAPL5g6LBs=
+github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240912140341-4066f2ead41d/go.mod h1:TFh01OyR/NP5Sy7vikMIpQc80AKl0WWPyYDaJBfFiGc=
 github.com/openstack-k8s-operators/ironic-operator/api v0.4.1-0.20240909085220-4736023a2e4f h1:Dj1KlPwlXzLyLaEDReJg3sHyo/TMN62pKH3X0L5bsZQ=
 github.com/openstack-k8s-operators/ironic-operator/api v0.4.1-0.20240909085220-4736023a2e4f/go.mod h1:iQq0r9XaY6+AN9LaJIvhoetuOwnaGIhU0XkQvHLFT9M=
 github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240906103150-990fe66f2e5d h1:PbTZo4RCo+RFiGZ0q/rllUXoUtxgtWAh4V0IUe3aW5k=

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -7,6 +7,7 @@ export RELATED_IMAGE_KEYSTONE_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-ce
 export RELATED_IMAGE_MARIADB_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 export RELATED_IMAGE_INFRA_MEMCACHED_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-memcached:current-podified
 export RELATED_IMAGE_INFRA_REDIS_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-redis:current-podified
+export RELATED_IMAGE_INFRA_INSTANCE_HA_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
 export RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT=quay.io/openstack-k8s-operators/openstack-ansibleee-runner:current-podified
 export RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
 export RELATED_IMAGE_NOVA_CONDUCTOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified

--- a/pkg/openstack/instanceha.go
+++ b/pkg/openstack/instanceha.go
@@ -1,0 +1,54 @@
+package openstack
+
+import (
+	"context"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+
+	corev1beta1 "github.com/openstack-k8s-operators/openstack-operator/apis/core/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	InstanceHaConfigMap = "infra-instanceha-config"
+	InstanceHaImageKey  = "instanceha-image"
+)
+
+func ReconcileInstanceHa(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, version *corev1beta1.OpenStackVersion, helper *helper.Helper) (ctrl.Result, error) {
+	missingImageDefault := ""
+	customData := map[string]string{
+		InstanceHaImageKey: *getImg(version.Status.ContainerImages.InfraInstanceHaImage, &missingImageDefault),
+	}
+
+	cms := []util.Template{
+		{
+			Name:          InstanceHaConfigMap,
+			Namespace:     instance.Namespace,
+			InstanceType:  instance.Kind,
+			Labels:        nil,
+			ConfigOptions: nil,
+			CustomData:    customData,
+		},
+	}
+
+	if err := configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil); err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			corev1beta1.OpenStackControlPlaneInstanceHaCMReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			corev1beta1.OpenStackControlPlaneInstanceHaCMReadyErrorMessage,
+			err.Error()))
+
+		return ctrl.Result{}, err
+	}
+
+	instance.Status.Conditions.Set(condition.TrueCondition(
+		corev1beta1.OpenStackControlPlaneInstanceHaCMReadyCondition,
+		corev1beta1.OpenStackControlPlaneInstanceHaCMReadyMessage,
+	))
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/openstack/version.go
+++ b/pkg/openstack/version.go
@@ -126,6 +126,7 @@ func GetContainerImages(defaults *corev1beta1.ContainerDefaults, instance corev1
 			InfraDnsmasqImage:             getImg(instance.Spec.CustomContainerImages.InfraDnsmasqImage, defaults.InfraDnsmasqImage),
 			InfraMemcachedImage:           getImg(instance.Spec.CustomContainerImages.InfraMemcachedImage, defaults.InfraMemcachedImage),
 			InfraRedisImage:               getImg(instance.Spec.CustomContainerImages.InfraRedisImage, defaults.InfraRedisImage),
+			InfraInstanceHaImage:          getImg(instance.Spec.CustomContainerImages.InfraInstanceHaImage, defaults.InfraInstanceHaImage),
 			IronicAPIImage:                getImg(instance.Spec.CustomContainerImages.IronicAPIImage, defaults.IronicAPIImage),
 			IronicConductorImage:          getImg(instance.Spec.CustomContainerImages.IronicConductorImage, defaults.IronicConductorImage),
 			IronicInspectorImage:          getImg(instance.Spec.CustomContainerImages.IronicInspectorImage, defaults.IronicInspectorImage),

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -252,6 +252,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/ctlplane-basic-deployment/03-assert-deploy-custom-cacert.yaml
+++ b/tests/kuttl/tests/ctlplane-basic-deployment/03-assert-deploy-custom-cacert.yaml
@@ -63,6 +63,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
+++ b/tests/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
@@ -203,6 +203,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
+++ b/tests/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
@@ -206,6 +206,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/ctlplane-galera-basic/01-assert-galera.yaml
+++ b/tests/kuttl/tests/ctlplane-galera-basic/01-assert-galera.yaml
@@ -229,6 +229,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/ctlplane-tls-cert-rotation/03-assert-new-certs.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-cert-rotation/03-assert-new-certs.yaml
@@ -273,6 +273,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/01-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/01-assert-deploy-openstack.yaml
@@ -238,6 +238,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/09-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/09-assert-deploy-openstack.yaml
@@ -238,6 +238,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/ctlplane-tls-custom-route/03-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-route/03-assert-deploy-openstack.yaml
@@ -230,6 +230,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneClientReady
+  - message: OpenStackControlPlane custom TLS cert secret available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneCustomTLSReadyCondition
   - message: OpenStackControlPlane barbican service exposed
     reason: Ready
     status: "True"
@@ -266,6 +270,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"


### PR DESCRIPTION
This commits renames InstanceHA to InstanceHa to adhere to the openstackversion naming (casing) scheme.
It also adds the Infra InstanceHa image to a dedicated configmap so that the infra-operator can watch it and react to changes.