### PR TITLE
Set rhoso 1.0.2 as OPENSTACK_IMG_BASE_RELEASE

### DIFF
--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,3 +1,7 @@
 export USE_IMAGE_DIGESTS=true
 export BUNDLE_DOCKERFILE=bundle.Dockerfile
 export FAIL_FIPS_CHECK=true
+# specifies the base image to be used in the prow kuttl job
+# to beform a minor update within this job, which was enabled in
+# https://github.com/openshift/release/pull/59699
+export OPENSTACK_IMG_BASE_RELEASE=quay.io/dprince/openstack-operator-index:1.0.2


### PR DESCRIPTION
OPENSTACK_IMG_BASE_RELEASE specifies the base image to be used in the prow kuttl job to beform a minor update within this job, which was enabled in [1]. For this right now we want to use the downstream 1.0.2 release.

[1] https://github.com/openshift/release/pull/59699