### PR TITLE
[18.0-fr1] [OSPRH-10956] Add telemetry api timeouts

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -853,6 +853,8 @@ func (r *OpenStackControlPlane) DefaultServices() {
 			r.Spec.Telemetry.Template = &telemetryv1.TelemetrySpecCore{}
 		}
 		r.Spec.Telemetry.Template.Default()
+		initializeOverrideSpec(&r.Spec.Telemetry.AodhAPIOverride.Route, true)
+		r.Spec.Telemetry.Template.Autoscaling.SetDefaultRouteAnnotations(r.Spec.Telemetry.AodhAPIOverride.Route.Annotations)
 	}
 
 	// Heat

--- a/tests/functional/ctlplane/base_test.go
+++ b/tests/functional/ctlplane/base_test.go
@@ -409,6 +409,20 @@ func GetDefaultOpenStackControlPlaneSpec() map[string]interface{} {
 	ironicTemplate := map[string]interface{}{
 		"ironicConductors": []interface{}{},
 	}
+	telemetryTemplate := map[string]interface{}{
+		"ceilometer": map[string]interface{}{
+			"enabled": false,
+		},
+		"metricStorage": map[string]interface{}{
+			"enabled": false,
+		},
+		"logging": map[string]interface{}{
+			"enabled": false,
+		},
+		"autoscaling": map[string]interface{}{
+			"enabled": false,
+		},
+	}
 
 	return map[string]interface{}{
 		"secret":       "osp-secret",
@@ -471,6 +485,10 @@ func GetDefaultOpenStackControlPlaneSpec() map[string]interface{} {
 		},
 		"manila": map[string]interface{}{
 			"enabled": true,
+		},
+		"telemetry": map[string]interface{}{
+			"enabled":  true,
+			"template": telemetryTemplate,
 		},
 	}
 }

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -581,6 +581,9 @@ var _ = Describe("OpenStackOperator controller", func() {
 			//Expect(OSCtlplane.Spec.Octavia.APIOverride.Route).Should(Not(BeNil()))
 			//Expect(OSCtlplane.Spec.Octavia.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "120s"))
 			//Expect(OSCtlplane.Spec.Octavia.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.octavia.openstack.org/timeout", "120s"))
+			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route).Should(Not(BeNil()))
+			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
+			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route.Annotations).Should(HaveKeyWithValue("api.aodh.openstack.org/timeout", "60s"))
 		})
 
 		It("should create selfsigned issuer and public+internal CA and issuer", func() {
@@ -849,6 +852,9 @@ var _ = Describe("OpenStackOperator controller", func() {
 			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route).Should(Not(BeNil()))
 			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "120s"))
 			Expect(OSCtlplane.Spec.Neutron.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.neutron.openstack.org/timeout", "120s"))
+			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route).Should(Not(BeNil()))
+			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
+			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route.Annotations).Should(HaveKeyWithValue("api.aodh.openstack.org/timeout", "60s"))
 		})
 
 		It("should create selfsigned issuer and public, internal, libvirt and ovn CA and issuer", func() {

--- a/tests/functional/ctlplane/openstackversion_controller_test.go
+++ b/tests/functional/ctlplane/openstackversion_controller_test.go
@@ -227,6 +227,9 @@ var _ = Describe("OpenStackOperator controller", func() {
 			spec["manila"] = map[string]interface{}{
 				"enabled": false,
 			}
+			spec["telemetry"] = map[string]interface{}{
+				"enabled": false,
+			}
 			spec["tls"] = GetTLSPublicSpec()
 			spec["ovn"] = map[string]interface{}{
 				"enabled": true,


### PR DESCRIPTION
Cherry-pick of https://github.com/openstack-k8s-operators/openstack-operator/pull/1196