### PR TITLE
[make]force-bump fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,10 +150,10 @@ vet: gowork ## Run go vet against code.
 
 .PHONY: force-bump
 force-bump: ## Force bump after tagging
-	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|openstack-operator' | awk '{print $$1}'); do \
+	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|openstack-operator|^replace' | awk '{print $$1}'); do \
 		go get $$dep@main ; \
 	done
-	for dep in $$(cat apis/go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|openstack-operator' | awk '{print $$1}'); do \
+	for dep in $$(cat apis/go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|openstack-operator|^replace' | awk '{print $$1}'); do \
 		cd ./apis && go get $$dep@main && cd .. ; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -148,13 +148,14 @@ vet: gowork ## Run go vet against code.
 	go vet ./...
 	go vet ./apis/...
 
+BRANCH=main
 .PHONY: force-bump
 force-bump: ## Force bump after tagging
 	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|openstack-operator|^replace' | awk '{print $$1}'); do \
-		go get $$dep@main ; \
+		go get $$dep@$(BRANCH) ; \
 	done
 	for dep in $$(cat apis/go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|openstack-operator|^replace' | awk '{print $$1}'); do \
-		cd ./apis && go get $$dep@main && cd .. ; \
+		cd ./apis && go get $$dep@$(BRANCH) && cd .. ; \
 	done
 
 .PHONY: tidy


### PR DESCRIPTION
Enhance the `make force-bump` target to be useful for bumping dependencies on stable branches eventually.

Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)
