### PR TITLE
Add openstack must-gather to required images

### DIFF
--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -163,3 +163,5 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-swift-object:current-podified
         - name: RELATED_IMAGE_SWIFT_PROXY_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-swift-proxy-server:current-podified
+        - name: RELEATED_IMAGE_OPENSTACK_MUST_GATHER_DEFAULT
+          value: quay.io/openstack-k8s-operators/openstack-must-gather:latest

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -78,3 +78,4 @@ export RELATED_IMAGE_EDPM_NEUTRON_OVN_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-a
 export RELATED_IMAGE_EDPM_NEUTRON_SRIOV_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent:current-podified
 export RELATED_IMAGE_EDPM_OVN_BGP_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ovn-bgp-agent:current-podified
 export RELATED_IMAGE_EDPM_NODE_EXPORTER_IMAGE_URL_DEFAULT=quay.io/prometheus/node-exporter:v1.5.0
+export RELATED_IMAGE_OPENSTACK_MUST_GATHER_DEFAULT=quay.io/openstack-k8s-operators/openstack-must-gather:latest


### PR DESCRIPTION
In disconnected environments, we should have a reference to the openstack-must-gather image. This allows for users to clone in the required image to their disconnected registries and enable them to gather logs for support cases and troubleshooting.

Signed-off-by: Brendan Shephard <bshephar@redhat.com>
(cherry picked from commit 6cac6382dac5a69bf3a93a4fa88024bc23823b30)