### PR TITLE
Use dns cluster info from lib common get function

### DIFF
--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -19,6 +19,7 @@ import (
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/route"
@@ -57,9 +58,6 @@ const (
 	// ooAppSelector service selector label added by the openstack-operator to service
 	// overrides
 	ooAppSelector = "osctlplane-service"
-
-	// ClusterInternalDomain - cluster internal dns domain
-	ClusterInternalDomain = "cluster.local"
 
 	// serviceCertSelector selector passed to cert-manager to set on the service cert secret
 	serviceCertSelector = "service-cert"
@@ -209,6 +207,7 @@ func EnsureEndpointConfig(
 	endpoints := Endpoints{
 		EndpointDetails: map[service.Endpoint]EndpointDetail{},
 	}
+	clusterDomain := clusterdns.GetDNSClusterDomain()
 
 	for _, svc := range svcs.Items {
 		ed := EndpointDetail{
@@ -316,7 +315,7 @@ func EnsureEndpointConfig(
 						CertName:   ed.Service.TLS.CertName,
 						Hostnames: []string{
 							fmt.Sprintf("%s.%s.svc", ed.Name, instance.Namespace),
-							fmt.Sprintf("%s.%s.svc.%s", ed.Name, instance.Namespace, ClusterInternalDomain),
+							fmt.Sprintf("%s.%s.svc.%s", ed.Name, instance.Namespace, clusterDomain),
 						},
 						Ips:         nil,
 						Annotations: ed.Annotations,
@@ -366,7 +365,7 @@ func EnsureEndpointConfig(
 					CertName:   ed.Service.TLS.CertName,
 					Hostnames: []string{
 						fmt.Sprintf("%s.%s.svc", ed.Name, instance.Namespace),
-						fmt.Sprintf("%s.%s.svc.%s", ed.Name, instance.Namespace, ClusterInternalDomain),
+						fmt.Sprintf("%s.%s.svc.%s", ed.Name, instance.Namespace, clusterDomain),
 					},
 					Ips:         nil,
 					Annotations: ed.Annotations,

--- a/pkg/openstack/galera.go
+++ b/pkg/openstack/galera.go
@@ -7,6 +7,7 @@ import (
 
 	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
@@ -41,6 +42,7 @@ func ReconcileGaleras(
 
 	var failures = []string{}
 	var inprogress = []string{}
+	clusterDomain := clusterdns.GetDNSClusterDomain()
 
 	if instance.Spec.Galera.Templates == nil {
 		instance.Spec.Galera.Templates = ptr.To(map[string]mariadbv1.GaleraSpecCore{})
@@ -57,11 +59,11 @@ func ReconcileGaleras(
 			CertName:   fmt.Sprintf("galera-%s-svc", name),
 			Hostnames: []string{
 				hostname,
-				fmt.Sprintf("%s.%s", hostname, ClusterInternalDomain),
+				fmt.Sprintf("%s.%s", hostname, clusterDomain),
 				hostnameHeadless,
-				fmt.Sprintf("%s.%s", hostnameHeadless, ClusterInternalDomain),
+				fmt.Sprintf("%s.%s", hostnameHeadless, clusterDomain),
 				fmt.Sprintf("*.%s", hostnameHeadless),
-				fmt.Sprintf("*.%s.%s", hostnameHeadless, ClusterInternalDomain),
+				fmt.Sprintf("*.%s.%s", hostnameHeadless, clusterDomain),
 			},
 			// Note (dciabrin) from https://github.com/openstack-k8s-operators/openstack-operator/pull/678#issuecomment-1952459166
 			// the certificate created for galera should populate the 'organization' field,
@@ -69,7 +71,7 @@ func ReconcileGaleras(
 			// at the initial deployment because there is no SST involved when the DB is bootstrapped
 			// as there are no data to be transferred yet.
 			Subject: &certmgrv1.X509Subject{
-				Organizations: []string{fmt.Sprintf("%s.%s", instance.Namespace, ClusterInternalDomain)},
+				Organizations: []string{fmt.Sprintf("%s.%s", instance.Namespace, clusterDomain)},
 			},
 			Usages: []certmgrv1.KeyUsage{
 				"key encipherment",

--- a/pkg/openstack/memcached.go
+++ b/pkg/openstack/memcached.go
@@ -7,6 +7,7 @@ import (
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
@@ -168,14 +169,15 @@ func reconcileMemcached(
 	tlsCert := ""
 	if instance.Spec.TLS.PodLevel.Enabled {
 		Log.Info("Reconciling Memcached TLS", "Memcached.Namespace", instance.Namespace, "Memcached.Name", name)
+		clusterDomain := clusterdns.GetDNSClusterDomain()
 		certRequest := certmanager.CertificateRequest{
 			IssuerName: instance.GetInternalIssuer(),
 			CertName:   fmt.Sprintf("%s-svc", memcached.Name),
 			Hostnames: []string{
 				fmt.Sprintf("%s.%s.svc", name, instance.Namespace),
 				fmt.Sprintf("*.%s.%s.svc", name, instance.Namespace),
-				fmt.Sprintf("%s.%s.svc.%s", name, instance.Namespace, ClusterInternalDomain),
-				fmt.Sprintf("*.%s.%s.svc.%s", name, instance.Namespace, ClusterInternalDomain),
+				fmt.Sprintf("%s.%s.svc.%s", name, instance.Namespace, clusterDomain),
+				fmt.Sprintf("*.%s.%s.svc.%s", name, instance.Namespace, clusterDomain),
 			},
 			Labels: map[string]string{serviceCertSelector: ""},
 		}

--- a/pkg/openstack/neutron.go
+++ b/pkg/openstack/neutron.go
@@ -6,6 +6,7 @@ import (
 
 	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -68,13 +69,14 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 		instance.Spec.Neutron.Template.TLS = neutronAPI.Spec.TLS
 
 		serviceName := "neutron"
+		clusterDomain := clusterdns.GetDNSClusterDomain()
 		// create ovndb client certificate for neutron
 		certRequest := certmanager.CertificateRequest{
 			IssuerName: instance.GetOvnIssuer(),
 			CertName:   fmt.Sprintf("%s-ovndbs", serviceName),
 			Hostnames: []string{
 				fmt.Sprintf("%s.%s.svc", serviceName, instance.Namespace),
-				fmt.Sprintf("%s.%s.svc.%s", serviceName, instance.Namespace, "cluster.local"),
+				fmt.Sprintf("%s.%s.svc.%s", serviceName, instance.Namespace, clusterDomain),
 			},
 			Ips: nil,
 			Usages: []certmgrv1.KeyUsage{

--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -273,6 +274,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 
 				// create novncproxy vencrypt cert
 				if instance.Spec.TLS.PodLevel.Enabled {
+					clusterDomain := clusterdns.GetDNSClusterDomain()
 					serviceName := endpointDetails.EndpointDetails[service.EndpointPublic].Service.Spec.Name
 					hostname := fmt.Sprintf("%s.%s.svc", serviceName, instance.Namespace)
 					certRequest := certmanager.CertificateRequest{
@@ -281,10 +283,10 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 						CommonName: ptr.To(serviceName), // common name has a max length of 64bytes, therefore just set the short name
 						Hostnames: []string{
 							hostname,
-							fmt.Sprintf("%s.%s", hostname, ClusterInternalDomain),
+							fmt.Sprintf("%s.%s", hostname, clusterDomain),
 						},
 						Subject: &certmgrv1.X509Subject{
-							Organizations: []string{fmt.Sprintf("%s.%s", instance.Namespace, ClusterInternalDomain)},
+							Organizations: []string{fmt.Sprintf("%s.%s", instance.Namespace, clusterDomain)},
 						},
 						Usages: []certmgrv1.KeyUsage{
 							certmgrv1.UsageKeyEncipherment,

--- a/pkg/openstack/octavia.go
+++ b/pkg/openstack/octavia.go
@@ -22,6 +22,7 @@ import (
 
 	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -81,6 +82,7 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 
 	// preserve any previously set TLS certs, set CA cert
 	if instance.Spec.TLS.PodLevel.Enabled {
+		clusterDomain := clusterdns.GetDNSClusterDomain()
 		instance.Spec.Octavia.Template.OctaviaAPI.TLS = octavia.Spec.OctaviaAPI.TLS
 
 		serviceName := "octavia"
@@ -90,7 +92,7 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 			CertName:   fmt.Sprintf("%s-ovndbs", serviceName),
 			Hostnames: []string{
 				fmt.Sprintf("%s.%s.svc", serviceName, instance.Namespace),
-				fmt.Sprintf("%s.%s.svc.%s", serviceName, instance.Namespace, ClusterInternalDomain),
+				fmt.Sprintf("%s.%s.svc.%s", serviceName, instance.Namespace, clusterDomain),
 			},
 			Ips: nil,
 			Usages: []certmgrv1.KeyUsage{

--- a/pkg/openstack/ovn.go
+++ b/pkg/openstack/ovn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 
@@ -73,6 +74,7 @@ func ReconcileOVN(ctx context.Context, instance *corev1beta1.OpenStackControlPla
 
 func ReconcileOVNDbClusters(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, version *corev1beta1.OpenStackVersion, helper *helper.Helper) (bool, error) {
 	Log := GetLogger(ctx)
+	dnsSuffix := clusterdns.GetDNSClusterDomain()
 
 	OVNDBClustersReady := len(instance.Spec.Ovn.Template.OVNDBCluster) != 0
 	for name, dbcluster := range instance.Spec.Ovn.Template.OVNDBCluster {
@@ -111,7 +113,7 @@ func ReconcileOVNDbClusters(ctx context.Context, instance *corev1beta1.OpenStack
 				// Cert needs to be valid for the individual pods in the statefulset so make this a wildcard cert
 				Hostnames: []string{
 					fmt.Sprintf("*.%s.svc", instance.Namespace),
-					fmt.Sprintf("*.%s.svc.%s", instance.Namespace, ovnv1.DNSSuffix),
+					fmt.Sprintf("*.%s.svc.%s", instance.Namespace, dnsSuffix),
 				},
 				Ips: nil,
 				Usages: []certmgrv1.KeyUsage{
@@ -217,6 +219,7 @@ func ReconcileOVNNorthd(ctx context.Context, instance *corev1beta1.OpenStackCont
 	}
 	if instance.Spec.TLS.PodLevel.Enabled {
 		ovnNorthdSpec.TLS = OVNNorthd.Spec.TLS
+		dnsSuffix := clusterdns.GetDNSClusterDomain()
 
 		serviceName := ovnv1.ServiceNameOvnNorthd
 		// create certificate for ovnnorthd
@@ -225,7 +228,7 @@ func ReconcileOVNNorthd(ctx context.Context, instance *corev1beta1.OpenStackCont
 			CertName:   fmt.Sprintf("%s-ovndbs", "ovnnorthd"),
 			Hostnames: []string{
 				fmt.Sprintf("%s.%s.svc", serviceName, instance.Namespace),
-				fmt.Sprintf("%s.%s.svc.%s", serviceName, instance.Namespace, ovnv1.DNSSuffix),
+				fmt.Sprintf("%s.%s.svc.%s", serviceName, instance.Namespace, dnsSuffix),
 			},
 			Ips: nil,
 			Usages: []certmgrv1.KeyUsage{
@@ -338,6 +341,7 @@ func ReconcileOVNController(ctx context.Context, instance *corev1beta1.OpenStack
 		}
 	}
 	if instance.Spec.TLS.PodLevel.Enabled {
+		dnsSuffix := clusterdns.GetDNSClusterDomain()
 		ovnControllerSpec.TLS = OVNController.Spec.TLS
 
 		serviceName := ovnv1.ServiceNameOvnController
@@ -347,7 +351,7 @@ func ReconcileOVNController(ctx context.Context, instance *corev1beta1.OpenStack
 			CertName:   fmt.Sprintf("%s-ovndbs", "ovncontroller"),
 			Hostnames: []string{
 				fmt.Sprintf("%s.%s.svc", serviceName, instance.Namespace),
-				fmt.Sprintf("%s.%s.svc.%s", serviceName, instance.Namespace, ovnv1.DNSSuffix),
+				fmt.Sprintf("%s.%s.svc.%s", serviceName, instance.Namespace, dnsSuffix),
 			},
 			Ips: nil,
 			Usages: []certmgrv1.KeyUsage{

--- a/pkg/openstack/rabbitmq.go
+++ b/pkg/openstack/rabbitmq.go
@@ -8,6 +8,7 @@ import (
 	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	networkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -259,13 +260,14 @@ func reconcileRabbitMQ(
 		},
 	}
 
+	clusterDomain := clusterdns.GetDNSClusterDomain()
 	hostname := fmt.Sprintf("%s.%s.svc", name, instance.Namespace)
 	hostnameHeadless := fmt.Sprintf("%s-nodes.%s.svc", name, instance.Namespace)
 	hostnames := []string{
 		hostname,
-		fmt.Sprintf("%s.%s", hostname, ClusterInternalDomain),
+		fmt.Sprintf("%s.%s", hostname, clusterDomain),
 		hostnameHeadless,
-		fmt.Sprintf("%s.%s", hostnameHeadless, ClusterInternalDomain),
+		fmt.Sprintf("%s.%s", hostnameHeadless, clusterDomain),
 	}
 	for i := 0; i < int(*spec.Replicas); i++ {
 		hostnames = append(hostnames, fmt.Sprintf("%s-server-%d.%s-nodes.%s", name, i, name, instance.Namespace))
@@ -278,7 +280,7 @@ func reconcileRabbitMQ(
 			CertName:   fmt.Sprintf("%s-svc", rabbitmq.Name),
 			Hostnames:  hostnames,
 			Subject: &certmgrv1.X509Subject{
-				Organizations: []string{fmt.Sprintf("%s.%s", rabbitmq.Namespace, ClusterInternalDomain)},
+				Organizations: []string{fmt.Sprintf("%s.%s", rabbitmq.Namespace, clusterDomain)},
 			},
 			Usages: []certmgrv1.KeyUsage{
 				certmgrv1.UsageKeyEncipherment,

--- a/pkg/openstack/redis.go
+++ b/pkg/openstack/redis.go
@@ -8,6 +8,7 @@ import (
 	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	redisv1 "github.com/openstack-k8s-operators/infra-operator/apis/redis/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
@@ -180,17 +181,18 @@ func reconcileRedis(
 
 	tlsCert := ""
 	if instance.Spec.TLS.PodLevel.Enabled {
+		clusterDomain := clusterdns.GetDNSClusterDomain()
 		certRequest := certmanager.CertificateRequest{
 			IssuerName: instance.GetInternalIssuer(),
 			CertName:   fmt.Sprintf("%s-svc", redis.Name),
 			Hostnames: []string{
 				fmt.Sprintf("redis-%s.%s.svc", name, instance.Namespace),
 				fmt.Sprintf("*.redis-%s.%s.svc", name, instance.Namespace),
-				fmt.Sprintf("redis-%s.%s.svc.%s", name, instance.Namespace, ClusterInternalDomain),
-				fmt.Sprintf("*.redis-%s.%s.svc.%s", name, instance.Namespace, ClusterInternalDomain),
+				fmt.Sprintf("redis-%s.%s.svc.%s", name, instance.Namespace, clusterDomain),
+				fmt.Sprintf("*.redis-%s.%s.svc.%s", name, instance.Namespace, clusterDomain),
 			},
 			Subject: &certmgrv1.X509Subject{
-				Organizations: []string{fmt.Sprintf("%s.%s", instance.Namespace, ClusterInternalDomain)},
+				Organizations: []string{fmt.Sprintf("%s.%s", instance.Namespace, clusterDomain)},
 			},
 			Usages: []certmgrv1.KeyUsage{
 				"key encipherment",


### PR DESCRIPTION
Openshift coreDNS creates the domain name using an string located in dnses.operator.openshift.io. This string can change in the future, calling lib-common/GetDNSClusterDomain the responsability of gathering this information correctly only falls under lib-common intead of all operators.

Depends-on: openstack-k8s-operators/lib-common#580
Related-Issue: [OSPRH-3627](https://issues.redhat.com//browse/OSPRH-3627)