### PR TITLE
[Designate] Add Mdns replica count

### DIFF
--- a/config/samples/base/openstackcontrolplane/core_v1beta1_openstackcontrolplane.yaml
+++ b/config/samples/base/openstackcontrolplane/core_v1beta1_openstackcontrolplane.yaml
@@ -205,7 +205,7 @@ spec:
       designateProducer:
         replicas: 1 # backend needs to be configured
       designateMdns:
-        replicas: 0 # backend needs to be configured
+        replicas: 1 # backend needs to be configured
       designateBackendbind9:
         replicas: 1 # backend needs to be configured
         storageClass: local-storage

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera.yaml
@@ -232,7 +232,7 @@ spec:
       designateProducer:
         replicas: 1
       designateMdns:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateBackendbind9:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
@@ -217,7 +217,7 @@ spec:
       designateProducer:
         replicas: 1
       designateMdns:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateBackendbind9:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
@@ -419,7 +419,7 @@ spec:
       designateProducer:
         replicas: 1
       designateMdns:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateBackendbind9:

--- a/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml
@@ -421,7 +421,7 @@ spec:
       designateProducer:
         replicas: 1
       designateMdns:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateBackendbind9:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
@@ -415,7 +415,7 @@ spec:
       designateProducer:
         replicas: 1
       designateMdns:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateBackendbind9:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml
@@ -440,7 +440,7 @@ spec:
       designateProducer:
         replicas: 1
       designateMdns:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateBackendbind9:

--- a/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
+++ b/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_tls_public_endpoint.yaml
@@ -418,7 +418,7 @@ spec:
       designateProducer:
         replicas: 1
       designateMdns:
-        replicas: 0
+        replicas: 1
         networkAttachments:
           - designate
       designateBackendbind9:

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -153,6 +153,8 @@ spec:
         replicas: 1
       designateCentral:
         replicas: 1
+      designateMdns:
+        replicas: 1
       designateWorker:
         replicas: 1
       designateProducer:

--- a/tests/kuttl/tests/ctlplane-tls-cert-rotation/00-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-cert-rotation/00-assert-deploy-openstack.yaml
@@ -153,6 +153,8 @@ spec:
         replicas: 1
       designateCentral:
         replicas: 1
+      designateMdns:
+        replicas: 1
       designateWorker:
         replicas: 1
       designateProducer:

--- a/tests/kuttl/tests/ctlplane-tls-cert-rotation/03-assert-new-certs.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-cert-rotation/03-assert-new-certs.yaml
@@ -174,6 +174,8 @@ spec:
         replicas: 1
       designateCentral:
         replicas: 1
+      designateMdns:
+        replicas: 1
       designateWorker:
         replicas: 1
       designateProducer:

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/01-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/01-assert-deploy-openstack.yaml
@@ -153,6 +153,8 @@ spec:
         replicas: 1
       designateCentral:
         replicas: 1
+      designateMdns:
+        replicas: 1
       designateWorker:
         replicas: 1
       designateProducer:

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/09-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/09-assert-deploy-openstack.yaml
@@ -153,6 +153,8 @@ spec:
         replicas: 1
       designateCentral:
         replicas: 1
+      designateMdns:
+        replicas: 1
       designateWorker:
         replicas: 1
       designateProducer:

--- a/tests/kuttl/tests/ctlplane-tls-custom-route/03-assert-deploy-openstack.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-route/03-assert-deploy-openstack.yaml
@@ -164,6 +164,8 @@ spec:
         replicas: 1
       designateCentral:
         replicas: 1
+      designateMdns:
+        replicas: 1
       designateWorker:
         replicas: 1
       designateProducer:


### PR DESCRIPTION
DesignateMdns deployment type is being changed to stateful set.

This commit adds replica count to Mdns in all the Designate CRs.