### PR TITLE
Reuse OpenstackClientImage instead of dedicated InstanceHaImage

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -18373,8 +18373,6 @@ spec:
                     type: string
                   infraDnsmasqImage:
                     type: string
-                  infraInstanceHaImage:
-                    type: string
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:

--- a/apis/bases/core.openstack.org_openstackversions.yaml
+++ b/apis/bases/core.openstack.org_openstackversions.yaml
@@ -127,8 +127,6 @@ spec:
                     type: string
                   infraDnsmasqImage:
                     type: string
-                  infraInstanceHaImage:
-                    type: string
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:
@@ -334,8 +332,6 @@ spec:
                       type: string
                     infraDnsmasqImage:
                       type: string
-                    infraInstanceHaImage:
-                      type: string
                     infraMemcachedImage:
                       type: string
                     infraRedisImage:
@@ -511,8 +507,6 @@ spec:
                   horizonImage:
                     type: string
                   infraDnsmasqImage:
-                    type: string
-                  infraInstanceHaImage:
                     type: string
                   infraMemcachedImage:
                     type: string

--- a/apis/core/v1beta1/openstackversion_types.go
+++ b/apis/core/v1beta1/openstackversion_types.go
@@ -118,7 +118,6 @@ type ContainerTemplate struct {
 	InfraDnsmasqImage             *string `json:"infraDnsmasqImage,omitempty"`
 	InfraMemcachedImage           *string `json:"infraMemcachedImage,omitempty"`
 	InfraRedisImage               *string `json:"infraRedisImage,omitempty"`
-	InfraInstanceHaImage          *string `json:"infraInstanceHaImage,omitempty"`
 	IronicAPIImage                *string `json:"ironicAPIImage,omitempty"`
 	IronicConductorImage          *string `json:"ironicConductorImage,omitempty"`
 	IronicInspectorImage          *string `json:"ironicInspectorImage,omitempty"`

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -468,11 +468,6 @@ func (in *ContainerTemplate) DeepCopyInto(out *ContainerTemplate) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.InfraInstanceHaImage != nil {
-		in, out := &in.InfraInstanceHaImage, &out.InfraInstanceHaImage
-		*out = new(string)
-		**out = **in
-	}
 	if in.IronicAPIImage != nil {
 		in, out := &in.IronicAPIImage, &out.IronicAPIImage
 		*out = new(string)

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -18373,8 +18373,6 @@ spec:
                     type: string
                   infraDnsmasqImage:
                     type: string
-                  infraInstanceHaImage:
-                    type: string
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:

--- a/config/crd/bases/core.openstack.org_openstackversions.yaml
+++ b/config/crd/bases/core.openstack.org_openstackversions.yaml
@@ -127,8 +127,6 @@ spec:
                     type: string
                   infraDnsmasqImage:
                     type: string
-                  infraInstanceHaImage:
-                    type: string
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:
@@ -334,8 +332,6 @@ spec:
                       type: string
                     infraDnsmasqImage:
                       type: string
-                    infraInstanceHaImage:
-                      type: string
                     infraMemcachedImage:
                       type: string
                     infraRedisImage:
@@ -511,8 +507,6 @@ spec:
                   horizonImage:
                     type: string
                   infraDnsmasqImage:
-                    type: string
-                  infraInstanceHaImage:
                     type: string
                   infraMemcachedImage:
                     type: string

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -99,8 +99,6 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-memcached:current-podified
         - name: RELATED_IMAGE_INFRA_REDIS_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-redis:current-podified
-        - name: RELATED_IMAGE_INFRA_INSTANCE_HA_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
         - name: RELATED_IMAGE_IRONIC_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
         - name: RELATED_IMAGE_IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -7,7 +7,6 @@ export RELATED_IMAGE_KEYSTONE_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-ce
 export RELATED_IMAGE_MARIADB_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 export RELATED_IMAGE_INFRA_MEMCACHED_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-memcached:current-podified
 export RELATED_IMAGE_INFRA_REDIS_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-redis:current-podified
-export RELATED_IMAGE_INFRA_INSTANCE_HA_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
 export RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT=quay.io/openstack-k8s-operators/openstack-ansibleee-runner:current-podified
 export RELATED_IMAGE_NOVA_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-nova-api:current-podified
 export RELATED_IMAGE_NOVA_CONDUCTOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-nova-conductor:current-podified

--- a/pkg/openstack/instanceha.go
+++ b/pkg/openstack/instanceha.go
@@ -20,7 +20,7 @@ const (
 func ReconcileInstanceHa(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, version *corev1beta1.OpenStackVersion, helper *helper.Helper) (ctrl.Result, error) {
 	missingImageDefault := ""
 	customData := map[string]string{
-		InstanceHaImageKey: *getImg(version.Status.ContainerImages.InfraInstanceHaImage, &missingImageDefault),
+		InstanceHaImageKey: *getImg(version.Status.ContainerImages.OpenstackClientImage, &missingImageDefault),
 	}
 
 	cms := []util.Template{

--- a/pkg/openstack/version.go
+++ b/pkg/openstack/version.go
@@ -127,7 +127,6 @@ func GetContainerImages(defaults *corev1beta1.ContainerDefaults, instance corev1
 			InfraDnsmasqImage:             getImg(instance.Spec.CustomContainerImages.InfraDnsmasqImage, defaults.InfraDnsmasqImage),
 			InfraMemcachedImage:           getImg(instance.Spec.CustomContainerImages.InfraMemcachedImage, defaults.InfraMemcachedImage),
 			InfraRedisImage:               getImg(instance.Spec.CustomContainerImages.InfraRedisImage, defaults.InfraRedisImage),
-			InfraInstanceHaImage:          getImg(instance.Spec.CustomContainerImages.InfraInstanceHaImage, defaults.InfraInstanceHaImage),
 			IronicAPIImage:                getImg(instance.Spec.CustomContainerImages.IronicAPIImage, defaults.IronicAPIImage),
 			IronicConductorImage:          getImg(instance.Spec.CustomContainerImages.IronicConductorImage, defaults.IronicConductorImage),
 			IronicInspectorImage:          getImg(instance.Spec.CustomContainerImages.IronicInspectorImage, defaults.IronicInspectorImage),


### PR DESCRIPTION
This resolves the warning at "make bundle" time:

```
WARN[0001] warning: multiple related images with the same image ref, "infra-instance-ha-image-url-default", and different names found.The image will only be listed once with an empty name.It is recmmended to either remove the duplicate or use the exact same name. 
```

while preserving the needed configmap:

```
[cifmw@haa-09 install_yamls]$ oc get cm infra-instanceha-config -o yaml
apiVersion: v1
data:
  instanceha-image: quay.io/podified-antelope-centos9/openstack-openstackclient@sha256:403c4f660f1b704d9ebbb9838c711ec6d20ca7183c63b2f224ad450f5ec37cf2
kind: ConfigMap
metadata:
  creationTimestamp: "2024-10-22T04:39:21Z"
  name: infra-instanceha-config
  namespace: openstack
  ownerReferences:
  - apiVersion: core.openstack.org/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: OpenStackControlPlane
    name: openstack-galera-network-isolation
    uid: cee79e70-639c-4974-acc5-5ec8f75ca299
  resourceVersion: "51877"
  uid: 8dd46abb-0cf1-414b-a3d7-6a3f34a9bb56
```