### PR TITLE
Restoring lost defaults for ansible env vars

### DIFF
--- a/pkg/dataplane/util/ansible_execution.go
+++ b/pkg/dataplane/util/ansible_execution.go
@@ -63,9 +63,10 @@ func AnsibleExecution(
 	}
 
 	ansibleEE := EEJob{
-		Name:      executionName,
-		Namespace: deployment.GetNamespace(),
-		Labels:    labels,
+		Name:             executionName,
+		Namespace:        deployment.GetNamespace(),
+		Labels:           labels,
+		EnvConfigMapName: "openstack-aee-default-env",
 	}
 
 	ansibleEE.NetworkAttachments = aeeSpec.NetworkAttachments

--- a/pkg/dataplane/util/ansibleee.go
+++ b/pkg/dataplane/util/ansibleee.go
@@ -230,10 +230,14 @@ func labelsForOpenStackAnsibleEE(name string, labels map[string]string) map[stri
 }
 
 func (a *EEJob) addEnvFrom(job *batchv1.Job) {
+	// Add optional config map
+
+	optional := true
 	job.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{
 		{
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{Name: a.EnvConfigMapName},
+				Optional:             &(optional),
 			},
 		},
 	}


### PR DESCRIPTION
`EnvConfigMapName` used to default to `openstack-aee-default-env`, which is a config map we use[0] in install-yamls.
After the merger of ansibleeeoperator with the openstack operator, we have lost this (and other) defaults, since the new `EEJob` struct is only an internal representation and not a resource for customers to modify. 

Going forward we have essentially two options.

1. Restore the default for the config map name. Allowing us to create and modify it, in order to change ansibleee behavior. 
2. Remove the ` EnvConfigMapName` field entirely, as it is effectively unused.

Should we go with option 1. the obvios next step would be to allow modifications to the field value. In order to substitute alternative configuration in a simpler fashion. We could put that field in the `OpenStackDataPlaneDeployment` for example.

[0] https://github.com/openstack-k8s-operators/install_yamls/blob/main/devsetup/edpm/config/ansible-ee-env.yaml