### PR TITLE
[OSPRH-13961] Remove the creation of the external Prometheus route

### DIFF
--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -205,7 +205,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 			return ctrlResult, nil
 		}
 		// update TLS settings with cert secret
-		instance.Spec.Telemetry.Template.MetricStorage.PrometheusTLS.SecretName = endpointDetails.GetEndptCertSecret(service.EndpointPublic)
+		instance.Spec.Telemetry.Template.MetricStorage.PrometheusTLS.SecretName = endpointDetails.GetEndptCertSecret(service.EndpointInternal)
 
 		// TODO: rewrite this once we have TLS on alertmanager
 		for _, alertmanagerSvc := range alertmanagerSvcs.Items {


### PR DESCRIPTION
Prometheus will only be exposing an internal route from now on so it makes sense to use the Internal certificate for that.