### PR TITLE
Add missing local webhooks for OpenStackVersion

### DIFF
--- a/hack/configure_local_webhook.sh
+++ b/hack/configure_local_webhook.sh
@@ -86,6 +86,34 @@ webhooks:
   timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: vopenstackversion.kb.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: ${CA_BUNDLE}
+    url: https://${CRC_IP}:9443/validate-core-openstack-org-v1beta1-openstackversion
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vopenstackversion.kb.io
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - core.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackversions
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mopenstackcontrolplane.kb.io
@@ -137,6 +165,34 @@ webhooks:
     - UPDATE
     resources:
     - openstackclients
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mopenstackversion.kb.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: ${CA_BUNDLE}
+    url: https://${CRC_IP}:9443/mutate-core-openstack-org-v1beta1-openstackversion
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: mopenstackversion.kb.io
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - core.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openstackversions
     scope: '*'
   sideEffects: None
   timeoutSeconds: 10


### PR DESCRIPTION
Adds local webhook support for `OpenStackVersion` to fix `make run-with-webhooks` target