### PR TITLE
Switch Nova to use *Core* spec

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -8790,8 +8790,6 @@ spec:
                     type: boolean
                   template:
                     properties:
-                      apiContainerImageURL:
-                        type: string
                       apiDatabaseAccount:
                         default: nova-api
                         type: string
@@ -9361,17 +9359,11 @@ spec:
                             cellMessageBusInstance: rabbitmq-cell1
                             hasAPIAccess: true
                         type: object
-                      computeContainerImageURL:
-                        type: string
-                      conductorContainerImageURL:
-                        type: string
                       keystoneInstance:
                         default: keystone
                         type: string
                       memcachedInstance:
                         default: memcached
-                        type: string
-                      metadataContainerImageURL:
                         type: string
                       metadataServiceTemplate:
                         default:
@@ -9497,8 +9489,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      novncproxyContainerImageURL:
-                        type: string
                       passwordSelectors:
                         default:
                           service: NovaPassword
@@ -9516,8 +9506,6 @@ spec:
                       preserveJobs:
                         default: false
                         type: boolean
-                      schedulerContainerImageURL:
-                        type: string
                       schedulerServiceTemplate:
                         default:
                           replicas: 1
@@ -9590,12 +9578,6 @@ spec:
                             type: string
                         type: object
                     required:
-                    - apiContainerImageURL
-                    - computeContainerImageURL
-                    - conductorContainerImageURL
-                    - metadataContainerImageURL
-                    - novncproxyContainerImageURL
-                    - schedulerContainerImageURL
                     - secret
                     type: object
                 type: object

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -564,7 +564,7 @@ type NovaSection struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// Template - Overrides to use when creating the Nova services
-	Template *novav1.NovaSpec `json:"template,omitempty"`
+	Template *novav1.NovaSpecCore `json:"template,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -418,7 +418,7 @@ func (r *OpenStackControlPlane) ValidateUpdateServices(old OpenStackControlPlane
 
 	if r.Spec.Nova.Enabled {
 		if old.Nova.Template == nil {
-			old.Nova.Template = &novav1.NovaSpec{}
+			old.Nova.Template = &novav1.NovaSpecCore{}
 		}
 		errors = append(errors, r.Spec.Nova.Template.ValidateUpdate(*old.Nova.Template, basePath.Child("nova").Child("template"), r.Namespace)...)
 		errors = append(errors, validateTLSOverrideSpec(&r.Spec.Nova.APIOverride.Route, basePath.Child("nova").Child("apiOverride").Child("route"))...)
@@ -836,7 +836,7 @@ func (r *OpenStackControlPlane) DefaultServices() {
 	// Nova
 	if r.Spec.Nova.Enabled || r.Spec.Nova.Template != nil {
 		if r.Spec.Nova.Template == nil {
-			r.Spec.Nova.Template = &novav1.NovaSpec{}
+			r.Spec.Nova.Template = &novav1.NovaSpecCore{}
 		}
 		r.Spec.Nova.Template.Default()
 	}

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1020,7 +1020,7 @@ func (in *NovaSection) DeepCopyInto(out *NovaSection) {
 	*out = *in
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template
-		*out = new(nova_operatorapiv1beta1.NovaSpec)
+		*out = new(nova_operatorapiv1beta1.NovaSpecCore)
 		(*in).DeepCopyInto(*out)
 	}
 	in.APIOverride.DeepCopyInto(&out.APIOverride)

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -8790,8 +8790,6 @@ spec:
                     type: boolean
                   template:
                     properties:
-                      apiContainerImageURL:
-                        type: string
                       apiDatabaseAccount:
                         default: nova-api
                         type: string
@@ -9361,17 +9359,11 @@ spec:
                             cellMessageBusInstance: rabbitmq-cell1
                             hasAPIAccess: true
                         type: object
-                      computeContainerImageURL:
-                        type: string
-                      conductorContainerImageURL:
-                        type: string
                       keystoneInstance:
                         default: keystone
                         type: string
                       memcachedInstance:
                         default: memcached
-                        type: string
-                      metadataContainerImageURL:
                         type: string
                       metadataServiceTemplate:
                         default:
@@ -9497,8 +9489,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      novncproxyContainerImageURL:
-                        type: string
                       passwordSelectors:
                         default:
                           service: NovaPassword
@@ -9516,8 +9506,6 @@ spec:
                       preserveJobs:
                         default: false
                         type: boolean
-                      schedulerContainerImageURL:
-                        type: string
                       schedulerServiceTemplate:
                         default:
                           replicas: 1
@@ -9590,12 +9578,6 @@ spec:
                             type: string
                         type: object
                     required:
-                    - apiContainerImageURL
-                    - computeContainerImageURL
-                    - conductorContainerImageURL
-                    - metadataContainerImageURL
-                    - novncproxyContainerImageURL
-                    - schedulerContainerImageURL
                     - secret
                     type: object
                 type: object

--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -65,7 +65,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 	}
 
 	if instance.Spec.Nova.Template == nil {
-		instance.Spec.Nova.Template = &novav1.NovaSpec{}
+		instance.Spec.Nova.Template = &novav1.NovaSpecCore{}
 	}
 
 	if instance.Spec.Nova.Template.NodeSelector == nil {
@@ -346,7 +346,7 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		// cell0 but cell0 should not have compute nodes registered. Eventually
 		// we need to support either rabbitmq vhosts or deploy a separate
 		// RabbitMQCluster per nova cell.
-		instance.Spec.Nova.Template.DeepCopyInto(&nova.Spec)
+		instance.Spec.Nova.Template.DeepCopyInto(&nova.Spec.NovaSpecCore)
 
 		nova.Spec.NovaImages.APIContainerImageURL = *version.Status.ContainerImages.NovaAPIImage
 		nova.Spec.NovaImages.NovaComputeContainerImageURL = *version.Status.ContainerImages.NovaComputeImage


### PR DESCRIPTION
These fields should have been dropped when the Nova *Core* spec was implemented.

Images get overwritten during reconcile to what exists in the openstackversion resource so there should be no user facing issues in dropping these fields.