### PR TITLE
Add checkServiceEndpoints, own deployments

### DIFF
--- a/config/operator/rbac/role.yaml
+++ b/config/operator/rbac/role.yaml
@@ -68,6 +68,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - discovery
+  resources:
+  - endpointslices
+  verbs:
+  - get;list
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors


### PR DESCRIPTION
Adds a checkServiceEndpoints function which uses a static list of service names to ensure an endpoint exists and has associated addresses. This should help make sure webhooks are fully configured before setting the
final ready condition upon initial deployment.

Also removes old code to "watch" deployments as
we can just own them since the initialization resource is namespaced.