### PR TITLE
Add openstack must-gather to required images

### DIFF
--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -177,3 +177,5 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-ansible-tests:current-podified
         - name: RELATED_IMAGE_TEST_HORIZONTEST_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-horizontest:current-podified
+        - name: RELEATED_IMAGE_OPENSTACK_MUST_GATHER_DEFAULT
+          value: quay.io/openstack-k8s-operators/openstack-must-gather:latest

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -85,3 +85,4 @@ export RELATED_IMAGE_TEST_TEMPEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-ce
 export RELATED_IMAGE_TEST_TOBIKO_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
 export RELATED_IMAGE_TEST_ANSIBLETEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ansible-tests:current-podified
 export RELATED_IMAGE_TEST_HORIZONTEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-horizontest:current-podified
+export RELATED_IMAGE_OPENSTACK_MUST_GATHER_DEFAULT=quay.io/openstack-k8s-operators/openstack-must-gather:latest


### PR DESCRIPTION
In disconnected environments, we should have a reference to the openstack-must-gather image. This allows for users to clone in the required image to their disconnected registries and enable them to gather logs for support cases and troubleshooting.

Jira: https://issues.redhat.com/browse/OSPRH-10635