### PR TITLE
Use tempest-all image for running tempest

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -15,6 +15,7 @@
       cifmw_operator_build_golang_ct: "docker.io/library/golang:1.20"
       cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.20"
       cifmw_run_test_role: tempest
+      cifmw_tempest_container: openstack-tempest-all
       cifmw_tempest_tempestconf_profile:
           overrides:
             compute-feature-enabled.vnc_console: true


### PR DESCRIPTION
Currently jobs are blocked on
https://issues.redhat.com/browse/OSPCIX-488.
Fix is already proposed in https://github.com/rdo-packages/tempest-distgit/commit/10a5d132a3605cf20dade3b40737911253d1dfe1 But it is not included in current-promotion.

Let's use to tempest-all image to fix the issue.