### PR TITLE
Use OCP registries.conf for disconnected deployments

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -35,13 +35,15 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/tools v0.24.0 // indirect
-	k8s.io/api v0.29.9
 	k8s.io/apimachinery v0.29.9
 	k8s.io/client-go v0.29.9
 	sigs.k8s.io/controller-runtime v0.17.6
 )
 
-require k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
+require (
+	k8s.io/api v0.29.9
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -35,14 +35,11 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/tools v0.24.0 // indirect
+	k8s.io/api v0.29.9
 	k8s.io/apimachinery v0.29.9
 	k8s.io/client-go v0.29.9
-	sigs.k8s.io/controller-runtime v0.17.6
-)
-
-require (
-	k8s.io/api v0.29.9
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
+	sigs.k8s.io/controller-runtime v0.17.6
 )
 
 require (

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -500,6 +500,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - machineconfig
+  verbs:
+  - get
+  - list
+- apiGroups:
   - manila.openstack.org
   resources:
   - manilas
@@ -647,6 +654,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - imagecontentsourcepolicy
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ovn.openstack.org
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -502,10 +502,11 @@ rules:
 - apiGroups:
   - machineconfiguration.openshift.io
   resources:
-  - machineconfig
+  - machineconfigs
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - manila.openstack.org
   resources:
@@ -657,7 +658,7 @@ rules:
 - apiGroups:
   - operator.openshift.io
   resources:
-  - imagecontentsourcepolicy
+  - imagecontentsourcepolicies
   verbs:
   - get
   - list

--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -120,6 +120,10 @@ func (r *OpenStackDataPlaneNodeSetReconciler) GetLogger(ctx context.Context) log
 // +kubebuilder:rbac:groups="image.openshift.io",resources=imagetags,verbs=get;list;watch
 // +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreamtags,verbs=get;list;watch
 
+// RBAC for ImageContentSourcePolicy and MachineConfig
+// +kubebuilder:rbac:groups="operator.openshift.io",resources=imagecontentsourcepolicy,verbs=get;list
+// +kubebuilder:rbac:groups="machineconfiguration.openshift.io",resources=machineconfig,verbs=get;list
+
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // TODO(user): Modify the Reconcile function to compare the state specified by
@@ -565,7 +569,8 @@ func checkDeployment(ctx context.Context, helper *helper.Helper,
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *OpenStackDataPlaneNodeSetReconciler) SetupWithManager(
-	ctx context.Context, mgr ctrl.Manager) error {
+	ctx context.Context, mgr ctrl.Manager,
+) error {
 	// index for ConfigMaps listed on ansibleVarsFrom
 	if err := mgr.GetFieldIndexer().IndexField(ctx,
 		&dataplanev1.OpenStackDataPlaneNodeSet{}, "spec.ansibleVarsFrom.ansible.configMaps",

--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -672,6 +672,14 @@ func (r *OpenStackDataPlaneNodeSetReconciler) machineConfigWatcherFn(
 		return nil
 	}
 
+	listOpts := []client.ListOption{
+		client.InNamespace(obj.GetNamespace()),
+	}
+	if err := r.Client.List(ctx, nodeSets, listOpts...); err != nil {
+		Log.Error(err, "Unable to retrieve OpenStackDataPlaneNodeSetList")
+		return nil
+	}
+
 	requests := make([]reconcile.Request, 0, len(nodeSets.Items))
 	for _, nodeSet := range nodeSets.Items {
 		requests = append(requests, reconcile.Request{

--- a/main.go
+++ b/main.go
@@ -77,6 +77,8 @@ import (
 	dataplanev1 "github.com/openstack-k8s-operators/openstack-operator/apis/dataplane/v1beta1"
 
 	ocp_configv1 "github.com/openshift/api/config/v1"
+	machineconfig "github.com/openshift/api/machineconfiguration/v1"
+	ocp_image "github.com/openshift/api/operator/v1alpha1"
 	clientcontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/client"
 	corecontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/core"
 	dataplanecontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/dataplane"
@@ -120,6 +122,8 @@ func init() {
 	utilruntime.Must(certmgrv1.AddToScheme(scheme))
 	utilruntime.Must(barbicanv1.AddToScheme(scheme))
 	utilruntime.Must(ocp_configv1.AddToScheme(scheme))
+	utilruntime.Must(ocp_image.AddToScheme(scheme))
+	utilruntime.Must(machineconfig.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/pkg/dataplane/util/image_registry.go
+++ b/pkg/dataplane/util/image_registry.go
@@ -1,0 +1,131 @@
+package util
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	mc "github.com/openshift/api/machineconfiguration/v1"
+	ocpimage "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// machineConfigIgnition - holds the relevant parts of the ignition file that we need to create
+// the registries.conf on the dataplane nodes.
+type machineConfigIgnition struct {
+	Ignition struct {
+		Version string `json:"version"`
+	} `json:"ignition"`
+	Storage struct {
+		Files []struct {
+			Contents struct {
+				Compression string `json:"compression,omitempty"`
+				Source      string `json:"source"`
+			} `json:"contents"`
+			Mode      int    `json:"mode,omitempty"`
+			Overwrite bool   `json:"overwrite,omitempty"`
+			Path      string `json:"path"`
+		} `json:"files"`
+	} `json:"storage"`
+}
+
+// IsDisconnectedOCP - Will retrieve a ImageContentSourcePolicyList. If the list is not
+// empty, we can infer that the OCP cluster is a disconnected deployment.
+func IsDisconnectedOCP(ctx context.Context, helper *helper.Helper) (bool, error) {
+	icspList := ocpimage.ImageContentSourcePolicyList{}
+
+	listOpts := []client.ListOption{}
+	err := helper.GetClient().List(ctx, &icspList, listOpts...)
+	if err != nil {
+		return false, err
+	}
+
+	if len(icspList.Items) != 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// GetMCRegistryConf - will unmarshal the MachineConfig ignition file the machineConfigIgnition object.
+// This is then parsed and the base64 decoded string is returned.
+func GetMCRegistryConf(ctx context.Context, helper *helper.Helper) (string, error) {
+	var registriesConf string
+
+	masterMachineConfig, err := getMachineConfig(ctx, helper)
+	if err != nil {
+		return registriesConf, err
+	}
+
+	config := machineConfigIgnition{}
+	registriesConf, err = config.formatRegistriesConfString(&masterMachineConfig)
+	if err != nil {
+		return registriesConf, err
+	}
+
+	return registriesConf, nil
+}
+
+func (mci *machineConfigIgnition) removePrefixFromB64String() (string, error) {
+	const b64Prefix string = "data:text/plain;charset=utf-8;base64,"
+	if strings.HasPrefix(mci.Storage.Files[0].Contents.Source, b64Prefix) {
+		return mci.Storage.Files[0].Contents.Source[len(b64Prefix):], nil
+	}
+
+	return "", fmt.Errorf("no b64prefix found in MachineConfig")
+}
+
+func (mci *machineConfigIgnition) formatRegistriesConfString(machineConfig *mc.MachineConfig) (string, error) {
+	var (
+		err             error
+		rawConfigString string
+		configString    []byte
+	)
+
+	err = json.Unmarshal([]byte(machineConfig.Spec.Config.Raw), &mci)
+	if err != nil {
+		return "", err
+	}
+
+	rawConfigString, err = mci.removePrefixFromB64String()
+	if err != nil {
+		return "", err
+	}
+	configString, err = base64.StdEncoding.DecodeString(rawConfigString)
+	if err != nil {
+		return "", err
+	}
+
+	return string(configString), nil
+}
+
+func masterMachineConfigBuilder(machineConfigRegistries string) mc.MachineConfig {
+	return mc.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineConfigRegistries,
+			Namespace: "",
+		},
+	}
+}
+
+func getMachineConfig(ctx context.Context, helper *helper.Helper) (mc.MachineConfig, error) {
+	const machineConfigRegistries string = "99-master-generated-registries"
+
+	masterMachineConfig := masterMachineConfigBuilder(machineConfigRegistries)
+
+	err := helper.GetClient().Get(ctx,
+		types.NamespacedName{
+			Name: masterMachineConfig.Name, Namespace: masterMachineConfig.Namespace,
+		}, &masterMachineConfig)
+	if err != nil {
+		return masterMachineConfig, err
+	}
+
+	return masterMachineConfig, nil
+}

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -30,6 +30,48 @@ var DefaultEdpmServiceAnsibleVarList = []string{
 var CustomEdpmServiceDomainTag = "test-image:latest"
 var DefaultBackoffLimit = int32(6)
 
+func CreateICSP(name types.NamespacedName, spec map[string]interface{}) client.Object {
+	raw := map[string]interface{}{
+		"apiVersion": "operator.openshift.io/v1alpha1",
+		"kind":       "ImageContentSourcePolicy",
+		"metadata": map[string]interface{}{
+			"name":      name.Name,
+			"namespace": name.Namespace,
+		},
+		"spec": spec,
+	}
+	return th.CreateUnstructured(raw)
+}
+
+func CreateMachineConfig() client.Object {
+	raw := map[string]interface{}{
+		"apiVersion": "machineconfiguration.openshift.io/v1",
+		"kind":       "MachineConfig",
+		"metadata": map[string]interface{}{
+			"name": "99-master-generated-registries",
+		},
+		"spec": map[string]interface{}{
+			"config": map[string]interface{}{
+				"storage": map[string]interface{}{
+					"files": []interface{}{
+						map[string]interface{}{
+							"contents": map[string]interface{}{
+								"source":      "data:text/plain;charset=utf-8;base64,dW5xdWFsaWZpZWQtc2VhcmNoLXJlZ2lzdHJpZXMgPSBbInJlZ2lzdHJ5LmFjY2Vzcy5yZWRoYXQuY29tIiwgImRvY2tlci5pbyJdCnNob3J0LW5hbWUtbW9kZSA9ICIiCgpbW3JlZ2lzdHJ5XV0KICBwcmVmaXggPSAiIgogIGxvY2F0aW9uID0gInJlZ2lzdHJ5LmNpLm9wZW5zaGlmdC5vcmcvb3JpZ2luLzQuMTMtMjAyMy0wMi0yNi0xNjMwMzAiCgogIFtbcmVnaXN0cnkubWlycm9yXV0KICAgIGxvY2F0aW9uID0gInJlZ2lzdHJ5Lm9rZC5ibmUtc2hpZnQubmV0Ojg0NDMvb2tkIgogICAgcHVsbC1mcm9tLW1pcnJvciA9ICJkaWdlc3Qtb25seSIKCltbcmVnaXN0cnldXQogIHByZWZpeCA9ICIiCiAgbG9jYXRpb24gPSAicmVnaXN0cnkuY2kub3BlbnNoaWZ0Lm9yZy9vcmlnaW4vNC4xMy0yMDIzLTAzLTA3LTA5NDQwNiIKCiAgW1tyZWdpc3RyeS5taXJyb3JdXQogICAgbG9jYXRpb24gPSAicmVnaXN0cnkub2tkLmJuZS1zaGlmdC5uZXQ6ODQ0My9va2QiCiAgICBwdWxsLWZyb20tbWlycm9yID0gImRpZ2VzdC1vbmx5IgoKW1tyZWdpc3RyeV1dCiAgcHJlZml4ID0gIiIKICBsb2NhdGlvbiA9ICJyZWdpc3RyeS5jaS5vcGVuc2hpZnQub3JnL29yaWdpbi9yZWxlYXNlIgoKICBbW3JlZ2lzdHJ5Lm1pcnJvcl1dCiAgICBsb2NhdGlvbiA9ICJyZWdpc3RyeS5va2QuYm5lLXNoaWZ0Lm5ldDo4NDQzL29rZCIKICAgIHB1bGwtZnJvbS1taXJyb3IgPSAiZGlnZXN0LW9ubHkiCg==",
+								"compression": "",
+							},
+						},
+					},
+				},
+			},
+			"overwrite": true,
+			"mode":      420,
+			"path":      "/etc/containers/registries.conf",
+		},
+	}
+
+	return th.CreateUnstructured(raw)
+}
+
 // Create OpenstackDataPlaneNodeSet in k8s and test that no errors occur
 func CreateDataplaneNodeSet(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
 	instance := DefaultDataplaneNodeSetTemplate(name, spec)
@@ -128,7 +170,6 @@ func CreateOpenStackVersion(name types.NamespacedName) *unstructured.Unstructure
 }
 
 // Struct initialization
-
 func DefaultOpenStackVersion(name types.NamespacedName) map[string]interface{} {
 	return map[string]interface{}{
 		"apiVersion": "core.openstack.org/v1beta1",
@@ -142,6 +183,19 @@ func DefaultOpenStackVersion(name types.NamespacedName) map[string]interface{} {
 		},
 		"status": map[string]interface{}{
 			"availableVersion": "0.0.1",
+		},
+	}
+}
+
+func DefaultICSPSpec() map[string]interface{} {
+	return map[string]interface{}{
+		"repositoryDigestMirrors": []interface{}{
+			map[string]interface{}{
+				"mirrors": []interface{}{
+					"registry.okd.bne-shift.net:8443/okd", // Change to a string
+				},
+				"source": "registry.ci.openshift.org/origin/release", // Move "source" here
+			},
 		},
 	}
 }

--- a/tests/functional/dataplane/suite_test.go
+++ b/tests/functional/dataplane/suite_test.go
@@ -49,6 +49,9 @@ import (
 
 	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 
+	machineconfig "github.com/openshift/api/machineconfiguration/v1"
+	ocp_image "github.com/openshift/api/operator/v1alpha1"
+
 	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	test "github.com/openstack-k8s-operators/lib-common/modules/test"
@@ -101,6 +104,10 @@ var _ = BeforeSuite(func() {
 	openstackCRDs, err := test.GetCRDDirFromModule(
 		"github.com/openstack-k8s-operators/openstack-operator/apis", gomod, "bases")
 	Expect(err).ShouldNot(HaveOccurred())
+	imageContentSourcePolicyCRDs, err := test.GetCRDDirFromModule("github.com/openshift/api", gomod, "operator/v1alpha1/zz_generated.crd-manifests/")
+	Expect(err).ShouldNot(HaveOccurred())
+	machineConfigCRDs, err := test.GetCRDDirFromModule("github.com/openshift/api", gomod, "machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigs.crd.yaml")
+	Expect(err).ShouldNot(HaveOccurred())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -110,6 +117,8 @@ var _ = BeforeSuite(func() {
 			infraCRDs,
 			certmgrv1CRDs,
 			openstackCRDs,
+			imageContentSourcePolicyCRDs,
+			machineConfigCRDs,
 		},
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -145,6 +154,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	err = certmgrv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	err = machineconfig.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = ocp_image.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	// +kubebuilder:scaffold:scheme
 
 	logger = ctrl.Log.WithName("---DataPlane Test---")


### PR DESCRIPTION
This change adds functionality to check for ImageContentSourcePolicy in the OCP cluster. If we find it, we infer from its existance that we are running in a disconnected OCP deployment. If this is indeed the case, we will pull the registries.conf file from the MachineConfig and use this for our dataplane nodes configured via edpm_ansible.

Jira: https://issues.redhat.com/browse/OSPRH-10303