### PR TITLE
[OSPRH-10186] Fix OpenStackVersion defaults setup

### DIFF
--- a/apis/core/v1beta1/openstackversion_webhook.go
+++ b/apis/core/v1beta1/openstackversion_webhook.go
@@ -37,7 +37,7 @@ var versionWebhookClient goClient.Client
 
 // OpenStackVersionDefaults -
 type OpenStackVersionDefaults struct {
-	availableVersion string
+	AvailableVersion string
 }
 
 var openstackVersionDefaults OpenStackVersionDefaults
@@ -71,7 +71,7 @@ var _ webhook.Defaulter = &OpenStackVersion{}
 func (r *OpenStackVersion) Default() {
 	openstackversionlog.Info("default", "name", r.Name)
 	if r.Spec.TargetVersion == "" {
-		r.Spec.TargetVersion = openstackVersionDefaults.availableVersion
+		r.Spec.TargetVersion = openstackVersionDefaults.AvailableVersion
 	}
 
 	// TODO(user): fill in your defaulting logic.
@@ -86,7 +86,7 @@ var _ webhook.Validator = &OpenStackVersion{}
 func (r *OpenStackVersion) ValidateCreate() (admission.Warnings, error) {
 	openstackversionlog.Info("validate create", "name", r.Name)
 
-	if r.Spec.TargetVersion != openstackVersionDefaults.availableVersion {
+	if r.Spec.TargetVersion != openstackVersionDefaults.AvailableVersion {
 		return nil, apierrors.NewForbidden(
 			schema.GroupResource{
 				Group:    GroupVersion.WithKind("OpenStackVersion").Group,
@@ -145,7 +145,7 @@ func (r *OpenStackVersion) ValidateUpdate(old runtime.Object) (admission.Warning
 	openstackversionlog.Info("validate update", "name", r.Name)
 
 	_, ok := r.Status.ContainerImageVersionDefaults[r.Spec.TargetVersion]
-	if r.Spec.TargetVersion != openstackVersionDefaults.availableVersion && !ok {
+	if r.Spec.TargetVersion != openstackVersionDefaults.AvailableVersion && !ok {
 		return nil, apierrors.NewForbidden(
 			schema.GroupResource{
 				Group:    GroupVersion.WithKind("OpenStackVersion").Group,
@@ -173,7 +173,7 @@ func (r *OpenStackVersion) ValidateDelete() (admission.Warnings, error) {
 // SetupVersionDefaults -
 func SetupVersionDefaults() {
 	openstackVersionDefaults := OpenStackVersionDefaults{
-		availableVersion: util.GetEnvVar("OPENSTACK_RELEASE_VERSION", ""),
+		AvailableVersion: util.GetEnvVar("OPENSTACK_RELEASE_VERSION", ""),
 	}
 
 	SetupOpenStackVersionDefaults(openstackVersionDefaults)


### PR DESCRIPTION
The `OpenStackVersion` defaults struct declares `availableVersion` as a private field.  It needs to be public (capitalized) so that it can be accessed outside of the function in which the surrounding struct/object was created.