### PR TITLE
Enable Heat in functional tests

### DIFF
--- a/tests/functional/ctlplane/base_test.go
+++ b/tests/functional/ctlplane/base_test.go
@@ -409,6 +409,13 @@ func GetDefaultOpenStackControlPlaneSpec() map[string]interface{} {
 	ironicTemplate := map[string]interface{}{
 		"ironicConductors": []interface{}{},
 	}
+	heatTemplate := map[string]interface{}{
+		"databaseInstance": "openstack",
+		"secret":           "osp-secret",
+		"passwordSelectors": map[string]interface{}{
+			"AuthEncryptionKey": "HeatAuthEncryptionKey",
+		},
+	}
 
 	return map[string]interface{}{
 		"secret":       "osp-secret",
@@ -471,6 +478,10 @@ func GetDefaultOpenStackControlPlaneSpec() map[string]interface{} {
 		},
 		"manila": map[string]interface{}{
 			"enabled": true,
+		},
+		"heat": map[string]interface{}{
+			"enabled":  true,
+			"template": heatTemplate,
 		},
 	}
 }

--- a/tests/functional/ctlplane/openstackversion_controller_test.go
+++ b/tests/functional/ctlplane/openstackversion_controller_test.go
@@ -227,6 +227,9 @@ var _ = Describe("OpenStackOperator controller", func() {
 			spec["manila"] = map[string]interface{}{
 				"enabled": false,
 			}
+			spec["heat"] = map[string]interface{}{
+				"enabled": false,
+			}
 			spec["tls"] = GetTLSPublicSpec()
 			spec["ovn"] = map[string]interface{}{
 				"enabled": true,


### PR DESCRIPTION
This change enables the Heat service in the openstackcontrolplane functional tests. It ensures webhook logic is evaluated to avoid any potential nil pointer derefs and that we can validate the route annotations are applied.