### PR TITLE
Add omitempty for ansibleUser

### DIFF
--- a/apis/dataplane/v1beta1/common.go
+++ b/apis/dataplane/v1beta1/common.go
@@ -79,7 +79,7 @@ type DataSource struct {
 type AnsibleOpts struct {
 	// AnsibleUser SSH user for Ansible connection
 	// +kubebuilder:validation:Optional
-	AnsibleUser string `json:"ansibleUser"`
+	AnsibleUser string `json:"ansibleUser,omitempty"`
 
 	// AnsibleHost SSH host for Ansible connection
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
ansibleUser can be provided either in the NodeSection or NodeTemplate. This shows as empty string in the CR if not provided which is confusing.