### PR TITLE
Update Kepler downstream image

### DIFF
--- a/docs/assemblies/common_configurations.adoc
+++ b/docs/assemblies/common_configurations.adoc
@@ -94,7 +94,7 @@ ifeval::["{build}" == "downstream"]
         edpm_ovn_bgp_agent_local_ovn_northd_image: "redhat.registry.io/rhoso-beta/openstack-ovn-northd-rhel9:18.0.0
         edpm_ovn_bgp_agent_local_ovn_controller_image: "redhat.registry.io/rhoso-beta/openstack-ovn-controller-rhel9:18.0.0
         edpm_telemetry_node_exporter_image: redhat.registry.io/prometheus/node-exporter-rhel9:18.0.0
-        edpm_telemetry_kepler_image: "registry.redhat.io/openshift-power-monitoring/kepler-rhel9:v0.7.10-2"
+        edpm_telemetry_kepler_image: "registry.redhat.io/openshift-power-monitoring/kepler-rhel9:v0.7.12-9"
         edpm_telemetry_ceilometer_compute_image: redhat.registry.io/rhoso-beta/openstack-ceilometer-compute-rhel9:18.0.0
         edpm_telemetry_ceilometer_ipmi_image: redhat.registry.io/rhoso-beta/openstack-ceilometer-ipmi-rhel9:18.0.0
         edpm_nova_compute_image: "redhat.registry.io/rhoso-beta/openstack-nova-compute-rhel9:18.0.0

--- a/docs/assemblies/proc_creating-a-set-of-data-plane-nodes.adoc
+++ b/docs/assemblies/proc_creating-a-set-of-data-plane-nodes.adoc
@@ -283,7 +283,7 @@ ifeval::["{build}" == "downstream"]
         edpm_frr_image: "registry.redhat.io/rhosp-dev-preview/openstack-frr:18.0"
         edpm_ovn_bgp_agent_image: "registry.redhat.io/rhosp-dev-preview/openstack-ovn-bgp-agent:18.0"
         telemetry_node_exporter_image: "quay.io/prometheus/node-exporter:v1.5.0"
-        edpm_telemetry_kepler_image: "registry.redhat.io/openshift-power-monitoring/kepler-rhel9:v0.7.10-2"
+        edpm_telemetry_kepler_image: "registry.redhat.io/openshift-power-monitoring/kepler-rhel9:v0.7.12-9"
         edpm_libvirt_image: "registry.redhat.io/rhosp-dev-preview/openstack-nova-libvirt:18.0"
         edpm_nova_compute_image: "registry.redhat.io/rhosp-dev-preview/openstack-nova-compute:18.0"
         edpm_neutron_sriov_image: "registry.redhat.io/rhosp-dev-preview/openstack-neutron-sriov-agent:18.0"


### PR DESCRIPTION
Use the newly released [Kepler image](https://catalog.redhat.com/software/containers/openshift-power-monitoring/kepler-rhel9/6570574c2e33dc0959f37f0a?image=67409648d7ea1bc6b1bceeb2&architecture=amd64&container-tabs=overview) while deploying downstream.