### PR TITLE
Bump to rabbitmq v2.9.0

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -113,5 +113,5 @@ require (
 // must consistent within modules and service operators
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 //allow-merging
 
-// custom RabbitmqClusterSpecCore for OpenStackControlplane (v2.6.0_patches_tag)
+// custom RabbitmqClusterSpecCore for OpenStackControlplane (v2.9.0_patches_tag)
 replace github.com/rabbitmq/cluster-operator/v2 => github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20241017142550-a3524acedd49 //allow-merging

--- a/go.mod
+++ b/go.mod
@@ -124,5 +124,5 @@ replace github.com/openstack-k8s-operators/openstack-operator/apis => ./apis
 // must consistent within modules and service operators
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 //allow-merging
 
-// custom RabbitmqClusterSpecCore for OpenStackControlplane (v2.6.0_patches_tag)
+// custom RabbitmqClusterSpecCore for OpenStackControlplane (v2.9.0_patches_tag)
 replace github.com/rabbitmq/cluster-operator/v2 => github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20241017142550-a3524acedd49 //allow-merging

--- a/hack/pin-bundle-images.sh
+++ b/hack/pin-bundle-images.sh
@@ -87,6 +87,6 @@ for MOD_PATH in ${MOD_PATHS}; do
 done
 # append the rabbitmq URL only if we aren't in Dockerfile mode
 if [ -z "$DOCKERFILE" ]; then
-    # pin rabbit to sha256 for the e7df1b654cb702d343996c7ac4245de8535c39c7 for our v2.6.0_patches fork
-    echo -n ",quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-bundle@sha256:c6ed5e2b416152c5adf42aeb984ab5de4f3d00593c15ffb626d1d87db67d1ccc"
+    # pin rabbit to sha256 for our v2.9.0_patches fork
+    echo -n ",quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-bundle@sha256:bad31e1b028840ac3c199efc3a8ecb3c87bdb68e6a11c8e32a7dbcd5a4d4114d"
 fi


### PR DESCRIPTION
This bumps the rabbitmq structs and bundle to our V2.9.0 which builds against golang 1.21