### PR TITLE
Don't use baremetal-operator API in functional tests.

### DIFF
--- a/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
@@ -30,7 +30,6 @@ import (
 	//revive:disable-next-line:dot-imports
 	infrav1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
-	baremetalv1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/api/v1beta1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -292,85 +291,56 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			})
 			It("should have the Spec fields initialized", func() {
 				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				emptyNodeSpec := dataplanev1.OpenStackDataPlaneNodeSetSpec{
-					BaremetalSetTemplate: baremetalv1.OpenStackBaremetalSetSpec{
-						BaremetalHosts:        nil,
-						OSImage:               "",
-						AutomatedCleaningMode: "metadata",
-						ProvisionServerName:   "",
-						ProvisioningInterface: "",
-						CtlplaneInterface:     "",
-						CtlplaneGateway:       "",
-						BmhNamespace:          "openshift-machine-api",
-						HardwareReqs: baremetalv1.HardwareReqs{
-							CPUReqs: baremetalv1.CPUReqs{
-								Arch:     "",
-								CountReq: baremetalv1.CPUCountReq{Count: 0, ExactMatch: false},
-								MhzReq:   baremetalv1.CPUMhzReq{Mhz: 0, ExactMatch: false},
-							},
-							MemReqs: baremetalv1.MemReqs{
-								GbReq: baremetalv1.MemGbReq{Gb: 0, ExactMatch: false},
-							},
-							DiskReqs: baremetalv1.DiskReqs{
-								GbReq:  baremetalv1.DiskGbReq{Gb: 0, ExactMatch: false},
-								SSDReq: baremetalv1.DiskSSDReq{SSD: false, ExactMatch: false},
-							},
-						},
-						PasswordSecret:   nil,
-						CloudUserName:    "",
-						DomainName:       "",
-						BootstrapDNS:     nil,
-						DNSSearchDomains: nil,
+				nodeTemplate := dataplanev1.NodeTemplate{
+					AnsibleSSHPrivateKeySecret: "dataplane-ansible-ssh-private-key-secret",
+					ManagementNetwork:          "ctlplane",
+					Ansible: dataplanev1.AnsibleOpts{
+						AnsibleUser: "cloud-admin",
+						AnsibleHost: "",
+						AnsiblePort: 0,
+						AnsibleVars: nil,
 					},
-					NodeTemplate: dataplanev1.NodeTemplate{
-						AnsibleSSHPrivateKeySecret: "dataplane-ansible-ssh-private-key-secret",
-						ManagementNetwork:          "ctlplane",
-						Ansible: dataplanev1.AnsibleOpts{
-							AnsibleUser: "cloud-admin",
-							AnsibleHost: "",
-							AnsiblePort: 0,
-							AnsibleVars: nil,
+					ExtraMounts: nil,
+					Networks: []infrav1.IPSetNetwork{
+						{
+							Name:       "networkinternal",
+							SubnetName: "subnet1",
 						},
-						ExtraMounts: nil,
-						Networks: []infrav1.IPSetNetwork{
-							{
-								Name:       "networkinternal",
-								SubnetName: "subnet1",
-							},
-							{
-								Name:       "ctlplane",
-								SubnetName: "subnet1",
-							},
+						{
+							Name:       "ctlplane",
+							SubnetName: "subnet1",
 						},
 					},
-					Env:                nil,
-					PreProvisioned:     true,
-					NetworkAttachments: nil,
-					SecretMaxSize:      1048576,
-					TLSEnabled:         tlsEnabled,
-					Nodes: map[string]dataplanev1.NodeSection{
-						dataplaneNodeName.Name: {
-							HostName: dataplaneNodeName.Name,
-						},
-					},
-					Services: []string{
-						"download-cache",
-						"bootstrap",
-						"configure-network",
-						"validate-network",
-						"install-os",
-						"configure-os",
-						"ssh-known-hosts",
-						"run-os",
-						"reboot-os",
-						"install-certs",
-						"ovn",
-						"neutron-metadata",
-						"libvirt",
-						"nova",
-						"telemetry"},
 				}
-				Expect(dataplaneNodeSetInstance.Spec).Should(Equal(emptyNodeSpec))
+
+				Expect(dataplaneNodeSetInstance.Spec.NodeTemplate).Should(Equal(nodeTemplate))
+				Expect(dataplaneNodeSetInstance.Spec.PreProvisioned).Should(BeTrue())
+				Expect(dataplaneNodeSetInstance.Spec.TLSEnabled).Should(Equal(tlsEnabled))
+				nodes := map[string]dataplanev1.NodeSection{
+					dataplaneNodeName.Name: {
+						HostName: dataplaneNodeName.Name,
+					},
+				}
+				Expect(dataplaneNodeSetInstance.Spec.Nodes).Should(Equal(nodes))
+				services := []string{
+					"download-cache",
+					"bootstrap",
+					"configure-network",
+					"validate-network",
+					"install-os",
+					"configure-os",
+					"ssh-known-hosts",
+					"run-os",
+					"reboot-os",
+					"install-certs",
+					"ovn",
+					"neutron-metadata",
+					"libvirt",
+					"nova",
+					"telemetry"}
+
+				Expect(dataplaneNodeSetInstance.Spec.BaremetalSetTemplate.BaremetalHosts).Should(BeEmpty())
+				Expect(dataplaneNodeSetInstance.Spec.Services).Should(Equal(services))
 			})
 
 			It("should have input not ready and unknown Conditions initialized", func() {
@@ -430,85 +400,56 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			})
 			It("should have the Spec fields initialized", func() {
 				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				emptyNodeSpec := dataplanev1.OpenStackDataPlaneNodeSetSpec{
-					BaremetalSetTemplate: baremetalv1.OpenStackBaremetalSetSpec{
-						BaremetalHosts:        nil,
-						OSImage:               "",
-						AutomatedCleaningMode: "metadata",
-						ProvisionServerName:   "",
-						ProvisioningInterface: "",
-						CtlplaneInterface:     "",
-						CtlplaneGateway:       "",
-						BmhNamespace:          "openshift-machine-api",
-						HardwareReqs: baremetalv1.HardwareReqs{
-							CPUReqs: baremetalv1.CPUReqs{
-								Arch:     "",
-								CountReq: baremetalv1.CPUCountReq{Count: 0, ExactMatch: false},
-								MhzReq:   baremetalv1.CPUMhzReq{Mhz: 0, ExactMatch: false},
-							},
-							MemReqs: baremetalv1.MemReqs{
-								GbReq: baremetalv1.MemGbReq{Gb: 0, ExactMatch: false},
-							},
-							DiskReqs: baremetalv1.DiskReqs{
-								GbReq:  baremetalv1.DiskGbReq{Gb: 0, ExactMatch: false},
-								SSDReq: baremetalv1.DiskSSDReq{SSD: false, ExactMatch: false},
-							},
-						},
-						PasswordSecret:   nil,
-						CloudUserName:    "",
-						DomainName:       "",
-						BootstrapDNS:     nil,
-						DNSSearchDomains: nil,
+				nodeTemplate := dataplanev1.NodeTemplate{
+					AnsibleSSHPrivateKeySecret: "dataplane-ansible-ssh-private-key-secret",
+					ManagementNetwork:          "ctlplane",
+					Ansible: dataplanev1.AnsibleOpts{
+						AnsibleUser: "cloud-admin",
+						AnsibleHost: "",
+						AnsiblePort: 0,
+						AnsibleVars: nil,
 					},
-					NodeTemplate: dataplanev1.NodeTemplate{
-						AnsibleSSHPrivateKeySecret: "dataplane-ansible-ssh-private-key-secret",
-						Networks: []infrav1.IPSetNetwork{
-							{
-								Name:       "networkinternal",
-								SubnetName: "subnet1",
-							},
-							{
-								Name:       "ctlplane",
-								SubnetName: "subnet1",
-							},
+					ExtraMounts: nil,
+					Networks: []infrav1.IPSetNetwork{
+						{
+							Name:       "networkinternal",
+							SubnetName: "subnet1",
 						},
-						ManagementNetwork: "ctlplane",
-						Ansible: dataplanev1.AnsibleOpts{
-							AnsibleUser: "cloud-admin",
-							AnsibleHost: "",
-							AnsiblePort: 0,
-							AnsibleVars: nil,
-						},
-						ExtraMounts: nil,
-					},
-					Env:                nil,
-					PreProvisioned:     true,
-					NetworkAttachments: nil,
-					SecretMaxSize:      1048576,
-					TLSEnabled:         tlsEnabled,
-					Nodes: map[string]dataplanev1.NodeSection{
-						dataplaneNodeName.Name: {
-							HostName: dataplaneNodeName.Name,
+						{
+							Name:       "ctlplane",
+							SubnetName: "subnet1",
 						},
 					},
-					Services: []string{
-						"download-cache",
-						"bootstrap",
-						"configure-network",
-						"validate-network",
-						"install-os",
-						"configure-os",
-						"run-os",
-						"reboot-os",
-						"install-certs",
-						"ovn",
-						"neutron-metadata",
-						"libvirt",
-						"nova",
-						"telemetry",
-						"global-service"},
 				}
-				Expect(dataplaneNodeSetInstance.Spec).Should(Equal(emptyNodeSpec))
+
+				Expect(dataplaneNodeSetInstance.Spec.NodeTemplate).Should(Equal(nodeTemplate))
+				Expect(dataplaneNodeSetInstance.Spec.PreProvisioned).Should(BeTrue())
+				Expect(dataplaneNodeSetInstance.Spec.TLSEnabled).Should(Equal(tlsEnabled))
+				nodes := map[string]dataplanev1.NodeSection{
+					dataplaneNodeName.Name: {
+						HostName: dataplaneNodeName.Name,
+					},
+				}
+				Expect(dataplaneNodeSetInstance.Spec.Nodes).Should(Equal(nodes))
+				services := []string{
+					"download-cache",
+					"bootstrap",
+					"configure-network",
+					"validate-network",
+					"install-os",
+					"configure-os",
+					"run-os",
+					"reboot-os",
+					"install-certs",
+					"ovn",
+					"neutron-metadata",
+					"libvirt",
+					"nova",
+					"telemetry",
+					"global-service"}
+
+				Expect(dataplaneNodeSetInstance.Spec.BaremetalSetTemplate.BaremetalHosts).Should(BeEmpty())
+				Expect(dataplaneNodeSetInstance.Spec.Services).Should(Equal(services))
 			})
 
 			It("should have input not ready and unknown Conditions initialized", func() {
@@ -881,89 +822,57 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			})
 			It("should have the Spec fields initialized", func() {
 				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				emptyNodeSpec := dataplanev1.OpenStackDataPlaneNodeSetSpec{
-					BaremetalSetTemplate: baremetalv1.OpenStackBaremetalSetSpec{
-						BaremetalHosts:        nil,
-						OSImage:               "",
-						AutomatedCleaningMode: "metadata",
-						ProvisionServerName:   "",
-						ProvisioningInterface: "",
-						CtlplaneInterface:     "",
-						CtlplaneGateway:       "",
-						BmhNamespace:          "openshift-machine-api",
-						HardwareReqs: baremetalv1.HardwareReqs{
-							CPUReqs: baremetalv1.CPUReqs{
-								Arch:     "",
-								CountReq: baremetalv1.CPUCountReq{Count: 0, ExactMatch: false},
-								MhzReq:   baremetalv1.CPUMhzReq{Mhz: 0, ExactMatch: false},
-							},
-							MemReqs: baremetalv1.MemReqs{
-								GbReq: baremetalv1.MemGbReq{Gb: 0, ExactMatch: false},
-							},
-							DiskReqs: baremetalv1.DiskReqs{
-								GbReq:  baremetalv1.DiskGbReq{Gb: 0, ExactMatch: false},
-								SSDReq: baremetalv1.DiskSSDReq{SSD: false, ExactMatch: false},
-							},
-						},
-						PasswordSecret:   nil,
-						CloudUserName:    "",
-						DomainName:       "",
-						BootstrapDNS:     nil,
-						DNSSearchDomains: nil,
+				nodeTemplate := dataplanev1.NodeTemplate{
+					AnsibleSSHPrivateKeySecret: "dataplane-ansible-ssh-private-key-secret",
+					ManagementNetwork:          "ctlplane",
+					Ansible: dataplanev1.AnsibleOpts{
+						AnsibleUser: "cloud-admin",
+						AnsibleHost: "",
+						AnsiblePort: 0,
+						AnsibleVars: nil,
 					},
-					NodeTemplate: dataplanev1.NodeTemplate{
-						AnsibleSSHPrivateKeySecret: "dataplane-ansible-ssh-private-key-secret",
-						Networks: []infrav1.IPSetNetwork{
-							{
-								Name:       "networkinternal",
-								SubnetName: "subnet1",
-							},
-							{
-								Name:       "ctlplane",
-								SubnetName: "subnet1",
-							},
+					ExtraMounts: nil,
+					Networks: []infrav1.IPSetNetwork{
+						{
+							Name:       "networkinternal",
+							SubnetName: "subnet1",
 						},
-						ManagementNetwork: "ctlplane",
-						Ansible: dataplanev1.AnsibleOpts{
-							AnsibleUser: "cloud-admin",
-							AnsibleHost: "",
-							AnsiblePort: 0,
-							AnsibleVars: nil,
-						},
-						ExtraMounts: nil,
-						UserData:    nil,
-						NetworkData: nil,
-					},
-					Env:                nil,
-					PreProvisioned:     true,
-					NetworkAttachments: nil,
-					SecretMaxSize:      1048576,
-					TLSEnabled:         tlsEnabled,
-					Nodes: map[string]dataplanev1.NodeSection{
-						dataplaneNodeName.Name: {
-							HostName: dataplaneNodeName.Name,
+						{
+							Name:       "ctlplane",
+							SubnetName: "subnet1",
 						},
 					},
-					Services: []string{
-						"download-cache",
-						"bootstrap",
-						"configure-network",
-						"validate-network",
-						"install-os",
-						"configure-os",
-						"ssh-known-hosts",
-						"run-os",
-						"reboot-os",
-						"install-certs",
-						"ovn",
-						"neutron-metadata",
-						"libvirt",
-						"nova",
-						"telemetry"},
 				}
-				Expect(dataplaneNodeSetInstance.Spec).Should(Equal(emptyNodeSpec))
-			})
 
+				Expect(dataplaneNodeSetInstance.Spec.NodeTemplate).Should(Equal(nodeTemplate))
+				Expect(dataplaneNodeSetInstance.Spec.PreProvisioned).Should(BeTrue())
+				Expect(dataplaneNodeSetInstance.Spec.TLSEnabled).Should(Equal(tlsEnabled))
+				nodes := map[string]dataplanev1.NodeSection{
+					dataplaneNodeName.Name: {
+						HostName: dataplaneNodeName.Name,
+					},
+				}
+				Expect(dataplaneNodeSetInstance.Spec.Nodes).Should(Equal(nodes))
+				services := []string{
+					"download-cache",
+					"bootstrap",
+					"configure-network",
+					"validate-network",
+					"install-os",
+					"configure-os",
+					"ssh-known-hosts",
+					"run-os",
+					"reboot-os",
+					"install-certs",
+					"ovn",
+					"neutron-metadata",
+					"libvirt",
+					"nova",
+					"telemetry"}
+
+				Expect(dataplaneNodeSetInstance.Spec.BaremetalSetTemplate.BaremetalHosts).Should(BeEmpty())
+				Expect(dataplaneNodeSetInstance.Spec.Services).Should(Equal(services))
+			})
 			It("should have input not ready and unknown Conditions initialized", func() {
 				th.ExpectCondition(
 					dataplaneNodeSetName,

--- a/tests/functional/dataplane/openstackdataplanenodeset_webhook_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_webhook_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	v1beta1 "github.com/openstack-k8s-operators/openstack-operator/apis/dataplane/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	baremetalv1 "github.com/openstack-k8s-operators/openstack-baremetal-operator/api/v1beta1"
 )
 
 var _ = Describe("DataplaneNodeSet Webhook", func() {
@@ -42,9 +40,9 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 				"compute-0": map[string]interface{}{
 					"hostName": "compute-0"},
 			}
-			nodeSetSpec["baremetalSetTemplate"] = baremetalv1.OpenStackBaremetalSetSpec{
-				CloudUserName: "test-user",
-				BmhLabelSelector: map[string]string{
+			nodeSetSpec["baremetalSetTemplate"] = map[string]interface{}{
+				"cloudUserName": "test-user",
+				"bmhLabelSelector": map[string]string{
 					"app": "test-openstack",
 				},
 			}
@@ -54,11 +52,9 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 		It("Should block changes to the BmhLabelSelector object in baremetalSetTemplate spec", func() {
 			Eventually(func(_ Gomega) string {
 				instance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				instance.Spec.BaremetalSetTemplate = baremetalv1.OpenStackBaremetalSetSpec{
-					CloudUserName: "new-user",
-					BmhLabelSelector: map[string]string{
-						"app": "openstack1",
-					},
+				instance.Spec.BaremetalSetTemplate.CloudUserName = "new-user"
+				instance.Spec.BaremetalSetTemplate.BmhLabelSelector = map[string]string{
+					"app": "openstack1",
 				}
 				err := th.K8sClient.Update(th.Ctx, instance)
 				return fmt.Sprintf("%s", err)
@@ -70,14 +66,14 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 		BeforeEach(func() {
 			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(false)
 			nodeSetSpec["preProvisioned"] = false
-			nodeSetSpec["baremetalSetTemplate"] = baremetalv1.OpenStackBaremetalSetSpec{
-				CloudUserName: "test-user",
-				BmhLabelSelector: map[string]string{
+			nodeSetSpec["baremetalSetTemplate"] = map[string]interface{}{
+				"cloudUserName": "test-user",
+				"bmhLabelSelector": map[string]string{
 					"app": "test-openstack",
 				},
-				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
-					"compute-0": {
-						CtlPlaneIP: "192.168.1.12/24",
+				"baremetalHosts": map[string]interface{}{
+					"compute-0": map[string]interface{}{
+						"ctlPlaneIP": "192.168.1.12/24",
 					},
 				},
 			}
@@ -86,17 +82,11 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 		It("Should allow changes to the CloudUserName", func() {
 			Eventually(func(_ Gomega) error {
 				instance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				instance.Spec.BaremetalSetTemplate = baremetalv1.OpenStackBaremetalSetSpec{
-					CloudUserName: "new-user",
-					BmhLabelSelector: map[string]string{
-						"app": "test-openstack",
-					},
-					BaremetalHosts: map[string]baremetalv1.InstanceSpec{
-						"compute-0": {
-							CtlPlaneIP: "192.168.1.12/24",
-						},
-					},
+				instance.Spec.BaremetalSetTemplate.CloudUserName = "new-user"
+				instance.Spec.BaremetalSetTemplate.BmhLabelSelector = map[string]string{
+					"app": "test-openstack",
 				}
+
 				return th.K8sClient.Update(th.Ctx, instance)
 			}).Should(Succeed())
 		})
@@ -110,14 +100,14 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 				"compute-0": map[string]interface{}{
 					"hostName": "compute-0"},
 			}
-			nodeSetSpec["baremetalSetTemplate"] = baremetalv1.OpenStackBaremetalSetSpec{
-				DomainName: "example.com",
-				BmhLabelSelector: map[string]string{
+			nodeSetSpec["baremetalSetTemplate"] = map[string]interface{}{
+				"domainName": "example.com",
+				"bmhLabelSelector": map[string]string{
 					"app": "test-openstack",
 				},
-				BaremetalHosts: map[string]baremetalv1.InstanceSpec{
-					"compute-0": {
-						CtlPlaneIP: "192.168.1.12/24",
+				"baremetalHosts": map[string]interface{}{
+					"compute-0": map[string]interface{}{
+						"ctlPlaneIP": "192.168.1.12/24",
 					},
 				},
 			}


### PR DESCRIPTION
We can't refactor baremetal-operator API as the tests fail when building openstack-operator with a baremetal-operator change.