### PR TITLE
Drop redhat service from default nodeset samples

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -900,7 +900,6 @@ spec:
                 type: integer
               services:
                 default:
-                - redhat
                 - download-cache
                 - bootstrap
                 - configure-network

--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -61,7 +61,7 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={redhat,download-cache,bootstrap,configure-network,validate-network,install-os,configure-os,ssh-known-hosts,run-os,reboot-os,install-certs,ovn,neutron-metadata,libvirt,nova,telemetry}
+	// +kubebuilder:default={download-cache,bootstrap,configure-network,validate-network,install-os,configure-os,ssh-known-hosts,run-os,reboot-os,install-certs,ovn,neutron-metadata,libvirt,nova,telemetry}
 	// Services list
 	Services []string `json:"services"`
 

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -900,7 +900,6 @@ spec:
                 type: integer
               services:
                 default:
-                - redhat
                 - download-cache
                 - bootstrap
                 - configure-network

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -8,7 +8,6 @@ spec:
     - name: ANSIBLE_FORCE_COLOR
       value: "True"
   services:
-    - redhat
     - bootstrap
     - download-cache
     - configure-network

--- a/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
@@ -355,7 +355,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 						},
 					},
 					Services: []string{
-						"redhat",
 						"download-cache",
 						"bootstrap",
 						"configure-network",
@@ -405,7 +404,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			BeforeEach(func() {
 				nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(tlsEnabled)
 				nodeSetSpec["services"] = []string{
-					"redhat",
 					"download-cache",
 					"bootstrap",
 					"configure-network",
@@ -496,7 +494,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 						},
 					},
 					Services: []string{
-						"redhat",
 						"download-cache",
 						"bootstrap",
 						"configure-network",
@@ -951,7 +948,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 						},
 					},
 					Services: []string{
-						"redhat",
 						"download-cache",
 						"bootstrap",
 						"configure-network",


### PR DESCRIPTION
The service requires rhel nodes to run which we
don't have upstream and so is not being tested.
Also enabling this service requires additional
vars like activationkey,token, username etc.

Also it broke some downstream jobs which running
older version of operators and using these upstream samples.

Related-Issue: [OSPCIX-596](https://issues.redhat.com//browse/OSPCIX-596)