### PR TITLE
Switch EDPMServiceType to Enum

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -71,6 +71,14 @@ spec:
               deployOnAllNodeSets:
                 type: boolean
               edpmServiceType:
+                enum:
+                - nova
+                - ovn
+                - update
+                - libvirt
+                - neutron-metadata
+                - telemetry
+                - generic
                 type: string
               openStackAnsibleEERunnerImage:
                 type: string

--- a/apis/dataplane/v1beta1/openstackdataplaneservice_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplaneservice_types.go
@@ -110,6 +110,7 @@ type OpenStackDataPlaneServiceSpec struct {
 	// corresponds to the ansible role name (without the "edpm_" prefix) used
 	// to manage the service. If not set, will default to the
 	// OpenStackDataPlaneService name.
+	// +kubebuilder:validation:Enum=nova;ovn;update;libvirt;neutron-metadata;telemetry;generic
 	EDPMServiceType string `json:"edpmServiceType,omitempty" yaml:"edpmServiceType,omitempty"`
 }
 

--- a/apis/dataplane/v1beta1/openstackdataplaneservice_webhook.go
+++ b/apis/dataplane/v1beta1/openstackdataplaneservice_webhook.go
@@ -44,14 +44,15 @@ var _ webhook.Defaulter = &OpenStackDataPlaneService{}
 func (r *OpenStackDataPlaneService) Default() {
 
 	openstackdataplaneservicelog.Info("default", "name", r.Name)
-	r.Spec.Default(r.Name)
+	r.Spec.Default()
 	r.DefaultLabels()
 }
 
 // Default - set defaults for this OpenStackDataPlaneService
-func (spec *OpenStackDataPlaneServiceSpec) Default(name string) {
+func (spec *OpenStackDataPlaneServiceSpec) Default() {
+	const EdpmGenericServiceName string = "generic"
 	if spec.EDPMServiceType == "" {
-		spec.EDPMServiceType = name
+		spec.EDPMServiceType = EdpmGenericServiceName
 	}
 }
 

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -71,6 +71,14 @@ spec:
               deployOnAllNodeSets:
                 type: boolean
               edpmServiceType:
+                enum:
+                - nova
+                - ovn
+                - update
+                - libvirt
+                - neutron-metadata
+                - telemetry
+                - generic
                 type: string
               openStackAnsibleEERunnerImage:
                 type: string

--- a/pkg/dataplane/service.go
+++ b/pkg/dataplane/service.go
@@ -196,7 +196,7 @@ func dedupe(ctx context.Context, helper *helper.Helper,
 			return dedupedServices, updatedglobalServices, err
 
 		}
-		if !slices.Contains(nodeSetServiceTypes, service.Spec.EDPMServiceType) && !slices.Contains(dedupedServices, svc) {
+		if !slices.Contains(nodeSetServiceTypes, service.Name) && !slices.Contains(dedupedServices, svc) {
 			if service.Spec.DeployOnAllNodeSets {
 				if !slices.Contains(globalServices, svc) {
 					updatedglobalServices = append(globalServices, svc)

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -240,7 +240,7 @@ func DuplicateServiceNodeSetSpec(nodeSetName string) map[string]interface{} {
 	return map[string]interface{}{
 		"services": []string{
 			"foo-service",
-			"duplicate-service",
+			"foo-service",
 		},
 		"nodeTemplate": map[string]interface{}{
 			"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
@@ -311,7 +311,7 @@ func DuplicateServiceDeploymentSpec() map[string]interface{} {
 		},
 		"servicesOverride": []string{
 			"foo-service",
-			"duplicate-service",
+			"foo-service",
 		},
 	}
 }

--- a/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
@@ -656,6 +656,12 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			}))
 			// DefaultDataPlanenodeSetSpec comes with two mock services, one marked for deployment on all nodesets
 			// But we will not create them to test this scenario
+			CreateDataplaneService(dataplaneGlobalServiceName, false)
+
+			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
+				"edpmServiceType":               "update",
+				"openStackAnsibleEERunnerImage": "foo-image:latest"})
+
 			DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
 			DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 			SimulateDNSMasqComplete(dnsMasqName)
@@ -969,6 +975,8 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			}))
 			// DefaultDataPlanenodeSetSpec comes with two mock services, one marked for deployment on all nodesets
 			// But we will not create them to test this scenario
+			CreateDataplaneService(dataplaneGlobalServiceName, true)
+			CreateDataplaneService(dataplaneUpdateServiceName, false)
 			DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
 			DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 			SimulateDNSMasqComplete(dnsMasqName)
@@ -987,7 +995,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				BackoffLimit:          &DefaultBackoffLimit,
 				PreserveJobs:          true,
 				DeploymentRequeueTime: 15,
-				ServicesOverride:      []string{dataplaneServiceName.Name, "duplicate-service"},
+				ServicesOverride:      []string{dataplaneServiceName.Name, "foo-service"},
 			}
 			Expect(dataplaneDeploymentInstance.Spec).Should(Equal(expectedSpec))
 		})

--- a/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			// with EDPMServiceType set
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
-				"edpmServiceType":               "foo-update-service",
+				"edpmServiceType":               "update",
 				"openStackAnsibleEERunnerImage": "foo-image:latest"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
@@ -279,7 +279,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
-				"edpmServiceType":               "foo-update-service",
+				"edpmServiceType":               "update",
 				"openStackAnsibleEERunnerImage": "foo-image:latest"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
@@ -750,7 +750,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
-				"EDPMServiceType": "foo-update-service"})
+				"EDPMServiceType": "update"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
 			DeferCleanup(th.DeleteService, dataplaneGlobalServiceName)
@@ -1081,7 +1081,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
-				"EDPMServiceType": "foo-update-service"})
+				"EDPMServiceType": "update"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
 			DeferCleanup(th.DeleteService, dataplaneGlobalServiceName)
@@ -1288,7 +1288,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
-				"EDPMServiceType": "foo-update-service"})
+				"EDPMServiceType": "update"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
 			DeferCleanup(th.DeleteService, dataplaneGlobalServiceName)


### PR DESCRIPTION
This change switches the EDPMServiceType parameter to be an Enum that accepts a fixed list of service names. This is required, since allowing arbitrary names can interfere with the TLS mounts desribed in the referenced Jira.

Jira: https://issues.redhat.com/browse/OSPRH-10804