### PR TITLE
Update Samples and configure Swift backend for Glance

### DIFF
--- a/config/samples/base/openstackcontrolplane/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/base/openstackcontrolplane/core_v1beta1_openstackcontrolplane.yaml
@@ -56,13 +56,24 @@ spec:
     template:
       secret: osp-secret
       databaseInstance: openstack
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       storage:
         storageClass: ""
         storageRequest: 10G
       keystoneEndpoint: default
       glanceAPIs:
         default:
-          type: single
           replicas: 1
   cinder:
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
@@ -46,6 +46,18 @@ spec:
     template:
       secret: osp-secret
       databaseInstance: openstack
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       storage:
         storageClass: ""
         storageRequest: 10G
@@ -53,7 +65,6 @@ spec:
       glanceAPIs:
         default:
           replicas: 1
-          type: single
   cinder:
     template:
       databaseInstance: openstack
@@ -149,3 +160,12 @@ spec:
         ipaddr: 172.17.0.80
         port: 10514
         cloNamespace: openshift-logging
+  swift:
+    enabled: true
+    template:
+      swiftRing:
+        ringReplicas: 1
+      swiftStorage:
+        replicas: 1
+      swiftProxy:
+        replicas: 1

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -54,13 +54,24 @@ spec:
     template:
       secret: osp-secret
       databaseInstance: openstack
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       storage:
         storageClass: ""
         storageRequest: 10G
       keystoneEndpoint: default
       glanceAPIs:
         default:
-          type: single
           replicas: 1
   cinder:
     template:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -52,6 +52,18 @@ spec:
       secret: osp-secret
   glance:
     template:
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       databaseInstance: openstack
       storage:
         storageClass: ""
@@ -61,7 +73,6 @@ spec:
       glanceAPIs:
         default:
           replicas: 1
-          type: single
   cinder:
     template:
       databaseInstance: openstack
@@ -213,3 +224,11 @@ spec:
         replicas: 0
         networkAttachments:
           - designate
+  swift:
+    template:
+      swiftRing:
+        ringReplicas: 1
+      swiftStorage:
+        replicas: 1
+      swiftProxy:
+        replicas: 1

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -54,6 +54,18 @@ spec:
       default:
         route: {}
     template:
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       databaseInstance: openstack
       storage:
         storageClass: ""
@@ -62,7 +74,6 @@ spec:
       keystoneEndpoint: default
       glanceAPIs:
         default:
-          type: single
           replicas: 1
           override:
             service:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -77,6 +77,18 @@ spec:
         route: {}
     template:
       databaseInstance: openstack
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       storage:
         storageClass: ""
         storageRequest: 10G
@@ -84,7 +96,6 @@ spec:
       keystoneEndpoint: default
       glanceAPIs:
         default:
-          type: single
           replicas: 1
           override:
             service:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas_only_default_enabled_services.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas_only_default_enabled_services.yaml
@@ -77,6 +77,18 @@ spec:
         route: {}
     template:
       databaseInstance: openstack
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       storage:
         storageClass: ""
         storageRequest: 10G
@@ -84,7 +96,6 @@ spec:
       keystoneEndpoint: default
       glanceAPIs:
         default:
-          type: single
           replicas: 1
           override:
             service:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -77,6 +77,18 @@ spec:
         route: {}
     template:
       databaseInstance: openstack
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       storage:
         storageClass: ""
         storageRequest: 10G
@@ -84,7 +96,6 @@ spec:
       keystoneEndpoint: default
       glanceAPIs:
         default:
-          type: single
           replicas: 1
           override:
             service:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
@@ -85,9 +85,20 @@ spec:
         storageRequest: 10G
       secret: osp-secret
       keystoneEndpoint: default
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:swift
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        swift_store_create_container_on_put = True
+        swift_store_auth_version = 3
+        swift_store_auth_address = {{ .KeystoneInternalURL }}
+        swift_store_endpoint_type = internalURL
+        swift_store_user = service:glance
+        swift_store_key = {{ .ServicePassword }}
       glanceAPIs:
         default:
-          type: single
           replicas: 1
           override:
             service:

--- a/tests/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
+++ b/tests/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
@@ -125,6 +125,15 @@ spec:
         replicas: 1
       barbicanKeystoneListener:
         replicas: 1
+  swift:
+    enabled: true
+    template:
+      swiftRing:
+        ringReplicas: 1
+      swiftStorage:
+        replicas: 1
+      swiftProxy:
+        replicas: 1
   tls:
     ingress:
       ca:
@@ -199,6 +208,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneExposePlacementAPIReady
+  - message: OpenStackControlPlane swift service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeSwiftReady
   - message: OpenStackControlPlane Glance completed
     reason: Ready
     status: "True"
@@ -239,6 +252,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneRabbitMQReady
+  - message: OpenStackControlPlane Swift completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneSwiftReady
   - message: OpenStackControlPlane Telemetry completed
     reason: Ready
     status: "True"

--- a/tests/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
+++ b/tests/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
@@ -152,6 +152,15 @@ spec:
           duration: 87600h0m0s
         cert:
           duration: 43800h0m0s
+  swift:
+    enabled: true
+    template:
+      swiftRing:
+        ringReplicas: 1
+      swiftStorage:
+        replicas: 1
+      swiftProxy:
+        replicas: 1
 status:
   conditions:
   - message: Setup complete
@@ -202,6 +211,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneExposePlacementAPIReady
+  - message: OpenStackControlPlane swift service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeSwiftReady
   - message: OpenStackControlPlane Glance completed
     reason: Ready
     status: "True"
@@ -242,6 +255,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneRabbitMQReady
+  - message: OpenStackControlPlane Swift completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneSwiftReady
   - message: OpenStackControlPlane Telemetry completed
     reason: Ready
     status: "True"


### PR DESCRIPTION
The unsupported `File` backend is currently used in most of the samples. They are not consistent even with the documentation, where we suggest to add `replicas: 0` to the glance service until a backend is chosen. Considering we have `Swift` deployed by default, this patch fixes the `Glance` samples and adds `Swift` as a backend. This change will be reflected in the openstack-operator guide as well.