### PR TITLE
[OSPRH-12079] Add mysqld exporter

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -16739,6 +16739,8 @@ spec:
                     type: string
                   ceilometerIpmiImage:
                     type: string
+                  ceilometerMysqldExporterImage:
+                    type: string
                   ceilometerNotificationImage:
                     type: string
                   ceilometerProxyImage:

--- a/apis/bases/core.openstack.org_openstackversions.yaml
+++ b/apis/bases/core.openstack.org_openstackversions.yaml
@@ -65,6 +65,8 @@ spec:
                     type: string
                   ceilometerIpmiImage:
                     type: string
+                  ceilometerMysqldExporterImage:
+                    type: string
                   ceilometerNotificationImage:
                     type: string
                   ceilometerSgcoreImage:
@@ -272,6 +274,8 @@ spec:
                       type: string
                     ceilometerIpmiImage:
                       type: string
+                    ceilometerMysqldExporterImage:
+                      type: string
                     ceilometerNotificationImage:
                       type: string
                     ceilometerSgcoreImage:
@@ -443,6 +447,8 @@ spec:
                   ceilometerComputeImage:
                     type: string
                   ceilometerIpmiImage:
+                    type: string
+                  ceilometerMysqldExporterImage:
                     type: string
                   ceilometerNotificationImage:
                     type: string

--- a/apis/core/v1beta1/openstackversion_types.go
+++ b/apis/core/v1beta1/openstackversion_types.go
@@ -89,6 +89,7 @@ type ContainerTemplate struct {
 	CeilometerIpmiImage           *string `json:"ceilometerIpmiImage,omitempty"`
 	CeilometerNotificationImage   *string `json:"ceilometerNotificationImage,omitempty"`
 	CeilometerSgcoreImage         *string `json:"ceilometerSgcoreImage,omitempty"`
+	CeilometerMysqldExporterImage *string `json:"ceilometerMysqldExporterImage,omitempty"`
 	CinderAPIImage                *string `json:"cinderAPIImage,omitempty"`
 	CinderBackupImage             *string `json:"cinderBackupImage,omitempty"`
 	CinderSchedulerImage          *string `json:"cinderSchedulerImage,omitempty"`

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -323,6 +323,11 @@ func (in *ContainerTemplate) DeepCopyInto(out *ContainerTemplate) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.CeilometerMysqldExporterImage != nil {
+		in, out := &in.CeilometerMysqldExporterImage, &out.CeilometerMysqldExporterImage
+		*out = new(string)
+		**out = **in
+	}
 	if in.CinderAPIImage != nil {
 		in, out := &in.CinderAPIImage, &out.CinderAPIImage
 		*out = new(string)

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -16739,6 +16739,8 @@ spec:
                     type: string
                   ceilometerIpmiImage:
                     type: string
+                  ceilometerMysqldExporterImage:
+                    type: string
                   ceilometerNotificationImage:
                     type: string
                   ceilometerProxyImage:

--- a/config/crd/bases/core.openstack.org_openstackversions.yaml
+++ b/config/crd/bases/core.openstack.org_openstackversions.yaml
@@ -65,6 +65,8 @@ spec:
                     type: string
                   ceilometerIpmiImage:
                     type: string
+                  ceilometerMysqldExporterImage:
+                    type: string
                   ceilometerNotificationImage:
                     type: string
                   ceilometerSgcoreImage:
@@ -272,6 +274,8 @@ spec:
                       type: string
                     ceilometerIpmiImage:
                       type: string
+                    ceilometerMysqldExporterImage:
+                      type: string
                     ceilometerNotificationImage:
                       type: string
                     ceilometerSgcoreImage:
@@ -443,6 +447,8 @@ spec:
                   ceilometerComputeImage:
                     type: string
                   ceilometerIpmiImage:
+                    type: string
+                  ceilometerMysqldExporterImage:
                     type: string
                   ceilometerNotificationImage:
                     type: string

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -39,6 +39,8 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
         - name: RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
+        - name: RELATED_IMAGE_CEILOMETER_MYSQLD_EXPORTER_IMAGE_URL_DEFAULT
+          value: quay.io/prometheus/mysqld-exporter:v0.16.0
         - name: RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT
           value: quay.io/openstack-k8s-operators/sg-core:v6.0.0
         - name: RELATED_IMAGE_CINDER_API_IMAGE_URL_DEFAULT

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -34,6 +34,7 @@ export RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT=quay.io/podified-antel
 export RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
 export RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
 export RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT=quay.io/openstack-k8s-operators/sg-core:v6.0.0
+export RELATED_IMAGE_CEILOMETER_MYSQLD_EXPORTER_IMAGE_URL_DEFAULT=quay.io/prometheus/mysqld-exporter:v0.16.0
 export RELATED_IMAGE_AODH_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
 export RELATED_IMAGE_AODH_EVALUATOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-evaluator:current-podified
 export RELATED_IMAGE_AODH_NOTIFIER_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-aodh-notifier:current-podified

--- a/pkg/openstack/version.go
+++ b/pkg/openstack/version.go
@@ -98,6 +98,7 @@ func GetContainerImages(defaults *corev1beta1.ContainerDefaults, instance corev1
 			CeilometerIpmiImage:           getImg(instance.Spec.CustomContainerImages.CeilometerIpmiImage, defaults.CeilometerIpmiImage),
 			CeilometerNotificationImage:   getImg(instance.Spec.CustomContainerImages.CeilometerNotificationImage, defaults.CeilometerNotificationImage),
 			CeilometerSgcoreImage:         getImg(instance.Spec.CustomContainerImages.CeilometerSgcoreImage, defaults.CeilometerSgcoreImage),
+			CeilometerMysqldExporterImage: getImg(instance.Spec.CustomContainerImages.CeilometerMysqldExporterImage, defaults.CeilometerMysqldExporterImage),
 			CinderAPIImage:                getImg(instance.Spec.CustomContainerImages.CinderAPIImage, defaults.CinderAPIImage),
 			CinderBackupImage:             getImg(instance.Spec.CustomContainerImages.CinderBackupImage, defaults.CinderBackupImage),
 			CinderSchedulerImage:          getImg(instance.Spec.CustomContainerImages.CinderSchedulerImage, defaults.CinderSchedulerImage),

--- a/tests/functional/ctlplane/openstackversion_controller_test.go
+++ b/tests/functional/ctlplane/openstackversion_controller_test.go
@@ -117,6 +117,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(version.Status.ContainerImages.CeilometerNotificationImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CeilometerSgcoreImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CeilometerProxyImage).ShouldNot(BeNil())
+				g.Expect(version.Status.ContainerImages.CeilometerMysqldExporterImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CinderAPIImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CinderBackupImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.CinderSchedulerImage).ShouldNot(BeNil())


### PR DESCRIPTION
This adds support for deploying the mysqld exporter as part of ceilometer CR. This is very similar to https://github.com/openstack-k8s-operators/openstack-operator/pull/1056

Depends-On: https://github.com/openstack-k8s-operators/telemetry-operator/pull/571