### PR TITLE
[bindata] add retry to skopeo copy

### DIFF
--- a/hack/sync-bindata.sh
+++ b/hack/sync-bindata.sh
@@ -142,7 +142,13 @@ EOF_CAT
 }
 
 for BUNDLE in $(hack/pin-bundle-images.sh | tr "," " "); do
-    skopeo copy "docker://$BUNDLE" dir:${EXTRACT_DIR}/tmp;
+    n=0
+    until [ "$n" -ge 5 ]; do
+        skopeo copy "docker://$BUNDLE" dir:${EXTRACT_DIR}/tmp && break
+        echo "Command failed. retrying ... $n/5"
+        n=$((n+1))
+        sleep 15
+    done
     extract_bundle "${EXTRACT_DIR}/tmp" "${OUT_DATA}/"
 done
 


### PR DESCRIPTION
In renovate in happened that there was some hickup in communication to the quay registry, but from checking there was no real issue.

```
skopeo copy docker://quay.io/openstack-k8s-operators/neutron-operator-bundle:61f1f61311e3bfa1c4fee2ceeda54e1891cc910a dir:tmp/bindata/tmp
time=\"2025-02-26T10:25:07Z\" level=fatal msg=\"initializing source docker://quay.io/openstack-k8s-operators/neutron-operator-bundle:61f1f61311e3bfa1c4fee2ceeda54e1891cc910a: can't talk to a V1 container registry\"
make: *** [Makefile:158: bindata] Error 1" 
```
This adds a retry with max 5/sleep 15 to retry the skopeo copy command.