### PR TITLE
When OVNController is disabed, set current version images

### DIFF
--- a/pkg/openstack/ovn.go
+++ b/pkg/openstack/ovn.go
@@ -321,6 +321,11 @@ func ReconcileOVNController(ctx context.Context, instance *corev1beta1.OpenStack
 		if _, err := EnsureDeleted(ctx, helper, OVNController); err != nil {
 			return false, err
 		}
+
+		// for minor updates, update the ovn controller images to the one from the version
+		instance.Status.ContainerImages.OvnControllerImage = version.Status.ContainerImages.OvnControllerImage
+		instance.Status.ContainerImages.OvnControllerOvsImage = version.Status.ContainerImages.OvnControllerOvsImage
+
 		return true, nil
 	}
 


### PR DESCRIPTION
When there is no nicMappings configured, the OVNController CR gets cleanup, because there is no need to run one on the ctlplane. In this case, ReconcileOVNController deletes the CR and returns ctrl.Result{}, nil .
`status.deployedOVNVersion:` on the ctlplane gets set correct to the new version, but there was no change for the images on
* instance.Status.ContainerImages.OvnControllerImage
* instance.Status.ContainerImages.OvnControllerOvsImage

As a result the minor update process gets stuck and never proceeds.

Jira: [OSPRH-12063](https://issues.redhat.com//browse/OSPRH-12063)