### PR TITLE
Only enable rabbitmq IPv6 when first OCP cluster network is IPv6

### DIFF
--- a/pkg/openstack/rabbitmq.go
+++ b/pkg/openstack/rabbitmq.go
@@ -156,7 +156,7 @@ func reconcileRabbitMQ(
 		},
 	}
 
-	IPv6Enabled, err := ocp.HasIPv6ClusterNetwork(ctx, helper)
+	IPv6Enabled, err := ocp.FirstClusterNetworkIsIPv6(ctx, helper)
 	if err != nil {
 		return mqFailed, ctrl.Result{}, err
 	}


### PR DESCRIPTION
Depends-on: https://github.com/openstack-k8s-operators/lib-common/pull/596

Jira: [OSPRH-13320](https://issues.redhat.com//browse/OSPRH-13320)