### PR TITLE
[18.0-fr1] This patch allows Octavia to set its route annotations.

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -10926,7 +10926,8 @@ spec:
                       apacheContainerImage:
                         type: string
                       apiTimeout:
-                        type: string
+                        default: 120
+                        type: integer
                       customServiceConfig:
                         default: '# add your customization here'
                         type: string
@@ -10953,10 +10954,12 @@ spec:
                               type: string
                             type: array
                           createDefaultLbMgmtNetwork:
+                            default: true
                             type: boolean
                           lbMgmtRouterGateway:
                             type: string
                           manageLbMgmtNetworks:
+                            default: true
                             type: boolean
                         type: object
                       nodeSelector:
@@ -10965,6 +10968,8 @@ spec:
                         type: object
                       octaviaAPI:
                         properties:
+                          apiTimeout:
+                            type: integer
                           customServiceConfig:
                             default: '# add your customization here'
                             type: string

--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -892,6 +892,8 @@ func (r *OpenStackControlPlane) DefaultServices() {
 		}
 
 		r.Spec.Octavia.Template.Default()
+		initializeOverrideSpec(&r.Spec.Octavia.APIOverride.Route, true)
+		r.Spec.Octavia.Template.SetDefaultRouteAnnotations(r.Spec.Octavia.APIOverride.Route.Annotations)
 	}
 
 	// Barbican

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.5.0
 	github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85
 	github.com/openstack-k8s-operators/nova-operator/api v0.5.0
-	github.com/openstack-k8s-operators/octavia-operator/api v0.5.0
+	github.com/openstack-k8s-operators/octavia-operator/api v0.5.1-0.20241119144914-248c7edb4442
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.5.0
 	github.com/openstack-k8s-operators/ovn-operator/api v0.5.0
 	github.com/openstack-k8s-operators/placement-operator/api v0.5.0

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -126,8 +126,8 @@ github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-
 github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85/go.mod h1:ARxoBFEgQUA+tM6Qu+TNDCArCN3kgG4WBI15pb2b1jc=
 github.com/openstack-k8s-operators/nova-operator/api v0.5.0 h1:DQLiGBWYYp7aq1f8/JEb5Xds5oGP1SPuwGuZS+g3Za4=
 github.com/openstack-k8s-operators/nova-operator/api v0.5.0/go.mod h1:E3DA4NEoTMqKDdgxEHut63BaHI0fSmRuVTMjGMqx1Z0=
-github.com/openstack-k8s-operators/octavia-operator/api v0.5.0 h1:0xkhjYlVvNkFdzNdRfH8dcfqDbIdcRkvL7rwtZJXEcQ=
-github.com/openstack-k8s-operators/octavia-operator/api v0.5.0/go.mod h1:6Z+1yna/RM9bCKkwd64pHxGrRpKFEhOtYUt1PDh6/xU=
+github.com/openstack-k8s-operators/octavia-operator/api v0.5.1-0.20241119144914-248c7edb4442 h1:pRY5uDsyG8grNGm2dKTVGtXIX4Bkhlx40CPuWgPPYkg=
+github.com/openstack-k8s-operators/octavia-operator/api v0.5.1-0.20241119144914-248c7edb4442/go.mod h1:6Z+1yna/RM9bCKkwd64pHxGrRpKFEhOtYUt1PDh6/xU=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.5.0 h1:RpBGZvePBzdksMU606bAUneSzcUdgMEhM6BQSgqqAsI=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.5.0/go.mod h1:O9pAzpJo2CT+wZgchU/fERxNL23zPR6+KOccviKbSNY=
 github.com/openstack-k8s-operators/ovn-operator/api v0.5.0 h1:pREC1L0Da4OUM4uKEakxrly7+7yJaKQuIDs1+EpvbDg=

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -10926,7 +10926,8 @@ spec:
                       apacheContainerImage:
                         type: string
                       apiTimeout:
-                        type: string
+                        default: 120
+                        type: integer
                       customServiceConfig:
                         default: '# add your customization here'
                         type: string
@@ -10953,10 +10954,12 @@ spec:
                               type: string
                             type: array
                           createDefaultLbMgmtNetwork:
+                            default: true
                             type: boolean
                           lbMgmtRouterGateway:
                             type: string
                           manageLbMgmtNetworks:
+                            default: true
                             type: boolean
                         type: object
                       nodeSelector:
@@ -10965,6 +10968,8 @@ spec:
                         type: object
                       octaviaAPI:
                         properties:
+                          apiTimeout:
+                            type: integer
                           customServiceConfig:
                             default: '# add your customization here'
                             type: string

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.5.0
 	github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85
 	github.com/openstack-k8s-operators/nova-operator/api v0.5.0
-	github.com/openstack-k8s-operators/octavia-operator/api v0.5.0
+	github.com/openstack-k8s-operators/octavia-operator/api v0.5.1-0.20241119144914-248c7edb4442
 	github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.5.0
 	github.com/openstack-k8s-operators/openstack-operator/apis v0.0.0-20240531084739-3b4c0451297c
 	github.com/openstack-k8s-operators/ovn-operator/api v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-
 github.com/openstack-k8s-operators/neutron-operator/api v0.5.1-0.20241112143215-294abc29ae85/go.mod h1:ARxoBFEgQUA+tM6Qu+TNDCArCN3kgG4WBI15pb2b1jc=
 github.com/openstack-k8s-operators/nova-operator/api v0.5.0 h1:DQLiGBWYYp7aq1f8/JEb5Xds5oGP1SPuwGuZS+g3Za4=
 github.com/openstack-k8s-operators/nova-operator/api v0.5.0/go.mod h1:E3DA4NEoTMqKDdgxEHut63BaHI0fSmRuVTMjGMqx1Z0=
-github.com/openstack-k8s-operators/octavia-operator/api v0.5.0 h1:0xkhjYlVvNkFdzNdRfH8dcfqDbIdcRkvL7rwtZJXEcQ=
-github.com/openstack-k8s-operators/octavia-operator/api v0.5.0/go.mod h1:6Z+1yna/RM9bCKkwd64pHxGrRpKFEhOtYUt1PDh6/xU=
+github.com/openstack-k8s-operators/octavia-operator/api v0.5.1-0.20241119144914-248c7edb4442 h1:pRY5uDsyG8grNGm2dKTVGtXIX4Bkhlx40CPuWgPPYkg=
+github.com/openstack-k8s-operators/octavia-operator/api v0.5.1-0.20241119144914-248c7edb4442/go.mod h1:6Z+1yna/RM9bCKkwd64pHxGrRpKFEhOtYUt1PDh6/xU=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.5.0 h1:RpBGZvePBzdksMU606bAUneSzcUdgMEhM6BQSgqqAsI=
 github.com/openstack-k8s-operators/openstack-baremetal-operator/api v0.5.0/go.mod h1:O9pAzpJo2CT+wZgchU/fERxNL23zPR6+KOccviKbSNY=
 github.com/openstack-k8s-operators/ovn-operator/api v0.5.0 h1:pREC1L0Da4OUM4uKEakxrly7+7yJaKQuIDs1+EpvbDg=

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -577,6 +577,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 			Expect(OSCtlplane.Spec.Manila.APIOverride.Route).Should(Not(BeNil()))
 			Expect(OSCtlplane.Spec.Manila.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
 			Expect(OSCtlplane.Spec.Manila.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.manila.openstack.org/timeout", "60s"))
+			//TODO (froyo) Enable these tests when Octavia would be enabled on FTs
+			//Expect(OSCtlplane.Spec.Octavia.APIOverride.Route).Should(Not(BeNil()))
+			//Expect(OSCtlplane.Spec.Octavia.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "120s"))
+			//Expect(OSCtlplane.Spec.Octavia.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.octavia.openstack.org/timeout", "120s"))
 		})
 
 		It("should create selfsigned issuer and public+internal CA and issuer", func() {


### PR DESCRIPTION
Depends-On:
https://github.com/openstack-k8s-operators/octavia-operator/pull/438 
Related-Issue: [OSPRH-10959](https://issues.redhat.com//browse/OSPRH-10959)
(cherry picked from commit f91c5f8)