### PR TITLE
[OSPRH-13152] Fix RabbitMQ on IPv6

### DIFF
--- a/pkg/openstack/rabbitmq.go
+++ b/pkg/openstack/rabbitmq.go
@@ -393,10 +393,17 @@ func reconcileRabbitMQ(
 			Log.Info("Setting AdditionalConfig")
 			// This is the same situation as RABBITMQ_UPGRADE_LOG above,
 			// except for the "main" rabbitmq log we can just force it to use the console.
+
+			// By default the prometheus and management endpoints always bind to ipv4.
+			// We need to set the correct address based on the IP version in use.
 			var settings []string
 			settings = append(settings, "log.console = true")
+			settings = append(settings, "prometheus.tcp.ip = ::")
+			settings = append(settings, "management.tcp.ip = ::")
 			if tlsCert != "" {
 				settings = append(settings, "ssl_options.verify = verify_none")
+				settings = append(settings, "prometheus.ssl.ip = ::")
+				// management ssl ip needs to be set in the AdvancedConfig
 			}
 			rabbitmq.Spec.Rabbitmq.AdditionalConfig = strings.Join(settings, "\n")
 		}
@@ -436,6 +443,7 @@ func reconcileRabbitMQ(
   ]},
   {rabbitmq_management, [
     {ssl_config, [
+      {ip,"::"},
       {cacertfile,"/etc/rabbitmq-tls/ca.crt"},
       {certfile,"/etc/rabbitmq-tls/tls.crt"},
       {keyfile,"/etc/rabbitmq-tls/tls.key"},


### PR DESCRIPTION
RabbitMQ by default listens only on IPv4 even when it's deployed in an IPv6 environment. This determines the used IP version and lets rabbit listen either on 0.0.0.0 or ::.

# Before
```
[stack@osp-cloudops-03 devsetup]$ oc rsh openstackclient curl rabbitmq.openstack.svc:5671
curl: (1) Received HTTP/0.9 when not allowed      <---- a fine response considering I'm using HTTP to communicate with AMQP service
command terminated with exit code 1
[stack@osp-cloudops-03 devsetup]$ oc rsh openstackclient curl rabbitmq.openstack.svc:15671
curl: (7) Failed to connect to rabbitmq.openstack.svc port 15671: Connection refused
command terminated with exit code 7
[stack@osp-cloudops-03 devsetup]$ oc rsh openstackclient curl rabbitmq.openstack.svc:15691
curl: (7) Failed to connect to rabbitmq.openstack.svc port 15691: Connection refused
command terminated with exit code 7 
```

# After
```
[stack@osp-cloudops-03 ~]$ ## IPv6 TLS ##
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl https://rabbitmq.openstack.svc:5671
curl: (1) Received HTTP/0.9 when not allowed
command terminated with exit code 1
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl https://rabbitmq.openstack.svc:15671 | head
<!DOCTYPE html>
<html>
  <head>
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
    <title>RabbitMQ Management</title>
    <script src="js/ejs-1.0.min.js" type="text/javascript"></script>
    <script src="js/jquery-3.5.1.min.js"></script>
    <script src="js/jquery.flot-0.8.1.min.js" type="text/javascript"></script>
    <script src="js/jquery.flot-0.8.1.time.min.js" type="text/javascript"></script>
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl https://rabbitmq.openstack.svc:15691/metrics | head
# TYPE erlang_mnesia_held_locks gauge
# HELP erlang_mnesia_held_locks Number of held locks.
erlang_mnesia_held_locks 0
# TYPE erlang_mnesia_lock_queue gauge
# HELP erlang_mnesia_lock_queue Number of transactions waiting for a lock.
erlang_mnesia_lock_queue 0
# TYPE erlang_mnesia_transaction_participants gauge
# HELP erlang_mnesia_transaction_participants Number of participant transactions.
erlang_mnesia_transaction_participants 0
# TYPE erlang_mnesia_transaction_coordinators gauge


[stack@osp-cloudops-03 ~]$ ## IPv6 no-TLS ##
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl http://rabbitmq.openstack.svc:5672
curl: (1) Received HTTP/0.9 when not allowed
command terminated with exit code 1
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl http://rabbitmq.openstack.svc:15672 | head
<!DOCTYPE html>
<html>
  <head>
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
    <title>RabbitMQ Management</title>
    <script src="js/ejs-1.0.min.js" type="text/javascript"></script>
    <script src="js/jquery-3.5.1.min.js"></script>
    <script src="js/jquery.flot-0.8.1.min.js" type="text/javascript"></script>
    <script src="js/jquery.flot-0.8.1.time.min.js" type="text/javascript"></script>
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl http://rabbitmq.openstack.svc:15692/metrics | head
# TYPE erlang_mnesia_held_locks gauge
# HELP erlang_mnesia_held_locks Number of held locks.
erlang_mnesia_held_locks 0
# TYPE erlang_mnesia_lock_queue gauge
# HELP erlang_mnesia_lock_queue Number of transactions waiting for a lock.
erlang_mnesia_lock_queue 0
# TYPE erlang_mnesia_transaction_participants gauge
# HELP erlang_mnesia_transaction_participants Number of participant transactions.
erlang_mnesia_transaction_participants 0
# TYPE erlang_mnesia_transaction_coordinators gauge


[stack@osp-cloudops-03 ~]$ ## IPv4 TLS I forgot to use "HTTPS" instead of "HTTP", but this is good enough (no connection refused)
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl http://rabbitmq.openstack.svc:5671
curl: (1) Received HTTP/0.9 when not allowed
command terminated with exit code 1
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl http://rabbitmq.openstack.svc:15671 | head
curl: (1) Received HTTP/0.9 when not allowed
command terminated with exit code 1
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl http://rabbitmq.openstack.svc:15691/metrics | head
curl: (1) Received HTTP/0.9 when not allowed
command terminated with exit code 1


[stack@osp-cloudops-03 ~]$ ## IPv4 no-TLS
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl http://rabbitmq.openstack.svc:5672
curl: (1) Received HTTP/0.9 when not allowed
command terminated with exit code 1
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl http://rabbitmq.openstack.svc:15672 | head
<!DOCTYPE html>
<html>
  <head>
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
    <title>RabbitMQ Management</title>
    <script src="js/ejs-1.0.min.js" type="text/javascript"></script>
    <script src="js/jquery-3.5.1.min.js"></script>
    <script src="js/jquery.flot-0.8.1.min.js" type="text/javascript"></script>
    <script src="js/jquery.flot-0.8.1.time.min.js" type="text/javascript"></script>
[stack@osp-cloudops-03 ~]$ oc rsh openstackclient curl http://rabbitmq.openstack.svc:15692/metrics | head
# TYPE erlang_mnesia_held_locks gauge
# HELP erlang_mnesia_held_locks Number of held locks.
erlang_mnesia_held_locks 0
# TYPE erlang_mnesia_lock_queue gauge
# HELP erlang_mnesia_lock_queue Number of transactions waiting for a lock.
erlang_mnesia_lock_queue 0
# TYPE erlang_mnesia_transaction_participants gauge
# HELP erlang_mnesia_transaction_participants Number of participant transactions.
erlang_mnesia_transaction_participants 0
# TYPE erlang_mnesia_transaction_coordinators gauge
```