### PR TITLE
[18.0-fr1] Add bindata noop Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,10 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: bindata
+bindata: ## NOOP call in 18.0-fr1
+	/bin/true
+
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -12,6 +12,7 @@
     parent: podified-multinode-edpm-deployment-crc-3comp
     dependencies: ["openstack-k8s-operators-content-provider"]
     vars:
+      cifmw_test_operator_index: quay.io/openstack-k8s-operators/test-operator-index:18.0-fr1-latest
       cifmw_operator_build_golang_ct: "docker.io/library/golang:1.21"
       cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.21"
       cifmw_tempest_tempestconf_config:


### PR DESCRIPTION
CI scripts are same for all branches. Introduction of bindata call for the main branch openstack-operator build results in error in the fr1 branch jobs. Lest add a noop target to not make it fail.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1007