### PR TITLE
Add barbican configurable API Timeout

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -908,6 +908,8 @@ func (r *OpenStackControlPlane) DefaultServices() {
 			r.Spec.Barbican.Template = &barbicanv1.BarbicanSpecCore{}
 		}
 		r.Spec.Barbican.Template.Default()
+		initializeOverrideSpec(&r.Spec.Barbican.APIOverride.Route, true)
+		r.Spec.Barbican.Template.SetDefaultRouteAnnotations(r.Spec.Barbican.APIOverride.Route.Annotations)
 	}
 
 	// Designate

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -590,6 +590,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route).Should(Not(BeNil()))
 			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
 			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route.Annotations).Should(HaveKeyWithValue("api.aodh.openstack.org/timeout", "60s"))
+			//TODO: Enable these tests when Barbican would be enabled on FTs
+			// Expect(OSCtlplane.Spec.Barbican.APIOverride.Route).Should(Not(BeNil()))
+			// Expect(OSCtlplane.Spec.Barbican.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "90s"))
+			// Expect(OSCtlplane.Spec.Barbican.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.barbican.openstack.org/timeout", "90s"))
 		})
 
 		It("should create selfsigned issuer and public+internal CA and issuer", func() {
@@ -867,6 +871,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route).Should(Not(BeNil()))
 			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "60s"))
 			Expect(OSCtlplane.Spec.Telemetry.AodhAPIOverride.Route.Annotations).Should(HaveKeyWithValue("api.aodh.openstack.org/timeout", "60s"))
+			//TODO: Enable these tests when Barbican would be enabled on FTs
+			// Expect(OSCtlplane.Spec.Barbican.APIOverride.Route).Should(Not(BeNil()))
+			// Expect(OSCtlplane.Spec.Barbican.APIOverride.Route.Annotations).Should(HaveKeyWithValue("haproxy.router.openshift.io/timeout", "90s"))
+			// Expect(OSCtlplane.Spec.Barbican.APIOverride.Route.Annotations).Should(HaveKeyWithValue("api.barbican.openstack.org/timeout", "90s"))
 		})
 
 		It("should create selfsigned issuer and public, internal, libvirt and ovn CA and issuer", func() {


### PR DESCRIPTION
Depends-On: openstack-k8s-operators/barbican-operator#197
Depends-On: openstack-k8s-operators/barbican-operator#198

Jira: https://issues.redhat.com/browse/OSPRH-10964