### PR TITLE
Reset deployment status when provisioned BMH hash changes

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -937,6 +937,8 @@ spec:
                 type: object
               ctlplaneSearchDomain:
                 type: string
+              deployedBmhHash:
+                type: string
               deployedConfigHash:
                 type: string
               deployedVersion:

--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -154,6 +154,9 @@ type OpenStackDataPlaneNodeSetStatus struct {
 
 	// DeployedVersion
 	DeployedVersion string `json:"deployedVersion,omitempty"`
+
+	//DeployedBmhHash - Hash of BMHs deployed
+	DeployedBmhHash string `json:"deployedBmhHash,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/bindata/crds/crds.yaml
+++ b/bindata/crds/crds.yaml
@@ -18127,6 +18127,8 @@ spec:
                 type: object
               ctlplaneSearchDomain:
                 type: string
+              deployedBmhHash:
+                type: string
               deployedConfigHash:
                 type: string
               deployedVersion:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -937,6 +937,8 @@ spec:
                 type: object
               ctlplaneSearchDomain:
                 type: string
+              deployedBmhHash:
+                type: string
               deployedConfigHash:
                 type: string
               deployedVersion:


### PR DESCRIPTION
This would happen when a faulty node has been replaced by deleting the BMH, openstack-baremetal-operator would provision a new node from the available BMHs. We also need to tell the user that they have to create a new deployment for the node to be deployed.

Note: Cleaning up the deleted nodes from the services is still a manual process.

jira: https://issues.redhat.com/browse/OSPRH-13948