### PR TITLE
Fix rabbitmq pod anti-affinity label selector

### DIFF
--- a/pkg/openstack/rabbitmq.go
+++ b/pkg/openstack/rabbitmq.go
@@ -344,7 +344,7 @@ func reconcileRabbitMQ(
 											Key:      "app.kubernetes.io/name",
 											Operator: metav1.LabelSelectorOpIn,
 											Values: []string{
-												"pod-anti-affinity",
+												rabbitmq.Name,
 											},
 										},
 									},


### PR DESCRIPTION
Appname is the CR name.
The value from the upstream example was accidentally used instead.