### PR TITLE
Support Roles on OpenStackDataPlaneService

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           # this fetches all branches. Needed because we need gh-pages branch for deploy to work
           fetch-depth: 0
-      - uses: ruby/setup-ruby@v1.160.0
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
 

--- a/apis/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -78,6 +78,8 @@ spec:
                 type: string
               playbookContents:
                 type: string
+              role:
+                type: string
               tlsCerts:
                 additionalProperties:
                   properties:

--- a/apis/dataplane/v1beta1/openstackdataplaneservice_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplaneservice_types.go
@@ -72,6 +72,9 @@ type OpenStackDataPlaneServiceSpec struct {
 	// Playbook is a path to the playbook that ansible will run on this execution
 	Playbook string `json:"playbook,omitempty"`
 
+	// Role is a path to the role that ansible will run on this execution
+	Role string `json:"role,omitempty"`
+
 	// CACerts - Secret containing the CA certificate chain
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxLength:=253

--- a/apis/dataplane/v1beta1/openstackdataplaneservice_webhook.go
+++ b/apis/dataplane/v1beta1/openstackdataplaneservice_webhook.go
@@ -78,10 +78,29 @@ func (r *OpenStackDataPlaneService) ValidateCreate() (admission.Warnings, error)
 	return nil, nil
 }
 
-func (r *OpenStackDataPlaneServiceSpec) ValidateCreate() field.ErrorList {
-	// TODO(user): fill in your validation logic upon object creation.
+func (r *OpenStackDataPlaneServiceSpec) ValidateArtifact() field.ErrorList {
+	if len(r.Playbook) == len(r.PlaybookContents) && len(r.Playbook) == len(r.Role) && len(r.Playbook) == 0 {
+		return field.ErrorList{
+			field.Invalid(
+				field.NewPath("Playbook"),
+				r.Playbook, "Playbook, PlaybookContents and Role cannot be empty at the same time",
+			),
+			field.Invalid(
+				field.NewPath("PlaybookContents"),
+				r.Playbook, "Playbook, PlaybookContents and Role cannot be empty at the same time",
+			),
+			field.Invalid(
+				field.NewPath("Role"),
+				r.Playbook, "Playbook, PlaybookContents and Role cannot be empty at the same time",
+			),
+		}
+	}
 
 	return field.ErrorList{}
+}
+
+func (r *OpenStackDataPlaneServiceSpec) ValidateCreate() field.ErrorList {
+	return r.ValidateArtifact()
 }
 
 func (r *OpenStackDataPlaneService) ValidateUpdate(original runtime.Object) (admission.Warnings, error) {
@@ -100,9 +119,7 @@ func (r *OpenStackDataPlaneService) ValidateUpdate(original runtime.Object) (adm
 }
 
 func (r *OpenStackDataPlaneServiceSpec) ValidateUpdate() field.ErrorList {
-	// TODO(user): fill in your validation logic upon object creation.
-
-	return field.ErrorList{}
+	return r.ValidateArtifact()
 }
 
 func (r *OpenStackDataPlaneService) ValidateDelete() (admission.Warnings, error) {

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplaneservices.yaml
@@ -78,6 +78,8 @@ spec:
                 type: string
               playbookContents:
                 type: string
+              role:
+                type: string
               tlsCerts:
                 additionalProperties:
                   properties:

--- a/pkg/dataplane/util/ansible_execution.go
+++ b/pkg/dataplane/util/ansible_execution.go
@@ -218,6 +218,9 @@ func (a *EEJob) BuildAeeJobSpec(
 	if len(service.Spec.Playbook) > 0 {
 		a.Playbook = service.Spec.Playbook
 	}
+	if len(service.Spec.Role) > 0 {
+		a.Role = service.Spec.Role
+	}
 
 	a.BackoffLimit = deployment.Spec.BackoffLimit
 	a.PreserveJobs = deployment.Spec.PreserveJobs

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -105,6 +105,9 @@ func CreateDataplaneServicesWithSameServiceType(name types.NamespacedName) {
 
 // Create an OpenStackDataPlaneService with a given NamespacedName, and a given unstructured spec
 func CreateDataPlaneServiceFromSpec(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
+	if spec["playbook"] == nil && spec["playbookContents"] == nil && spec["role"] == nil {
+		spec["playbook"] = "test"
+	}
 	raw := map[string]interface{}{
 
 		"apiVersion": "dataplane.openstack.org/v1beta1",
@@ -514,6 +517,9 @@ func DefaultDataplaneService(name types.NamespacedName) map[string]interface{} {
 		"metadata": map[string]interface{}{
 			"name":      name.Name,
 			"namespace": name.Namespace,
+		},
+		"spec": map[string]interface{}{
+			"playbook": "test",
 		}}
 }
 
@@ -531,6 +537,7 @@ func DefaultDataplaneGlobalService(name types.NamespacedName) map[string]interfa
 		},
 		"spec": map[string]interface{}{
 			"deployOnAllNodeSets": true,
+			"playbook":            "test",
 		},
 	}
 }

--- a/tests/functional/dataplane/openstackdataplaneservice_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplaneservice_controller_test.go
@@ -42,7 +42,8 @@ var _ = Describe("OpenstackDataplaneService Test", func() {
 		It("spec fields are set up", func() {
 			service := GetService(dataplaneServiceName)
 			Expect(service.Spec.DataSources).To(BeEmpty())
-			Expect(service.Spec.Playbook).To(BeEmpty())
+			Expect(service.Spec.PlaybookContents).To(BeEmpty())
+			Expect(service.Spec.Role).To(BeEmpty())
 			Expect(service.Spec.DeployOnAllNodeSets).To(BeFalse())
 		})
 	})
@@ -57,7 +58,8 @@ var _ = Describe("OpenstackDataplaneService Test", func() {
 		It("spec fields are set up", func() {
 			service := GetService(dataplaneServiceName)
 			Expect(service.Spec.DataSources).To(BeEmpty())
-			Expect(service.Spec.Playbook).To(BeEmpty())
+			Expect(service.Spec.PlaybookContents).To(BeEmpty())
+			Expect(service.Spec.Role).To(BeEmpty())
 			Expect(service.Spec.DeployOnAllNodeSets).To(BeTrue())
 		})
 	})

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -95,15 +95,15 @@ spec:
         - ansible-runner
         - run
         - /runner
-        - -p
-        - playbook.yaml
+        - -r
+        - test role
         - -i
         - custom-img-svc-edpm-compute-no-nodes-edpm-no-nodes-custom-svc
         env:
-        - name: RUNNER_PLAYBOOK
+        - name: RUNNER_ROLE
           value: |2+
 
-            playbook.yaml
+            test role
 
         - name: RUNNER_EXTRA_VARS
           value: |2+

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
@@ -4,14 +4,7 @@ metadata:
   name: custom-img-svc
 spec:
   openStackAnsibleEERunnerImage: example.com/repo/runner-image:latest
-  role:
-    name: "test role"
-    hosts: "all"
-    strategy: "linear"
-    tasks:
-      - name: "test task"
-        import_role:
-          name: "test role"
+  role: "test role"
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet


### PR DESCRIPTION
Additionally to playbooks, it enables running roles directly with ansible-runner

closes [OSPRH-12358](https://issues.redhat.com//browse/OSPRH-12358)