### PR TITLE
Cherry pick the csv epoch for OpenStackVersion back to 18 proposed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,8 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 CRD_MARKDOWN ?= $(LOCALBIN)/crd-to-markdown
 GINKGO ?= $(LOCALBIN)/ginkgo
+GINKGO_TESTS ?= ./tests/... ./apis/client/... ./apis/core/... ./apis/dataplane/...
+
 KUTTL ?= $(LOCALBIN)/kubectl-kuttl
 
 ## Tool Versions

--- a/apis/core/v1beta1/openstackversion_types.go
+++ b/apis/core/v1beta1/openstackversion_types.go
@@ -17,7 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"regexp"
+
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -200,4 +203,43 @@ func init() {
 // IsReady - returns true if service is ready to serve requests
 func (instance OpenStackVersion) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
+}
+
+func getOpenStackReleaseVersion(openstackReleaseVersion string, releaseVersionScheme string, operatorConditionName string) string {
+
+	/* NOTE: dprince
+	 * The releaseVersionScheme can be optionally used to enable 'csvEpochAppend' behavior
+	 * This is used by some downstream builds to append the version to the CSV version suffix (epoch) which
+	 * is obtained from the OPERATOR_CONDITION_NAME environment variable to the openstack release version.
+	 * In some downstream build systems CSV version bumps can be easily automated where as the
+	 * OPENSTACK_RELEASE_VERSION is more of a static constant.
+	 * The reason we don't always use the CSV version is that the raw version in those same downstream
+	 * builds does not match the OpenStackVersion (for example CSV version is 1.0 where as OpenStack product
+	 * version is set to 18.0, go figure!)
+	 */
+	if releaseVersionScheme == "csvEpochAppend" {
+		re := regexp.MustCompile(`\.[[:digit:]]{10,}\.p`)
+		operatorConditionEpoch := re.FindString(operatorConditionName)
+		if operatorConditionEpoch == "" {
+			return openstackReleaseVersion
+		} else {
+			return openstackReleaseVersion + operatorConditionEpoch
+		}
+	}
+	return openstackReleaseVersion
+}
+
+// GetOpenStackReleaseVersion - returns the OpenStack release version
+func GetOpenStackReleaseVersion(envVars []string) string {
+
+	return getOpenStackReleaseVersion(
+		util.GetEnvVar("OPENSTACK_RELEASE_VERSION", ""),
+		// can be set to csvEpochAppend
+		util.GetEnvVar("OPENSTACK_RELEASE_VERSION_SCHEME", ""),
+		// NOTE: dprince this is essentially the CSV version. OLM sets this to provide
+		// a way for the controller-manager to know the operator condition name
+		// we do it this way to *avoid requiring the CSV structs in this operator*
+		util.GetEnvVar("OPERATOR_CONDITION_NAME", ""),
+	)
+
 }

--- a/apis/core/v1beta1/openstackversion_webhook.go
+++ b/apis/core/v1beta1/openstackversion_webhook.go
@@ -18,12 +18,12 @@ package v1beta1
 
 import (
 	"context"
+	"os"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -173,7 +173,7 @@ func (r *OpenStackVersion) ValidateDelete() (admission.Warnings, error) {
 // SetupVersionDefaults -
 func SetupVersionDefaults() {
 	openstackVersionDefaults := OpenStackVersionDefaults{
-		AvailableVersion: util.GetEnvVar("OPENSTACK_RELEASE_VERSION", ""),
+		AvailableVersion: GetOpenStackReleaseVersion(os.Environ()),
 	}
 
 	SetupOpenStackVersionDefaults(openstackVersionDefaults)

--- a/apis/core/v1beta1/version_test.go
+++ b/apis/core/v1beta1/version_test.go
@@ -1,0 +1,40 @@
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OpenStackReleaseVersion", func() {
+
+	Context("test interal getOpenStackReleaseVersion", func() {
+
+		// NOTE: this is the default behavior where OPENSTACK_RELEASE_VERSION is just an environment variable
+		// and enables the clearest understanding of the version number with regards to testing upgrades
+		It("Generates a default version based on the OPENSTACK_RELEASE_VERSION when no mode is set", func() {
+			Expect(
+				getOpenStackReleaseVersion("1.2.3", "", "openstack-operator.v1.0.0-0.1724144685.p"),
+			).To(Equal("1.2.3"))
+
+		})
+
+		It("Generates a default version based on the OPENSTACK_RELEASE_VERSION when invalid mode is set", func() {
+			Expect(
+				getOpenStackReleaseVersion("1.2.3", "asdf", "openstack-operator.v1.0.0-0.1724144685.p"),
+			).To(Equal("1.2.3"))
+
+		})
+
+		// NOTE: this is what some downstream projects use for custom release automation
+		// Will envolve extra understanding of the version number when testing upgrades with regards to how the
+		// epoch gets appended
+		It("Generates a version which appends the epoch when csvEpochAppend is enabled", func() {
+			Expect(
+				getOpenStackReleaseVersion("1.2.3", "csvEpochAppend", "openstack-operator.v1.0.0-0.1234567890.p"),
+			).To(Equal("1.2.3.1234567890.p"))
+
+		})
+
+	})
+
+})

--- a/apis/core/v1beta1/webhook_suite_test.go
+++ b/apis/core/v1beta1/webhook_suite_test.go
@@ -18,10 +18,11 @@ package v1beta1
 
 import (
 	"testing"
+        . "github.com/onsi/ginkgo/v2"
+        . "github.com/onsi/gomega"
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-// Implement later
 func TestAPIs(t *testing.T) {
+        RegisterFailHandler(Fail)
+        RunSpecs(t, "Controller v1beta1 Suite")
 }

--- a/controllers/core/openstackversion_controller.go
+++ b/controllers/core/openstackversion_controller.go
@@ -56,6 +56,7 @@ func SetupVersionDefaults() {
 			localVars[envArr[0]] = &envArr[1]
 		}
 	}
+	envAvailableVersion = corev1beta1.GetOpenStackReleaseVersion(os.Environ())
 	envContainerImages = localVars
 }
 


### PR DESCRIPTION
git cherry-pick 5656b3224b4fce1451558855f15e2722159f7498
git cherry-pick 7e218cbc70d7f1baa148938055e854cb510ecded