### PR TITLE
Provide DatabaseInstance for Octavia if not explicitly set

### DIFF
--- a/pkg/openstack/octavia.go
+++ b/pkg/openstack/octavia.go
@@ -183,6 +183,11 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 			octavia.Spec.Secret = instance.Spec.Secret
 		}
 
+		if octavia.Spec.DatabaseInstance == "" {
+			// octavia.Spec.DatabaseInstance = instance.Name // name of MariaDB we create here
+			octavia.Spec.DatabaseInstance = "openstack" // FIXME: see above
+		}
+
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), octavia, helper.GetScheme())
 		if err != nil {
 			return err


### PR DESCRIPTION
Several of the operator integrations include a conditional to set a hardcoded-yet-consistent default DatabaseInstance value if it is not explicitly set for the component operator. This block was missing from the Octavia integration.

Jira: [OSPRH-12243](https://issues.redhat.com//browse/OSPRH-12243)