### PR TITLE
Add watch to ImageContentSourcePolicy permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -661,6 +661,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ovn.openstack.org
   resources:

--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -123,7 +123,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) GetLogger(ctx context.Context) log
 // +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreamtags,verbs=get;list;watch
 
 // RBAC for ImageContentSourcePolicy and MachineConfig
-// +kubebuilder:rbac:groups="operator.openshift.io",resources=imagecontentsourcepolicies,verbs=get;list
+// +kubebuilder:rbac:groups="operator.openshift.io",resources=imagecontentsourcepolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups="machineconfiguration.openshift.io",resources=machineconfigs,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
Adding the watch permission will suppress the large number of errors being reported by the openstack-operator related to watching ICSP objects.

Jira: https://issues.redhat.com/browse/OSPRH-12713