### PR TITLE
Require EDPMServiceType

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -129,6 +129,8 @@ spec:
                   - contents
                   type: object
                 type: object
+            required:
+            - edpmServiceType
             type: object
           status:
             properties:

--- a/apis/dataplane/v1beta1/openstackdataplaneservice_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplaneservice_types.go
@@ -114,7 +114,8 @@ type OpenStackDataPlaneServiceSpec struct {
 	// corresponds to the ansible role name (without the "edpm_" prefix) used
 	// to manage the service. If not set, will default to the
 	// OpenStackDataPlaneService name.
-	EDPMServiceType string `json:"edpmServiceType,omitempty" yaml:"edpmServiceType,omitempty"`
+	// +kubebuilder:validation:Required
+	EDPMServiceType string `json:"edpmServiceType" yaml:"edpmServiceType"`
 }
 
 // OpenStackDataPlaneServiceStatus defines the observed state of OpenStackDataPlaneService

--- a/apis/dataplane/v1beta1/openstackdataplaneservice_webhook.go
+++ b/apis/dataplane/v1beta1/openstackdataplaneservice_webhook.go
@@ -44,15 +44,7 @@ var _ webhook.Defaulter = &OpenStackDataPlaneService{}
 func (r *OpenStackDataPlaneService) Default() {
 
 	openstackdataplaneservicelog.Info("default", "name", r.Name)
-	r.Spec.Default(r.Name)
 	r.DefaultLabels()
-}
-
-// Default - set defaults for this OpenStackDataPlaneService
-func (spec *OpenStackDataPlaneServiceSpec) Default(name string) {
-	if spec.EDPMServiceType == "" {
-		spec.EDPMServiceType = name
-	}
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -129,6 +129,8 @@ spec:
                   - contents
                   type: object
                 type: object
+            required:
+            - edpmServiceType
             type: object
           status:
             properties:

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
@@ -4,3 +4,4 @@ metadata:
   name: bootstrap
 spec:
   playbook: osp.edpm.bootstrap
+  edpmServiceType: bootstrap

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_client.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_client.yaml
@@ -4,3 +4,4 @@ metadata:
   name: ceph-client
 spec:
   playbook: osp.edpm.ceph_client
+  edpmServiceType: ceph-client

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
@@ -4,3 +4,4 @@ metadata:
   name: ceph-hci-pre
 spec:
   playbook: osp.edpm.ceph_hci_pre
+  edpmServiceType: ceph-hci-pre

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
@@ -4,3 +4,4 @@ metadata:
   name: configure-network
 spec:
   playbook: osp.edpm.configure_network
+  edpmServiceType: configure-network

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_os.yaml
@@ -4,3 +4,4 @@ metadata:
   name: configure-os
 spec:
   playbook: osp.edpm.configure_os
+  edpmServiceType: configure-os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovs_dpdk.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovs_dpdk.yaml
@@ -4,3 +4,4 @@ metadata:
   name: configure-ovs-dpdk
 spec:
   playbook: osp.edpm.configure_ovs_dpdk
+  edpmServiceType: configure-ovs-dpdk

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ddp_package_option.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ddp_package_option.yaml
@@ -4,3 +4,4 @@ metadata:
   name: ddp-package-option
 spec:
   playbook: osp.edpm.select_kernel_ddp_package
+  edpmServiceType: ddp-package-option

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_derive_pci_devicespec.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_derive_pci_devicespec.yaml
@@ -4,3 +4,4 @@ metadata:
   name: derive-pci-devicespec
 spec:
   playbook: osp.edpm.sriov_derive_device_spec
+  edpmServiceType: derive-pci-devicespec

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_download_cache.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_download_cache.yaml
@@ -4,3 +4,4 @@ metadata:
   name: download-cache
 spec:
   playbook: osp.edpm.download_cache
+  edpmServiceType: download-cache

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_fips_status.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_fips_status.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   label: fips-status
   playbook: osp.edpm.fips_status
+  edpmServiceType: fips-status

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_frr.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_frr.yaml
@@ -6,3 +6,4 @@ spec:
   playbook: osp.edpm.frr
   containerImageFields:
   - EdpmFrrImage
+  edpmServiceType: frr

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_certs.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_certs.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   playbook: osp.edpm.install_certs
   addCertMounts: True
+  edpmServiceType: install-certs

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
@@ -4,3 +4,4 @@ metadata:
   name: install-os
 spec:
   playbook: osp.edpm.install_os
+  edpmServiceType: install-os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
@@ -23,3 +23,4 @@ spec:
         - client auth
       issuer: osp-rootca-issuer-libvirt
   caCerts: combined-ca-bundle
+  edpmServiceType: libvirt

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_logging.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_logging.yaml
@@ -7,3 +7,4 @@ spec:
     - secretRef:
         name: logging-compute-config-data
   playbook: osp.edpm.telemetry_logging
+  edpmServiceType: logging

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_dhcp.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_dhcp.yaml
@@ -10,3 +10,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmNeutronDhcpAgentImage
+  edpmServiceType: neutron-dhcp

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_metadata.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_metadata.yaml
@@ -24,3 +24,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmNeutronMetadataAgentImage
+  edpmServiceType: neutron-metadata

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_ovn.yaml
@@ -22,3 +22,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmNeutronOvnAgentImage
+  edpmServiceType: neutron-ovn

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
@@ -10,3 +10,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmNeutronSriovAgentImage
+  edpmServiceType: neutron-sriov

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_os_reboot.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_os_reboot.yaml
@@ -4,3 +4,4 @@ metadata:
   name: reboot-os
 spec:
   playbook: osp.edpm.reboot
+  edpmServiceType: reboot-os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
@@ -23,3 +23,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - OvnControllerImage
+  edpmServiceType: ovn

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
@@ -23,3 +23,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmOvnBgpAgentImage
+  edpmServiceType: ovn-bgp-agent

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_run_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_run_os.yaml
@@ -7,3 +7,4 @@ spec:
   containerImageFields:
   - EdpmLogrotateCrondImage
   - EdpmIscsidImage
+  edpmServiceType: run-os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ssh_known_hosts.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ssh_known_hosts.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   playbook: osp.edpm.ssh_known_hosts
   deployOnAllNodeSets: true
+  edpmServiceType: ssh-known-hosts

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_swift.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_swift.yaml
@@ -11,3 +11,4 @@ spec:
         name: swift-storage-config-data
     - configMapRef:
         name: swift-ring-files
+  edpmServiceType: swift

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry.yaml
@@ -16,3 +16,4 @@ spec:
   containerImageFields:
   - CeilometerComputeImage
   - EdpmNodeExporterImage
+  edpmServiceType: telemetry

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry_power_monitoring.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry_power_monitoring.yaml
@@ -16,3 +16,4 @@ spec:
   containerImageFields:
   - CeilometerIpmiImage
   - EdpmKeplerImage
+  edpmServiceType: telemetry-power-monitoring

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_update.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_update.yaml
@@ -4,3 +4,4 @@ metadata:
   name: update
 spec:
   playbook: osp.edpm.update
+  edpmServiceType: update

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
@@ -4,3 +4,4 @@ metadata:
   name: validate-network
 spec:
   playbook: osp.edpm.validate_network
+  edpmServiceType: validate-network

--- a/docs/assemblies/proc_creating-a-custom-service.adoc
+++ b/docs/assemblies/proc_creating-a-custom-service.adoc
@@ -112,7 +112,7 @@ spec:
   deployOnAllNodeSets: true
 ----
 
-. Optional: Specify the `edpmServiceType` field for the service. Different custom services may use the same ansible content to manage the same EDPM service (such as `ovn` or `nova`). The `DataSources`, TLS certificates, and CA certificates need to be mounted at the same locations so they can be found by the ansible content even when using a custom service. `edpmServiceType` is used to create this association. The value is the name of the default service that uses the same ansible content as the custom service. If there are multiple services with the same `edpmServiceType` listed in a nodeset or deployment spec, latter ones would be ignored.
+. Required: Specify the `edpmServiceType` field for the service. Different custom services may use the same ansible content to manage the same EDPM service (such as `ovn` or `nova`). The `DataSources`, TLS certificates, and CA certificates need to be mounted at the same locations so they can be found by the ansible content even when using a custom service. `edpmServiceType` is used to create this association. The value is the name of the default service that uses the same ansible content as the custom service. If there are multiple services with the same `edpmServiceType` listed in a nodeset or deployment spec, latter ones would be ignored.
 +
 For example, a custom service that uses the `edpm_ovn` ansible content from `edpm-ansible` would set `edpmServiceType` to `ovn`, which matches the default `ovn` service name provided by `openstack-operator`.
 +

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -519,8 +519,10 @@ func DefaultDataplaneService(name types.NamespacedName) map[string]interface{} {
 			"namespace": name.Namespace,
 		},
 		"spec": map[string]interface{}{
-			"playbook": "test",
-		}}
+			"playbook":        "test",
+			"edpmServiceType": "notGlobal",
+		},
+	}
 }
 
 // Create an empty OpenStackDataPlaneService struct
@@ -538,6 +540,7 @@ func DefaultDataplaneGlobalService(name types.NamespacedName) map[string]interfa
 		"spec": map[string]interface{}{
 			"deployOnAllNodeSets": true,
 			"playbook":            "test",
+			"edpmServiceType":     "global",
 		},
 	}
 }

--- a/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
-				"edpmServiceType":               "foo-update-service",
+				"edpmServiceType":               "update",
 				"openStackAnsibleEERunnerImage": "foo-image:latest"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
@@ -750,7 +750,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
-				"EDPMServiceType": "foo-update-service"})
+				"edpmServiceType": "foo-update-service"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
 			DeferCleanup(th.DeleteService, dataplaneGlobalServiceName)
@@ -1081,7 +1081,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
-				"EDPMServiceType": "foo-update-service"})
+				"edpmServiceType": "foo-update-service"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
 			DeferCleanup(th.DeleteService, dataplaneGlobalServiceName)
@@ -1288,7 +1288,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
-				"EDPMServiceType": "foo-update-service"})
+				"edpmServiceType": "foo-update-service"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
 			DeferCleanup(th.DeleteService, dataplaneGlobalServiceName)

--- a/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
@@ -1236,7 +1236,8 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 
 			dataplanev1.SetupDefaults()
 			updateServiceSpec := map[string]interface{}{
-				"playbook": "osp.edpm.update",
+				"playbook":        "osp.edpm.update",
+				"edpmServiceType": "update",
 			}
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, updateServiceSpec)
 			DeferCleanup(th.DeleteService, dataplaneUpdateServiceName)

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
@@ -90,6 +90,7 @@ spec:
           command: sleep 1
           delegate_to: localhost
   deployOnAllNodeSets: true
+  edpmServiceType: "custom-global-service"
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
This change switches EDPMServiceType from optional to required. Since the EDPMServiceType of custom services needs to match that of an existing service, we also remove the defaulting mechanism in the webhook.

jira: https://issues.redhat.com/browse/OSPRH-11333