### PR TITLE
[OSPRH-12359] Add dnsnames to telemetry certs

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry.yaml
@@ -11,6 +11,7 @@ spec:
     default:
       contents:
       - ips
+      - dnsnames
   caCerts: combined-ca-bundle
   containerImageFields:
   - CeilometerComputeImage

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry_power_monitoring.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry_power_monitoring.yaml
@@ -11,6 +11,7 @@ spec:
     default:
       contents:
       - ips
+      - dnsnames
   caCerts: combined-ca-bundle
   containerImageFields:
   - CeilometerIpmiImage


### PR DESCRIPTION
Telemetry-operator tries to use IP addresses to access its dataplane resources, but as a backup it might use hostnames. In order to access Node Exporter and Kepler when they're with hostnames when they're behind TLS, we need to include the hostnames in the certificates.