### PR TITLE
Remove unnecessary NodeSet loop and dedicated NodeSet List logic

### DIFF
--- a/controllers/dataplane/openstackdataplanedeployment_controller.go
+++ b/controllers/dataplane/openstackdataplanedeployment_controller.go
@@ -149,44 +149,12 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 	}()
 
 	// Ensure NodeSets
-	nodeSets := dataplanev1.OpenStackDataPlaneNodeSetList{}
-	for _, nodeSet := range instance.Spec.NodeSets {
-
-		// Fetch the OpenStackDataPlaneNodeSet instance
-		nodeSetInstance := &dataplanev1.OpenStackDataPlaneNodeSet{}
-		err := r.Client.Get(
-			ctx,
-			types.NamespacedName{
-				Namespace: instance.GetNamespace(),
-				Name:      nodeSet,
-			},
-			nodeSetInstance)
-		if err != nil {
-			// NodeSet not found, force a requeue
-			if k8s_errors.IsNotFound(err) {
-				Log.Info("NodeSet not found", "NodeSet", nodeSet)
-				return ctrl.Result{RequeueAfter: time.Second * time.Duration(instance.Spec.DeploymentRequeueTime)}, nil
-			}
-			instance.Status.Conditions.MarkFalse(
-				dataplanev1.SetupReadyCondition,
-				condition.ErrorReason,
-				condition.SeverityError,
-				dataplanev1.DataPlaneNodeSetErrorMessage,
-				err.Error())
-			// Error reading the object - requeue the request.
-			return ctrl.Result{}, err
+	nodeSets, err := r.listNodeSets(ctx, &Log, instance)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			return ctrl.Result{RequeueAfter: time.Second * time.Duration(instance.Spec.DeploymentRequeueTime)}, nil
 		}
-		if err = nodeSetInstance.Spec.ValidateTLS(instance.GetNamespace(), r.Client, ctx); err != nil {
-			Log.Info("error while comparing TLS settings of nodeset %s with control plane: %w", nodeSet, err)
-			instance.Status.Conditions.MarkFalse(
-				dataplanev1.SetupReadyCondition,
-				condition.ErrorReason,
-				condition.SeverityError,
-				dataplanev1.DataPlaneNodeSetErrorMessage,
-				err.Error())
-			return ctrl.Result{}, err
-		}
-		nodeSets.Items = append(nodeSets.Items, *nodeSetInstance)
+		return ctrl.Result{}, err
 	}
 
 	globalInventorySecrets := map[string]string{}
@@ -384,7 +352,7 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 	if version != nil {
 		instance.Status.DeployedVersion = version.Spec.TargetVersion
 	}
-	err = r.setHashes(ctx, helper, instance, nodeSets)
+	err = r.setHashes(ctx, helper, instance, *nodeSets)
 	if err != nil {
 		Log.Error(err, "Error setting service hashes")
 	}
@@ -517,4 +485,39 @@ func (r *OpenStackDataPlaneDeploymentReconciler) SetupWithManager(mgr ctrl.Manag
 		Watches(&certmgrv1.Certificate{},
 			handler.EnqueueRequestsFromMapFunc(certFn)).
 		Complete(r)
+}
+
+func (r *OpenStackDataPlaneDeploymentReconciler) listNodeSets(ctx context.Context, Log *logr.Logger, instance *dataplanev1.OpenStackDataPlaneDeployment) (*dataplanev1.OpenStackDataPlaneNodeSetList, error) {
+
+	var nodeSets = dataplanev1.OpenStackDataPlaneNodeSetList{}
+	var err error
+
+	for _, nodeSet := range instance.Spec.NodeSets {
+
+		// Fetch the OpenStackDataPlaneNodeSet instance
+		nodeSetInstance := &dataplanev1.OpenStackDataPlaneNodeSet{}
+		err := r.Client.Get(
+			ctx,
+			types.NamespacedName{
+				Namespace: instance.GetNamespace(),
+				Name:      nodeSet,
+			},
+			nodeSetInstance)
+		if err != nil {
+			Log.Info("NodeSet not found", "NodeSet", nodeSet)
+			return &nodeSets, err
+		}
+		if err = nodeSetInstance.Spec.ValidateTLS(instance.GetNamespace(), r.Client, ctx); err != nil {
+			Log.Info("error while comparing TLS settings of nodeset %s with control plane: %w", nodeSet, err)
+			instance.Status.Conditions.MarkFalse(
+				dataplanev1.SetupReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityError,
+				dataplanev1.DataPlaneNodeSetErrorMessage,
+				err.Error())
+			return &nodeSets, err
+		}
+		nodeSets.Items = append(nodeSets.Items, *nodeSetInstance)
+	}
+	return &nodeSets, err
 }


### PR DESCRIPTION
This change removes an unnecessary loop over the NodeSets and moves the logic that gets that list of node sets to a dedicated method to tidy up the reconciler logic.