### PR TITLE
Increase TLS kuttl timeout

### DIFF
--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/04-assert-service-certs-default-issuers.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/04-assert-service-certs-default-issuers.yaml
@@ -1,10 +1,10 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 500
+timeout: 800
 commands:
   - script: |
       echo "Waiting for OpenStack control plane to be ready..."
-      oc wait openstackcontrolplane -n $NAMESPACE --for=condition=Ready --timeout=400s -l core.openstack.org/openstackcontrolplane
+      oc wait openstackcontrolplane -n $NAMESPACE --for=condition=Ready --timeout=700s -l core.openstack.org/openstackcontrolplane
 
   - script: |
       echo "Checking issuer of internal certificates..."

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/10-assert-service-certs-issuers.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/10-assert-service-certs-issuers.yaml
@@ -1,10 +1,10 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 500
+timeout: 800
 commands:
   - script: |
       echo "Waiting for OpenStack control plane to be ready..."
-      oc wait openstackcontrolplane -n $NAMESPACE --for=condition=Ready --timeout=400s -l core.openstack.org/openstackcontrolplane
+      oc wait openstackcontrolplane -n $NAMESPACE --for=condition=Ready --timeout=700s -l core.openstack.org/openstackcontrolplane
 
   - script: |
       echo "Checking issuer of internal certificates..."


### PR DESCRIPTION
After deleting TLS cert secrets, the ctlplane can take longer to become ready again. The timeout is increased to prevent false failures.