### PR TITLE
[kuttl] add test to enable tls as day2 in ctlplane-tls-cert-rotation

### DIFF
--- a/config/samples/tls/tls_ingress/kustomization.yaml
+++ b/config/samples/tls/tls_ingress/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+- ../../base/openstackcontrolplane
+
+patches:
+- target:
+    kind: OpenStackControlPlane
+    name: .*
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: openstack
+- target:
+    kind: OpenStackControlPlane
+  path: patch.yaml

--- a/config/samples/tls/tls_ingress/patch.yaml
+++ b/config/samples/tls/tls_ingress/patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  tls:
+    podLevel:
+      enabled: false

--- a/tests/kuttl/tests/ctlplane-tls-cert-rotation/00-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-cert-rotation/00-assert-deploy-openstack.yaml
@@ -1,0 +1,311 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  keystone:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  galera:
+    enabled: true
+    templates:
+      openstack:
+        storageRequest: 500M
+        secret: osp-secret
+        replicas: 1
+      openstack-cell1:
+        storageRequest: 500M
+        secret: osp-secret
+        replicas: 1
+  rabbitmq:
+    templates:
+      rabbitmq:
+        replicas: 1
+      rabbitmq-cell1:
+        replicas: 1
+  memcached:
+    templates:
+      memcached:
+        replicas: 1
+  placement:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  glance:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+      glanceAPIs:
+        default:
+          replicas: 1
+      storage:
+        storageRequest: 10G
+  cinder:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+      cinderAPI:
+        replicas: 1
+      cinderScheduler:
+        replicas: 1
+      cinderBackup:
+        replicas: 0 # backend needs to be configured
+      cinderVolumes:
+        volume1:
+          replicas: 0 # backend needs to be configured
+  manila:
+    template:
+      manilaAPI:
+        replicas: 1
+      manilaScheduler:
+        replicas: 1
+      manilaShares:
+        share1:
+          replicas: 1
+  ovn:
+    template:
+      ovnDBCluster:
+        ovndbcluster-nb:
+          replicas: 1
+          dbType: NB
+          storageRequest: 10G
+        ovndbcluster-sb:
+          replicas: 1
+          dbType: SB
+          storageRequest: 10G
+      ovnNorthd:
+        replicas: 1
+      ovnController:
+        external-ids:
+          system-id: "random"
+          ovn-bridge: "br-int"
+          ovn-encap-type: "geneve"
+  neutron:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  horizon:
+    template:
+      replicas: 1
+      secret: osp-secret
+  nova:
+    template:
+      secret: osp-secret
+  heat:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      heatAPI:
+        replicas: 1
+      heatEngine:
+        replicas: 1
+      secret: osp-secret
+  octavia:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      octaviaAPI:
+        replicas: 1
+      secret: osp-secret
+  ironic:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      ironicAPI:
+        replicas: 1
+      ironicConductors:
+      - replicas: 1
+        storageRequest: 10G
+      ironicInspector:
+        replicas: 1
+      ironicNeutronAgent:
+        replicas: 1
+      secret: osp-secret
+  telemetry:
+    enabled: true
+    template:
+      autoscaling:
+        aodh:
+          secret: osp-secret
+          serviceUser: aodh
+      ceilometer:
+        passwordSelector:
+          ceilometerService: CeilometerPassword
+        secret: osp-secret
+        serviceUser: ceilometer
+  swift:
+    enabled: true
+    template:
+      swiftRing:
+        ringReplicas: 1
+      swiftStorage:
+        replicas: 1
+      swiftProxy:
+        replicas: 1
+  designate:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+      designateAPI:
+        replicas: 1
+      designateCentral:
+        replicas: 0 # backend needs to be configured
+      designateWorker:
+        replicas: 0 # backend needs to be configured
+      designateProducer:
+        replicas: 0 # backend needs to be configured
+      designateBackendbind9:
+        replicas: 0 # backend needs to be configured
+  barbican:
+    enabled: true
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+      barbicanAPI:
+        replicas: 1
+      barbicanWorker:
+        replicas: 1
+      barbicanKeystoneListener:
+        replicas: 1
+  tls:
+    ingress:
+      ca:
+        duration: 87600h0m0s
+      cert:
+        duration: 43800h0m0s
+      enabled: true
+    podLevel:
+      enabled: false
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: OpenStackControlPlane Barbican completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneBarbicanReady
+  - message: OpenStackControlPlane CAs completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneCAReadyCondition
+  - message: OpenStackControlPlane Cinder completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneCinderReady
+  - message: OpenStackControlPlane Client completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneClientReady
+  - message: OpenStackControlPlane barbican service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeBarbicanReady
+  - message: OpenStackControlPlane cinder service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeCinderReady
+  - message: OpenStackControlPlane glance service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeGlanceReady
+  - message: OpenStackControlPlane keystone service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeKeystoneAPIReady
+  - message: OpenStackControlPlane neutron service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeNeutronReady
+  - message: OpenStackControlPlane nova service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeNovaReady
+  - message: OpenStackControlPlane placement service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposePlacementAPIReady
+  - message: OpenStackControlPlane swift service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeSwiftReady
+  - message: OpenStackControlPlane Glance completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane KeystoneAPI completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneKeystoneAPIReady
+  - message: OpenStackControlPlane MariaDB completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneMariaDBReady
+  - message: OpenStackControlPlane Memcached completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneMemcachedReady
+  - message: OpenStackControlPlane Neutron completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneNeutronReady
+  - message: OpenStackControlPlane Nova completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneNovaReady
+  - message: OpenStackControlPlane OVN completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneOVNReady
+  - message: OpenStackControlPlane PlacementAPI completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlanePlacementAPIReady
+  - message: OpenStackControlPlane RabbitMQ completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneRabbitMQReady
+  - message: OpenStackControlPlane Swift completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneSwiftReady
+  - message: OpenStackControlPlane Telemetry completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneTelemetryReady
+  - message: OpenStackControlPlane Test Operator CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneTestCMReadyCondition
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 500
+commands:
+  - script: |
+      echo "Waiting for OpenStack control plane to be ready..."
+      oc wait openstackcontrolplane -n $NAMESPACE --for=condition=Ready --timeout=400s -l core.openstack.org/openstackcontrolplane
+  - script: |
+      echo "Fail if internal https endpoints are registered"
+      oc exec -i openstackclient -n $NAMESPACE -- bash -c "openstack endpoint list --interface internal -f value -c URL" | grep 'https:' && exit 1
+      exit 0
+  - script: |
+      echo "check ovn sb internalDbAddress use tcp"
+      oc get -n $NAMESPACE OVNDBCluster ovndbcluster-sb -o jsonpath={.status.internalDbAddress} | grep -q tcp
+  - script: |
+      echo "check ovn sb DB connection use tcp"
+      oc exec -i statefulset/ovsdbserver-sb -n $NAMESPACE -- bash -c "ovn-sbctl --no-leader-only get-connection | grep -q ptcp"
+  - script: |
+      echo "check nova transport_url use tcp"
+      oc exec -i statefulset/nova-cell1-conductor -n $NAMESPACE -- bash -c "grep transport_url /etc/nova/nova.conf.d/01-nova.conf | grep -q 'ssl=0'"
+  - script: |
+      echo "check neutron ovn_sb_connection url tcp address"
+      oc exec -i deployment/neutron -n $NAMESPACE -- bash -c "grep ovn_sb_connection /etc/neutron/neutron.conf.d/01-neutron.conf | grep -q tcp"

--- a/tests/kuttl/tests/ctlplane-tls-cert-rotation/00-deploy-openstack-tls-ingress-only.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-cert-rotation/00-deploy-openstack-tls-ingress-only.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc kustomize ../../../../config/samples/tls/tls_ingress | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/ctlplane-tls-cert-rotation/02-assert-endpoint-proto.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-cert-rotation/02-assert-endpoint-proto.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 500
+commands:
+  - script: |
+      echo "Waiting for OpenStack control plane to be ready..."
+      oc wait openstackcontrolplane -n $NAMESPACE --for=condition=Ready --timeout=400s -l core.openstack.org/openstackcontrolplane
+  - script: |
+      echo "Fail if internal http endpoints are registered"
+      oc exec -i openstackclient -n $NAMESPACE -- bash -c "openstack endpoint list --interface internal -f value -c URL" | grep 'http:' && exit 1
+      exit 0
+  - script: |
+      echo "check ovn sb internalDbAddress use ssl"
+      oc get -n $NAMESPACE OVNDBCluster ovndbcluster-sb -o jsonpath={.status.internalDbAddress} | grep -q ssl
+  - script: |
+      echo "check ovn sb DB connection use ssl"
+      oc exec -i statefulset/ovsdbserver-sb -n $NAMESPACE -- bash -c "ovn-sbctl --no-leader-only get-connection | grep -q pssl"
+  - script: |
+      echo "check nova transport_url use ssl"
+      oc exec -i statefulset/nova-cell1-conductor -n $NAMESPACE -- bash -c "grep transport_url /etc/nova/nova.conf.d/01-nova.conf | grep -q 'ssl=1'"
+  - script: |
+      echo "check neutron ovn_sb_connection url ssl"
+      oc exec -i deployment/neutron -n $NAMESPACE -- bash -c "grep ovn_sb_connection /etc/neutron/neutron.conf.d/01-neutron.conf| grep -q ssl"


### PR DESCRIPTION
Changes the ctlplane-tls-cert-rotation tls kuttl test to start with a deployment where only the ingress/routes are configured to have tls. The podLevel tls is disabled. Later it gets enabled and the usual test steps to run.

Depends-On: https://github.com/openstack-k8s-operators/ovn-operator/pull/361

Jira: [OSPRH-6624](https://issues.redhat.com//browse/OSPRH-6624)