### PR TITLE
Enable openstack-baremetal-operator webhooks

### DIFF
--- a/bindata/operator/managers.yaml
+++ b/bindata/operator/managers.yaml
@@ -30,7 +30,7 @@ spec:
         - /manager
         env:
         - name: ENABLE_WEBHOOKS
-{{ if eq $operatorName "infra" }}
+{{ if or (eq $operatorName "infra") (eq $operatorName "openstack-baremetal") }}
           value: 'true'
 {{ else }}
           value: 'false'
@@ -58,7 +58,7 @@ spec:
             memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
-{{ if eq $operatorName "infra" }}
+{{ if or (eq $operatorName "infra") (eq $operatorName "openstack-baremetal") }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
@@ -88,7 +88,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ $operatorName }}-operator-controller-manager
       terminationGracePeriodSeconds: 10
-{{ if eq $operatorName "infra" }}
+{{ if or (eq $operatorName "infra") (eq $operatorName "openstack-baremetal") }}
       volumes:
       - name: cert
         secret:

--- a/bindata/operator/openstack-baremetal-operator-webhooks.yaml
+++ b/bindata/operator/openstack-baremetal-operator-webhooks.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: openstack-operator
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: openstack-baremetal-operator
+  name: openstack-baremetal-operator-webhook-service
+  namespace: '{{ .OperatorNamespace }}'
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    openstack.org/operator-name: openstack-baremetal
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: openstack-operator
+    app.kubernetes.io/instance: serving-cert
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/part-of: openstack-baremetal-operator
+  name: openstack-baremetal-operator-serving-cert
+  namespace: '{{ .OperatorNamespace }}'
+spec:
+  dnsNames:
+  - openstack-baremetal-operator-webhook-service.{{ .OperatorNamespace }}.svc
+  - openstack-baremetal-operator-webhook-service.{{ .OperatorNamespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: openstack-baremetal-operator-selfsigned-issuer
+  secretName: openstack-baremetal-operator-webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: openstack-operator
+    app.kubernetes.io/instance: selfsigned-issuer
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: issuer
+    app.kubernetes.io/part-of: openstack-baremetal-operator
+  name: openstack-baremetal-operator-selfsigned-issuer
+  namespace: '{{ .OperatorNamespace }}'
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .OperatorNamespace }}/openstack-baremetal-operator-serving-cert'
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: openstack-operator
+    app.kubernetes.io/instance: mutating-webhook-configuration
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: mutatingwebhookconfiguration
+    app.kubernetes.io/part-of: openstack-baremetal-operator
+  name: openstack-baremetal-operator-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  failurePolicy: Fail
+  name: mopenstackprovisionserver.kb.io
+  rules:
+    - apiGroups:
+        - baremetal.openstack.org
+      apiVersions:
+      - v1beta1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - openstackprovisionservers
+  sideEffects: None
+  clientConfig:
+    service:
+      name: openstack-baremetal-operator-webhook-service
+      namespace: '{{ .OperatorNamespace }}'
+      path: /mutate-baremetal-openstack-org-v1beta1-openstackprovisionserver
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .OperatorNamespace }}/openstack-baremetal-operator-serving-cert'
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: openstack-operator
+    app.kubernetes.io/instance: validating-webhook-configuration
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: validatingwebhookconfiguration
+    app.kubernetes.io/part-of: openstack-baremetal-operator
+  name: openstack-baremetal-operator-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  failurePolicy: Fail
+  name: vopenstackbaremetalset.kb.io
+  rules:
+    - apiGroups:
+        - baremetal.openstack.org
+      apiVersions:
+      - v1beta1
+      operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+      resources:
+        - openstackbaremetalsets
+  sideEffects: None
+  clientConfig:
+    service:
+      name: openstack-baremetal-operator-webhook-service
+      namespace: '{{ .OperatorNamespace }}'
+      path: /validate-baremetal-openstack-org-v1beta1-openstackbaremetalset
+- admissionReviewVersions:
+  - v1
+  failurePolicy: Fail
+  name: vopenstackprovisionserver.kb.io
+  rules:
+    - apiGroups:
+        - baremetal.openstack.org
+      apiVersions:
+      - v1beta1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - openstackprovisionservers
+  sideEffects: None
+  clientConfig:
+    service:
+      name: openstack-baremetal-operator-webhook-service
+      namespace: '{{ .OperatorNamespace }}'
+      path: /validate-baremetal-openstack-org-v1beta1-openstackprovisionserver

--- a/config/operator/managers.yaml
+++ b/config/operator/managers.yaml
@@ -30,7 +30,7 @@ spec:
         - /manager
         env:
         - name: ENABLE_WEBHOOKS
-{{ if eq $operatorName "infra" }}
+{{ if or (eq $operatorName "infra") (eq $operatorName "openstack-baremetal") }}
           value: 'true'
 {{ else }}
           value: 'false'
@@ -58,7 +58,7 @@ spec:
             memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
-{{ if eq $operatorName "infra" }}
+{{ if or (eq $operatorName "infra") (eq $operatorName "openstack-baremetal") }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
@@ -88,7 +88,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ $operatorName }}-operator-controller-manager
       terminationGracePeriodSeconds: 10
-{{ if eq $operatorName "infra" }}
+{{ if or (eq $operatorName "infra") (eq $operatorName "openstack-baremetal") }}
       volumes:
       - name: cert
         secret:

--- a/hack/sync-bindata.sh
+++ b/hack/sync-bindata.sh
@@ -158,7 +158,7 @@ for X in $(ls manifests/*clusterserviceversion.yaml); do
         CLUSTER_ROLE_RULES=$(cat $X | $LOCAL_BINARIES/yq -r .spec.install.spec.clusterPermissions| sed -e 's|- rules:|rules:|' | sed -e 's|    ||' | sed -e '/  serviceAccountName.*/d'
 )
 
-if [[ "$OPERATOR_NAME" == "infra-operator" ]]; then
+if [[ "$OPERATOR_NAME" == "infra-operator" || "$OPERATOR_NAME" == "openstack-baremetal-operator" ]]; then
     write_webhooks "$X" "$OPERATOR_NAME"
 fi
 


### PR DESCRIPTION
Few of the reasons:

- All defaulting and validation is not done in the openstack-operator webhooks.
- There is an option to create OpenStackProvisionServer directly and reuse it for provisioning multiple 
  OpenStackDataPlaneNodeSets.