### PR TITLE
Switch DNS to use *Core* spec

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -2390,8 +2390,6 @@ spec:
                     type: boolean
                   template:
                     properties:
-                      containerImage:
-                        type: string
                       dnsDataLabelSelectorValue:
                         default: dnsdata
                         type: string

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -345,7 +345,7 @@ type DNSMasqSection struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// Template - Overrides to use when creating the DNSMasq service
-	Template *networkv1.DNSMasqSpec `json:"template,omitempty"`
+	Template *networkv1.DNSMasqSpecCore `json:"template,omitempty"`
 }
 
 // KeystoneSection defines the desired state of Keystone service

--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -843,7 +843,7 @@ func (r *OpenStackControlPlane) DefaultServices() {
 	// DNS
 	if r.Spec.DNS.Enabled || r.Spec.DNS.Template != nil {
 		if r.Spec.DNS.Template == nil {
-			r.Spec.DNS.Template = &networkv1.DNSMasqSpec{}
+			r.Spec.DNS.Template = &networkv1.DNSMasqSpecCore{}
 		}
 
 		r.Spec.DNS.Template.Default()

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -734,7 +734,7 @@ func (in *DNSMasqSection) DeepCopyInto(out *DNSMasqSection) {
 	*out = *in
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template
-		*out = new(networkv1beta1.DNSMasqSpec)
+		*out = new(networkv1beta1.DNSMasqSpecCore)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -2390,8 +2390,6 @@ spec:
                     type: boolean
                   template:
                     properties:
-                      containerImage:
-                        type: string
                       dnsDataLabelSelectorValue:
                         default: dnsdata
                         type: string

--- a/pkg/openstack/dnsmasq.go
+++ b/pkg/openstack/dnsmasq.go
@@ -37,7 +37,7 @@ func ReconcileDNSMasqs(ctx context.Context, instance *corev1beta1.OpenStackContr
 	Log := GetLogger(ctx)
 
 	if instance.Spec.DNS.Template == nil {
-		instance.Spec.DNS.Template = &networkv1.DNSMasqSpec{}
+		instance.Spec.DNS.Template = &networkv1.DNSMasqSpecCore{}
 	}
 
 	if instance.Spec.DNS.Template.NodeSelector == nil {
@@ -46,7 +46,7 @@ func ReconcileDNSMasqs(ctx context.Context, instance *corev1beta1.OpenStackContr
 
 	Log.Info("Reconciling DNSMasq", "DNSMasq.Namespace", instance.Namespace, "DNSMasq.Name", "dnsmasq")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), dnsmasq, func() error {
-		instance.Spec.DNS.Template.DeepCopyInto(&dnsmasq.Spec)
+		instance.Spec.DNS.Template.DeepCopyInto(&dnsmasq.Spec.DNSMasqSpecCore)
 		dnsmasq.Spec.ContainerImage = *version.Status.ContainerImages.InfraDnsmasqImage
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), dnsmasq, helper.GetScheme())
 		if err != nil {


### PR DESCRIPTION
These fields should have been dropped when the DNS *Core* spec was implemented.

Images get overwritten during reconcile to what exists in the openstackversion resource so there should be no user facing issues in dropping these fields.

