### PR TITLE
[Designate] Add Bind9 storageRequest and replica count

### DIFF
--- a/config/samples/base/openstackcontrolplane/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/base/openstackcontrolplane/core_v1beta1_openstackcontrolplane.yaml
@@ -199,12 +199,14 @@ spec:
       designateAPI:
         replicas: 1
       designateCentral:
-        replicas: 0 # backend needs to be configured
+        replicas: 1 # backend needs to be configured
       designateWorker:
-        replicas: 0 # backend needs to be configured
+        replicas: 1 # backend needs to be configured
       designateProducer:
-        replicas: 0 # backend needs to be configured
+        replicas: 1 # backend needs to be configured
       designateMdns:
         replicas: 0 # backend needs to be configured
       designateBackendbind9:
-        replicas: 0 # backend needs to be configured
+        replicas: 1 # backend needs to be configured
+        storageClass: local-storage
+        storageRequest: 10G

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -226,16 +226,18 @@ spec:
       designateCentral:
         replicas: 1
       designateWorker:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateProducer:
-        replicas: 0
+        replicas: 1
       designateMdns:
         replicas: 0
         networkAttachments:
           - designate
       designateBackendbind9:
-        replicas: 0
+        replicas: 1
+        storageClass: local-storage
+        storageRequest: 10G
         networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -211,17 +211,19 @@ spec:
       designateCentral:
         replicas: 1
       designateWorker:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateProducer:
-        replicas: 0
+        replicas: 1
       designateMdns:
         replicas: 0
         networkAttachments:
           - designate
       designateBackendbind9:
-        replicas: 0
+        replicas: 1
+        storageClass: local-storage
+        storageRequest: 10G
         networkAttachments:
           - designate
   swift:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -413,16 +413,18 @@ spec:
       designateCentral:
         replicas: 1
       designateWorker:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateProducer:
-        replicas: 0
+        replicas: 1
       designateMdns:
         replicas: 0
         networkAttachments:
           - designate
       designateBackendbind9:
-        replicas: 0
+        replicas: 1
+        storageClass: local-storage
+        storageRequest: 10G
         networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -415,16 +415,18 @@ spec:
       designateCentral:
         replicas: 1
       designateWorker:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateProducer:
-        replicas: 0
+        replicas: 1
       designateMdns:
         replicas: 0
         networkAttachments:
           - designate
       designateBackendbind9:
-        replicas: 0
+        replicas: 1
+        storageClass: local-storage
+        storageRequest: 10G
         networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -409,16 +409,18 @@ spec:
       designateCentral:
         replicas: 1
       designateWorker:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateProducer:
-        replicas: 0
+        replicas: 1
       designateMdns:
         replicas: 0
         networkAttachments:
           - designate
       designateBackendbind9:
-        replicas: 0
+        replicas: 1
+        storageClass: local-storage
+        storageRequest: 10G
         networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -434,16 +434,18 @@ spec:
       designateCentral:
         replicas: 1
       designateWorker:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateProducer:
-        replicas: 0
+        replicas: 1
       designateMdns:
         replicas: 0
         networkAttachments:
           - designate
       designateBackendbind9:
-        replicas: 0
+        replicas: 1
+        storageClass: local-storage
+        storageRequest: 10G
         networkAttachments:
           - designate

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
@@ -412,16 +412,18 @@ spec:
       designateCentral:
         replicas: 1
       designateWorker:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateProducer:
-        replicas: 0
+        replicas: 1
       designateMdns:
         replicas: 0
         networkAttachments:
           - designate
       designateBackendbind9:
-        replicas: 0
+        replicas: 1
+        storageClass: local-storage
+        storageRequest: 10G
         networkAttachments:
           - designate

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -152,13 +152,13 @@ spec:
       designateAPI:
         replicas: 1
       designateCentral:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateWorker:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateProducer:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateBackendbind9:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
   barbican:
     enabled: true
     template:

--- a/tests/kuttl/tests/ctlplane-tls-cert-rotation/00-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-cert-rotation/00-assert-deploy-openstack.yaml
@@ -152,13 +152,13 @@ spec:
       designateAPI:
         replicas: 1
       designateCentral:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateWorker:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateProducer:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateBackendbind9:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
   barbican:
     enabled: true
     template:

--- a/tests/kuttl/tests/ctlplane-tls-cert-rotation/03-assert-new-certs.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-cert-rotation/03-assert-new-certs.yaml
@@ -173,13 +173,13 @@ spec:
       designateAPI:
         replicas: 1
       designateCentral:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateWorker:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateProducer:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateBackendbind9:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
   barbican:
     enabled: true
     template:

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/01-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/01-assert-deploy-openstack.yaml
@@ -152,13 +152,13 @@ spec:
       designateAPI:
         replicas: 1
       designateCentral:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateWorker:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateProducer:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateBackendbind9:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
   barbican:
     enabled: true
     template:

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/09-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/09-assert-deploy-openstack.yaml
@@ -152,13 +152,13 @@ spec:
       designateAPI:
         replicas: 1
       designateCentral:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateWorker:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateProducer:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateBackendbind9:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
   barbican:
     enabled: true
     template:

--- a/tests/kuttl/tests/ctlplane-tls-custom-route/03-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-route/03-assert-deploy-openstack.yaml
@@ -163,13 +163,13 @@ spec:
       designateAPI:
         replicas: 1
       designateCentral:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateWorker:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateProducer:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
       designateBackendbind9:
-        replicas: 0 # backend needs to be configured
+        replicas: 1
   barbican:
     enabled: true
     apiOverride:


### PR DESCRIPTION
After DesignateBackendBind9 was changed to a stateful set, Designate requires a persistent volume claim.

This patch adds the pvc value to the control plane definition, and requires a replica count minimum of at least 1.