### PR TITLE
[OSPRH-13960] Fix OpenStack CR condition initialization

### DIFF
--- a/controllers/operator/openstack_controller.go
+++ b/controllers/operator/openstack_controller.go
@@ -189,11 +189,6 @@ func (r *OpenStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}()
 
-	// If we're not deleting this and the object doesn't have our finalizer, add it.
-	if instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, openstackHelper.GetFinalizer()) || isNewInstance {
-		return ctrl.Result{}, err
-	}
-
 	cl := condition.CreateList(
 		condition.UnknownCondition(operatorv1beta1.OpenStackOperatorReadyCondition, condition.InitReason, string(operatorv1beta1.OpenStackOperatorReadyInitMessage)),
 	)
@@ -205,6 +200,11 @@ func (r *OpenStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		condition.RequestedReason,
 		condition.SeverityInfo,
 		operatorv1beta1.OpenStackOperatorReadyRunningMessage))
+
+	// If we're not deleting this and the object doesn't have our finalizer, add it.
+	if instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, openstackHelper.GetFinalizer()) || isNewInstance {
+		return ctrl.Result{}, err
+	}
 
 	// We only want one instance of OpenStack. Ignore anything after that.
 	if len(instanceList.Items) > 0 {


### PR DESCRIPTION
When a new `OpenStack` CR is created and enters its first reconcile loop, it kicks out after adding the finalizer [1] and improperly sets the `Ready` condition to true [2] because there are no sub-conditions to consider (and the default is to consider the conditions "ready" if there are no other conditions).  We need to therefore make sure we first initialize the conditions before setting the finalizer so that the `Ready` condition is properly assessed.

Jira: https://issues.redhat.com/browse/OSPRH-13960

[1] https://github.com/openstack-k8s-operators/openstack-operator/blob/b419ca790f9fdfd103347978761ef4728791e898/controllers/operator/openstack_controller.go#L192-L195
[2] https://github.com/openstack-k8s-operators/openstack-operator/blob/b419ca790f9fdfd103347978761ef4728791e898/controllers/operator/openstack_controller.go#L170-L172