### PR TITLE
Add power monitoring dataplane service

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry_power_monitoring.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry_power_monitoring.yaml
@@ -1,17 +1,17 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
 metadata:
-  name: telemetry
+  name: telemetry-power-monitoring
 spec:
   dataSources:
     - secretRef:
         name: ceilometer-compute-config-data
-  playbook: osp.edpm.telemetry
+  playbook: osp.edpm.telemetry_power_monitoring
   tlsCerts:
     default:
       contents:
       - ips
   caCerts: combined-ca-bundle
   containerImageFields:
-  - CeilometerComputeImage
-  - EdpmNodeExporterImage
+  - CeilometerIpmiImage
+  - EdpmKeplerImage


### PR DESCRIPTION
Deploys power monitoring services, Kepler and Ceilometer IPMI on EDPM nodes using the [role](https://github.com/openstack-k8s-operators/edpm-ansible/pull/781). Deploying these services is optional and is disabled by default.

Closes: [OSPRH-10269](https://issues.redhat.com/browse/OSPRH-10269)