### PR TITLE
Rebuild ManilaShares list

### DIFF
--- a/pkg/openstack/manila.go
+++ b/pkg/openstack/manila.go
@@ -120,9 +120,8 @@ func ReconcileManila(ctx context.Context, instance *corev1beta1.OpenStackControl
 			return errors.New("default Manila Share images is unset")
 		}
 
-		if manila.Spec.ManilaShares == nil {
-			manila.Spec.ManilaShares = make(map[string]manilav1.ManilaShareTemplate)
-		}
+		// Discard old list of share services and rebuild it
+		manila.Spec.ManilaShares = make(map[string]manilav1.ManilaShareTemplate)
 
 		for name, share := range instance.Spec.Manila.Template.ManilaShares {
 			manilaCore := manilav1.ManilaShareTemplate{}


### PR DESCRIPTION
We're currently not able to trigger a `shareCleanup` reconciliation loop when the top-level `CR` is updated and a `ManilaShare` entry is removed. In the effort of adding the `shareCleanup` feature in [1], we need to fix the `openstack-operator` code to rebuild a fresh version of `ManilaShares` from the existing CR.
Similarly to Cinder [2], this also fixes a regression for users who wants multiple shares with different backends after the initial deployment.

Jira: https://issues.redhat.com/browse/OSPRH-6525

[1] https://github.com/openstack-k8s-operators/manila-operator/pull/79
[2] https://github.com/openstack-k8s-operators/openstack-operator/commit/ede5a0645f17b2b5e4a06ac8c660f9cdd7507424