### PR TITLE
Remove webhook validation for networks

### DIFF
--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"golang.org/x/exp/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -348,30 +347,4 @@ func (r *OpenStackDataPlaneNodeSetSpec) TLSMatch(controlPlane openstackv1.OpenSt
 				controlPlane.Spec.TLS.PodLevel.Enabled))
 	}
 	return nil
-}
-
-// Validate NodeSet networks
-func (r *OpenStackDataPlaneNodeSetSpec) ValidateNetworks() (errors field.ErrorList) {
-	for nodeName, node := range r.Nodes {
-		if len(node.Networks) > 0 && !strings.EqualFold(string(node.Networks[0].Name), CtlPlaneNetwork) {
-			errors = append(errors, field.Invalid(
-				field.NewPath("spec").Child("nodes").Child(nodeName).Child("networks"),
-				node.Networks,
-				fmt.Sprintf(
-					"node %s error: networks should start with %s got %s instead",
-					node.HostName, CtlPlaneNetwork, node.Networks[0].Name,
-				)))
-		}
-	}
-	if len(r.NodeTemplate.Networks) > 0 && !strings.EqualFold(string(r.NodeTemplate.Networks[0].Name), CtlPlaneNetwork) {
-		errors = append(errors, field.Invalid(
-			field.NewPath("spec").Child("nodeTemplate").Child("networks"),
-			r.NodeTemplate.Networks,
-			fmt.Sprintf(
-				"networks should start with %s got %s instead",
-				CtlPlaneNetwork, r.NodeTemplate.Networks[0].Name,
-			)))
-	}
-
-	return errors
 }

--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_webhook.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_webhook.go
@@ -114,8 +114,6 @@ func (r *OpenStackDataPlaneNodeSet) ValidateCreate() (admission.Warnings, error)
 	if err != nil {
 		return nil, err
 	}
-	errors = append(errors, r.Spec.ValidateNetworks()...)
-
 	// Check if OpenStackDataPlaneNodeSet name matches RFC1123 for use in labels
 	validate := validator.New()
 	if err := validate.Var(r.Name, "hostname_rfc1123"); err != nil {
@@ -185,7 +183,6 @@ func (r *OpenStackDataPlaneNodeSet) ValidateUpdate(old runtime.Object) (admissio
 		return nil, err
 	}
 
-	errors = append(errors, r.Spec.ValidateNetworks()...)
 	errors = append(errors, r.Spec.ValidateUpdate(&oldNodeSet.Spec)...)
 
 	if errors != nil {

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -165,6 +165,7 @@ func DefaultDataPlaneNodeSetSpec(nodeSetName string) map[string]interface{} {
 			fmt.Sprintf("%s-node-1", nodeSetName): map[string]interface{}{
 				"hostName": "edpm-compute-node-1",
 				"networks": []infrav1.IPSetNetwork{
+					{Name: "networkinternal", SubnetName: "subnet1"},
 					{Name: "ctlplane", SubnetName: "subnet1"},
 				},
 			},
@@ -197,6 +198,7 @@ func DuplicateServiceNodeSetSpec(nodeSetName string) map[string]interface{} {
 			fmt.Sprintf("%s-node-1", nodeSetName): map[string]interface{}{
 				"hostName": "edpm-compute-node-1",
 				"networks": []infrav1.IPSetNetwork{
+					{Name: "networkinternal", SubnetName: "subnet1"},
 					{Name: "ctlplane", SubnetName: "subnet1"},
 				},
 			},
@@ -213,6 +215,7 @@ func DefaultDataPlaneNoNodeSetSpec(tlsEnabled bool) map[string]interface{} {
 		"preProvisioned": true,
 		"nodeTemplate": map[string]interface{}{
 			"networks": []infrav1.IPSetNetwork{
+				{Name: "networkinternal", SubnetName: "subnet1"},
 				{Name: "ctlplane", SubnetName: "subnet1"},
 			},
 			"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
@@ -290,9 +293,10 @@ func SingleGlobalServiceDeploymentSpec() map[string]interface{} {
 func DefaultNetConfigSpec() map[string]interface{} {
 	return map[string]interface{}{
 		"networks": []map[string]interface{}{{
-			"dnsDomain": "test-domain.test",
-			"mtu":       1500,
-			"name":      "CtlPLane",
+			"dnsDomain":  "test-domain.test",
+			"mtu":        1500,
+			"name":       "CtlPlane",
+			"serviceNet": "ctlplane",
 			"subnets": []map[string]interface{}{{
 				"allocationRanges": []map[string]interface{}{{
 					"end":   "172.20.12.120",
@@ -302,6 +306,22 @@ func DefaultNetConfigSpec() map[string]interface{} {
 				"name":    "subnet1",
 				"cidr":    "172.20.12.0/16",
 				"gateway": "172.20.12.1",
+			},
+			},
+		}, {
+			"dnsDomain":  "test-domain.test",
+			"mtu":        1500,
+			"name":       "networkinternal",
+			"serviceNet": "internalapi",
+			"subnets": []map[string]interface{}{{
+				"allocationRanges": []map[string]interface{}{{
+					"end":   "172.20.13.120",
+					"start": "172.20.13.0",
+				},
+				},
+				"name":    "subnet1",
+				"cidr":    "172.20.13.0/16",
+				"gateway": "172.20.13.1",
 			},
 			},
 		},
@@ -357,6 +377,15 @@ func SimulateIPSetComplete(name types.NamespacedName) {
 				Subnet:         "subnet1",
 				Gateway:        &gateway,
 				ServiceNetwork: "ctlplane",
+			},
+			{
+				Address:        "172.20.13.76",
+				Cidr:           "172.20.13.0/16",
+				MTU:            1500,
+				Network:        "NetworkInternal",
+				Subnet:         "subnet1",
+				Gateway:        &gateway,
+				ServiceNetwork: "internalapi",
 			},
 		}
 		// This can return conflict so we have the gomega.Eventually block to retry

--- a/tests/functional/dataplane/openstackdataplanenodeset_webhook_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_webhook_test.go
@@ -243,21 +243,4 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 				dataplaneDeploymentName.Name, string(v1beta1.NodeSetDeploymentReadyCondition))))
 		})
 	})
-	When("networks are out of order", func() {
-		BeforeEach(func() {
-			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(false)
-			dataplaneNodeSetName.Name = "unordered"
-			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
-		})
-
-		It("Should fail when ctlplane is not the first network", func() {
-			Eventually(func(_ Gomega) string {
-				dataplaneNodeSetName.Name = "unordered"
-				instance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				instance.Spec.NodeTemplate.Networks[0].Name = "wrong"
-				err := th.K8sClient.Update(th.Ctx, instance)
-				return fmt.Sprintf("%s", err)
-			}).Should(ContainSubstring("networks should start with ctlplane got wrong instead"))
-		})
-	})
 })


### PR DESCRIPTION
We now support custom network names. `ctlplane` network name or the network for which serviceNet is `ctlplane` could be anywhere in the order and it won't matter.

Jira: https://issues.redhat.com/browse/OSPRH-10125