### PR TITLE
minor update: unblock if dataplane never deployed

### DIFF
--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -223,7 +223,7 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrlResult, nil
 	}
 
-	if instance.Status.DeployedVersion == nil || version.Spec.TargetVersion == *instance.Status.DeployedVersion { //revive:disable:indent-error-flow
+	if version.IsReady() { //revive:disable:indent-error-flow
 		// green field deployment or no minor update in progress
 		ctrlResult, err := r.reconcileNormal(ctx, instance, version, helper)
 		if err != nil {

--- a/controllers/core/openstackversion_controller.go
+++ b/controllers/core/openstackversion_controller.go
@@ -297,7 +297,7 @@ func (r *OpenStackVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			corev1beta1.OpenStackVersionMinorUpdateReadyMessage)
 	}
 
-	if controlPlane.IsReady() {
+	if controlPlane.IsReady() && openstack.DataplaneNodesetsDeployed(instance, dataplaneNodesets) {
 		Log.Info("Setting DeployedVersion")
 		instance.Status.DeployedVersion = &instance.Spec.TargetVersion
 	}


### PR DESCRIPTION
Add a unit test and adjust logic to allow minor updates to complete when only the ControlPlane is completely deployed. Previously if the dataplaneDeployments were in a state of failure (upon initial deployment) a minor update would not succeed. The new logic allows targetVersiont to be switched without following the minor update workflow sequence and immediately updates the images on the Controlplane.

This is a rare case but a user actually hit it when updating the operators with failed/incomplete dataplane resources.

Jira: OSPRH-10645