### PR TITLE
[18.0-fr1] Set Neutron route annotations

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -8807,6 +8807,10 @@ spec:
                     type: boolean
                   template:
                     properties:
+                      apiTimeout:
+                        default: 120
+                        minimum: 1
+                        type: integer
                       corePlugin:
                         default: ml2
                         type: string

--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -802,7 +802,8 @@ func (r *OpenStackControlPlane) DefaultServices() {
 			r.Spec.Neutron.Template = &neutronv1.NeutronAPISpecCore{}
 		}
 		r.Spec.Neutron.Template.Default()
-		setOverrideSpec(&r.Spec.Neutron.APIOverride.Route, r.Spec.Neutron.Template.GetDefaultRouteAnnotations())
+		initializeOverrideSpec(&r.Spec.Neutron.APIOverride.Route, true)
+		r.Spec.Neutron.Template.SetDefaultRouteAnnotations(r.Spec.Neutron.APIOverride.Route.Annotations)
 	}
 
 	// Nova

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20241014140317-e5c35d28f3af
 	github.com/openstack-k8s-operators/manila-operator/api v0.4.1-0.20241016213652-f06ae482a4bf
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.4.1-0.20241017063825-352c57936a86
-	github.com/openstack-k8s-operators/neutron-operator/api v0.4.1-0.20241018124837-82fbf3bc498e
+	github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85
 	github.com/openstack-k8s-operators/nova-operator/api v0.4.1-0.20241017115306-c3ef3bef3be5
 	github.com/openstack-k8s-operators/octavia-operator/api v0.4.1-0.20241017154659-930f3479c2e4
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.4.1-0.20241016131858-2bace32a527a

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -122,8 +122,8 @@ github.com/openstack-k8s-operators/manila-operator/api v0.4.1-0.20241016213652-f
 github.com/openstack-k8s-operators/manila-operator/api v0.4.1-0.20241016213652-f06ae482a4bf/go.mod h1:Gi9t38UJU4opGJIS55qhunX2qC4oihlVdRhn7IJhQAg=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.4.1-0.20241017063825-352c57936a86 h1:eGlqcxs8fDP62/Vd56y+Gd0xy+3bfZyUGumyNduFVBA=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.4.1-0.20241017063825-352c57936a86/go.mod h1:Uyc8m+72l3rVm6jKb8FRUrQbjMWyifc5m0K+Ge0QV80=
-github.com/openstack-k8s-operators/neutron-operator/api v0.4.1-0.20241018124837-82fbf3bc498e h1:wG/wIq2IPZbIL6uSEFGE0E0dRE8jSzuW3V+jafcgZpE=
-github.com/openstack-k8s-operators/neutron-operator/api v0.4.1-0.20241018124837-82fbf3bc498e/go.mod h1:ARxoBFEgQUA+tM6Qu+TNDCArCN3kgG4WBI15pb2b1jc=
+github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85 h1:SOA+aOrNq3qqta4Hh6nwQACS5f5yHDunl4WczUkgA8I=
+github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85/go.mod h1:ARxoBFEgQUA+tM6Qu+TNDCArCN3kgG4WBI15pb2b1jc=
 github.com/openstack-k8s-operators/nova-operator/api v0.4.1-0.20241017115306-c3ef3bef3be5 h1:e+TtFliPKKjvac14t92kvTOQjIm3F1ikFT1bWS9cun4=
 github.com/openstack-k8s-operators/nova-operator/api v0.4.1-0.20241017115306-c3ef3bef3be5/go.mod h1:E3DA4NEoTMqKDdgxEHut63BaHI0fSmRuVTMjGMqx1Z0=
 github.com/openstack-k8s-operators/octavia-operator/api v0.4.1-0.20241017154659-930f3479c2e4 h1:OGaICctMZLrly0njlZ8uMXYipIvKC0g81Aw9oAeiQvk=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -8807,6 +8807,10 @@ spec:
                     type: boolean
                   template:
                     properties:
+                      apiTimeout:
+                        default: 120
+                        minimum: 1
+                        type: integer
                       corePlugin:
                         default: ml2
                         type: string

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.4.1-0.20241014140317-e5c35d28f3af
 	github.com/openstack-k8s-operators/manila-operator/api v0.4.1-0.20241016213652-f06ae482a4bf
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.4.1-0.20241017063825-352c57936a86
-	github.com/openstack-k8s-operators/neutron-operator/api v0.4.1-0.20241018124837-82fbf3bc498e
+	github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85
 	github.com/openstack-k8s-operators/nova-operator/api v0.4.1-0.20241017115306-c3ef3bef3be5
 	github.com/openstack-k8s-operators/octavia-operator/api v0.4.1-0.20241017154659-930f3479c2e4
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.4.1-0.20241016131858-2bace32a527a

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/openstack-k8s-operators/manila-operator/api v0.4.1-0.20241016213652-f
 github.com/openstack-k8s-operators/manila-operator/api v0.4.1-0.20241016213652-f06ae482a4bf/go.mod h1:Gi9t38UJU4opGJIS55qhunX2qC4oihlVdRhn7IJhQAg=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.4.1-0.20241017063825-352c57936a86 h1:eGlqcxs8fDP62/Vd56y+Gd0xy+3bfZyUGumyNduFVBA=
 github.com/openstack-k8s-operators/mariadb-operator/api v0.4.1-0.20241017063825-352c57936a86/go.mod h1:Uyc8m+72l3rVm6jKb8FRUrQbjMWyifc5m0K+Ge0QV80=
-github.com/openstack-k8s-operators/neutron-operator/api v0.4.1-0.20241018124837-82fbf3bc498e h1:wG/wIq2IPZbIL6uSEFGE0E0dRE8jSzuW3V+jafcgZpE=
-github.com/openstack-k8s-operators/neutron-operator/api v0.4.1-0.20241018124837-82fbf3bc498e/go.mod h1:ARxoBFEgQUA+tM6Qu+TNDCArCN3kgG4WBI15pb2b1jc=
+github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85 h1:SOA+aOrNq3qqta4Hh6nwQACS5f5yHDunl4WczUkgA8I=
+github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85/go.mod h1:ARxoBFEgQUA+tM6Qu+TNDCArCN3kgG4WBI15pb2b1jc=
 github.com/openstack-k8s-operators/nova-operator/api v0.4.1-0.20241017115306-c3ef3bef3be5 h1:e+TtFliPKKjvac14t92kvTOQjIm3F1ikFT1bWS9cun4=
 github.com/openstack-k8s-operators/nova-operator/api v0.4.1-0.20241017115306-c3ef3bef3be5/go.mod h1:E3DA4NEoTMqKDdgxEHut63BaHI0fSmRuVTMjGMqx1Z0=
 github.com/openstack-k8s-operators/octavia-operator/api v0.4.1-0.20241017154659-930f3479c2e4 h1:OGaICctMZLrly0njlZ8uMXYipIvKC0g81Aw9oAeiQvk=

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -565,6 +565,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			Expect(OSCtlplane).Should(Not(BeNil()))
 			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route).Should(Not(BeNil()))
 			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "120s"))
+			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.neutron.openstack.org/timeout", "120s"))
 			Expect(OSCtlplane.Spec.Cinder.APIOverride.Route).Should(Not(BeNil()))
 			Expect(OSCtlplane.Spec.Cinder.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
 			Expect(OSCtlplane.Spec.Cinder.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.cinder.openstack.org/timeout", "60s"))
@@ -843,6 +844,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			Expect(OSCtlplane).Should(Not(BeNil()))
 			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route).Should(Not(BeNil()))
 			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "120s"))
+			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.neutron.openstack.org/timeout", "120s"))
 		})
 
 		It("should create selfsigned issuer and public, internal, libvirt and ovn CA and issuer", func() {


### PR DESCRIPTION
Depends-On: https://github.com/openstack-k8s-operators/neutron-operator/pull/438
Related-Issue: [OSPRH-10843](https://issues.redhat.com//browse/OSPRH-10843)
(cherry picked from commit 7eb08879dcd5534d890dd771aa72a1ef05acde57)