### PR TITLE
Consume a top-level TopologyRef

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17413,6 +17413,13 @@ spec:
                         type: object
                     type: object
                 type: object
+              topologyRef:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
             required:
             - secret
             - storageClass

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -30,6 +30,7 @@ import (
 	memcachedv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	networkv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	redisv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/redis/v1beta1"
+	topologyv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	ironic_operatorapiv1beta1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	apiv1beta1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
@@ -1166,6 +1167,11 @@ func (in *OpenStackControlPlaneSpec) DeepCopyInto(out *OpenStackControlPlaneSpec
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.TopologyRef != nil {
+		in, out := &in.TopologyRef, &out.TopologyRef
+		*out = new(topologyv1beta1.TopoRef)
+		**out = **in
 	}
 }
 

--- a/bindata/crds/crds.yaml
+++ b/bindata/crds/crds.yaml
@@ -17577,6 +17577,13 @@ spec:
                         type: object
                     type: object
                 type: object
+              topologyRef:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
             required:
             - secret
             - storageClass

--- a/bindata/rbac/rbac.yaml
+++ b/bindata/rbac/rbac.yaml
@@ -871,6 +871,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - topology.openstack.org
+  resources:
+  - topologies
+  verbs:
+  - get
+  - list
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -17413,6 +17413,13 @@ spec:
                         type: object
                     type: object
                 type: object
+              topologyRef:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
             required:
             - secret
             - storageClass

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -828,3 +828,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - topology.openstack.org
+  resources:
+  - topologies
+  verbs:
+  - get
+  - list
+  - update
+  - watch

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	networkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
 	redisv1 "github.com/openstack-k8s-operators/infra-operator/apis/redis/v1beta1"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	manilav1 "github.com/openstack-k8s-operators/manila-operator/api/v1beta1"
@@ -129,6 +130,7 @@ func init() {
 	utilruntime.Must(machineconfig.AddToScheme(scheme))
 	utilruntime.Must(k8s_networkv1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1beta1.AddToScheme(scheme))
+	utilruntime.Must(topologyv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/pkg/openstack/barbican.go
+++ b/pkg/openstack/barbican.go
@@ -106,6 +106,14 @@ func ReconcileBarbican(ctx context.Context, instance *corev1beta1.OpenStackContr
 		instance.Spec.Barbican.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Barbican.Template.TopologyRef == nil {
+		instance.Spec.Barbican.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	helper.GetLogger().Info("Reconciling Barbican", "Barbican.Namespace", instance.Namespace, "Barbican.Name", "barbican")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), barbican, func() error {
 		instance.Spec.Barbican.Template.BarbicanSpecBase.DeepCopyInto(&barbican.Spec.BarbicanSpecBase)

--- a/pkg/openstack/cinder.go
+++ b/pkg/openstack/cinder.go
@@ -122,6 +122,14 @@ func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControl
 		instance.Spec.Cinder.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Cinder.Template.TopologyRef == nil {
+		instance.Spec.Cinder.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	Log.Info("Reconciling Cinder", "Cinder.Namespace", instance.Namespace, "Cinder.Name", cinderName)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), cinder, func() error {
 		instance.Spec.Cinder.Template.CinderSpecBase.DeepCopyInto(&cinder.Spec.CinderSpecBase)

--- a/pkg/openstack/designate.go
+++ b/pkg/openstack/designate.go
@@ -114,6 +114,14 @@ func ReconcileDesignate(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Spec.Designate.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Designate.Template.TopologyRef == nil {
+		instance.Spec.Designate.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	helper.GetLogger().Info("Reconciling Designate", "Designate.Namespace", instance.Namespace, "Designate.Name", "designate")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), designate, func() error {
 		// FIXME: the designate structs need some rework (images should be at the top level, not in the sub structs)

--- a/pkg/openstack/dnsmasq.go
+++ b/pkg/openstack/dnsmasq.go
@@ -44,6 +44,14 @@ func ReconcileDNSMasqs(ctx context.Context, instance *corev1beta1.OpenStackContr
 		instance.Spec.DNS.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.DNS.Template.TopologyRef == nil {
+		instance.Spec.DNS.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	Log.Info("Reconciling DNSMasq", "DNSMasq.Namespace", instance.Namespace, "DNSMasq.Name", "dnsmasq")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), dnsmasq, func() error {
 		instance.Spec.DNS.Template.DeepCopyInto(&dnsmasq.Spec.DNSMasqSpecCore)

--- a/pkg/openstack/galera.go
+++ b/pkg/openstack/galera.go
@@ -174,6 +174,14 @@ func reconcileGalera(
 		spec.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if spec.TopologyRef == nil {
+		spec.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	Log.Info("Reconciling Galera", "Galera.Namespace", instance.Namespace, "Galera.Name", name)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), galera, func() error {
 		spec.DeepCopyInto(&galera.Spec.GaleraSpecCore)

--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -66,6 +66,14 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		instance.Spec.Glance.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Glance.Template.TopologyRef == nil {
+		instance.Spec.Glance.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	// When component services got created check if there is the need to create a route
 	if err := helper.GetClient().Get(ctx, types.NamespacedName{Name: glanceName, Namespace: instance.Namespace}, glance); err != nil {
 		if !k8s_errors.IsNotFound(err) {

--- a/pkg/openstack/heat.go
+++ b/pkg/openstack/heat.go
@@ -51,6 +51,14 @@ func ReconcileHeat(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		instance.Spec.Heat.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Heat.Template.TopologyRef == nil {
+		instance.Spec.Heat.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	// add selector to service overrides
 	for _, endpointType := range []service.Endpoint{service.EndpointPublic, service.EndpointInternal} {
 		if instance.Spec.Heat.Template.HeatAPI.Override.Service == nil {

--- a/pkg/openstack/horizon.go
+++ b/pkg/openstack/horizon.go
@@ -54,6 +54,14 @@ func ReconcileHorizon(ctx context.Context, instance *corev1beta1.OpenStackContro
 		instance.Spec.Horizon.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Horizon.Template.TopologyRef == nil {
+		instance.Spec.Horizon.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	// add selector to service overrides
 	serviceOverrides := map[service.Endpoint]service.RoutedOverrideSpec{}
 	if instance.Spec.Horizon.Template.Override.Service != nil {

--- a/pkg/openstack/ironic.go
+++ b/pkg/openstack/ironic.go
@@ -51,6 +51,14 @@ func ReconcileIronic(ctx context.Context, instance *corev1beta1.OpenStackControl
 		instance.Spec.Ironic.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Ironic.Template.TopologyRef == nil {
+		instance.Spec.Ironic.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	// add selector to service overrides
 	for _, endpointType := range []service.Endpoint{service.EndpointPublic, service.EndpointInternal} {
 		if instance.Spec.Ironic.Template.IronicAPI.Override.Service == nil {

--- a/pkg/openstack/keystone.go
+++ b/pkg/openstack/keystone.go
@@ -107,6 +107,14 @@ func ReconcileKeystoneAPI(ctx context.Context, instance *corev1beta1.OpenStackCo
 		instance.Spec.Keystone.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Keystone.Template.TopologyRef == nil {
+		instance.Spec.Keystone.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	Log.Info("Reconciling KeystoneAPI", "KeystoneAPI.Namespace", instance.Namespace, "KeystoneAPI.Name", "keystone")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), keystoneAPI, func() error {
 		instance.Spec.Keystone.Template.DeepCopyInto(&keystoneAPI.Spec.KeystoneAPISpecCore)

--- a/pkg/openstack/manila.go
+++ b/pkg/openstack/manila.go
@@ -110,6 +110,14 @@ func ReconcileManila(ctx context.Context, instance *corev1beta1.OpenStackControl
 		instance.Spec.Manila.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// There's no Topology referenced in Manila Template, inject the top-level
+	// one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Manila.Template.TopologyRef == nil {
+		instance.Spec.Manila.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	Log.Info("Reconciling Manila", "Manila.Namespace", instance.Namespace, "Manila.Name", "manila")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), manila, func() error {
 		instance.Spec.Manila.Template.ManilaSpecBase.DeepCopyInto(&manila.Spec.ManilaSpecBase)

--- a/pkg/openstack/memcached.go
+++ b/pkg/openstack/memcached.go
@@ -245,6 +245,14 @@ func reconcileMemcached(
 		spec.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if spec.TopologyRef == nil {
+		spec.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), memcached, func() error {
 		spec.DeepCopyInto(&memcached.Spec.MemcachedSpecCore)
 

--- a/pkg/openstack/neutron.go
+++ b/pkg/openstack/neutron.go
@@ -147,6 +147,14 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 		instance.Spec.Neutron.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Neutron.Template.TopologyRef == nil {
+		instance.Spec.Neutron.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	Log.Info("Reconciling NeutronAPI", "NeutronAPI.Namespace", instance.Namespace, "NeutronAPI.Name", "neutron")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), neutronAPI, func() error {
 		instance.Spec.Neutron.Template.DeepCopyInto(&neutronAPI.Spec.NeutronAPISpecCore)

--- a/pkg/openstack/nova.go
+++ b/pkg/openstack/nova.go
@@ -72,6 +72,14 @@ func ReconcileNova(ctx context.Context, instance *corev1beta1.OpenStackControlPl
 		instance.Spec.Nova.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Nova.Template.TopologyRef == nil {
+		instance.Spec.Nova.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	// When component services got created check if there is the need to create routes and certificates
 	if err := helper.GetClient().Get(ctx, types.NamespacedName{Name: "nova", Namespace: instance.Namespace}, nova); err != nil {
 		if !k8s_errors.IsNotFound(err) {

--- a/pkg/openstack/octavia.go
+++ b/pkg/openstack/octavia.go
@@ -70,6 +70,14 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 		instance.Spec.Octavia.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Octavia.Template.TopologyRef == nil {
+		instance.Spec.Octavia.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	// add selector to service overrides
 	for _, endpointType := range []service.Endpoint{service.EndpointPublic, service.EndpointInternal} {
 		if instance.Spec.Octavia.Template.OctaviaAPI.Override.Service == nil {

--- a/pkg/openstack/ovn.go
+++ b/pkg/openstack/ovn.go
@@ -148,6 +148,14 @@ func ReconcileOVNDbClusters(ctx context.Context, instance *corev1beta1.OpenStack
 			dbcluster.NodeSelector = &instance.Spec.NodeSelector
 		}
 
+		// When there's no Topology referenced in the Service Template, inject the
+		// top-level one
+		// NOTE: This does not check the Service subCRs: by default the generated
+		// subCRs inherit the top-level TopologyRef unless an override is present
+		if dbcluster.TopologyRef == nil {
+			dbcluster.TopologyRef = instance.Spec.TopologyRef
+		}
+
 		Log.Info("Reconciling OVNDBCluster", "OVNDBCluster.Namespace", instance.Namespace, "OVNDBCluster.Name", name)
 		op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), OVNDBCluster, func() error {
 
@@ -262,6 +270,14 @@ func ReconcileOVNNorthd(ctx context.Context, instance *corev1beta1.OpenStackCont
 
 	if ovnNorthdSpec.NodeSelector == nil {
 		ovnNorthdSpec.NodeSelector = &instance.Spec.NodeSelector
+	}
+
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if ovnNorthdSpec.TopologyRef == nil {
+		ovnNorthdSpec.TopologyRef = instance.Spec.TopologyRef
 	}
 
 	Log.Info("Reconciling OVNNorthd", "OVNNorthd.Namespace", instance.Namespace, "OVNNorthd.Name", "ovnnorthd")
@@ -385,6 +401,14 @@ func ReconcileOVNController(ctx context.Context, instance *corev1beta1.OpenStack
 
 	if ovnControllerSpec.NodeSelector == nil {
 		ovnControllerSpec.NodeSelector = &instance.Spec.NodeSelector
+	}
+
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if ovnControllerSpec.TopologyRef == nil {
+		ovnControllerSpec.TopologyRef = instance.Spec.TopologyRef
 	}
 
 	Log.Info("Reconciling OVNController", "OVNController.Namespace", instance.Namespace, "OVNController.Name", "ovncontroller")

--- a/pkg/openstack/placement.go
+++ b/pkg/openstack/placement.go
@@ -45,6 +45,14 @@ func ReconcilePlacementAPI(ctx context.Context, instance *corev1beta1.OpenStackC
 		instance.Spec.Placement.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Placement.Template.TopologyRef == nil {
+		instance.Spec.Placement.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	// add selector to service overrides
 	for _, endpointType := range []service.Endpoint{service.EndpointPublic, service.EndpointInternal} {
 		if instance.Spec.Placement.Template.Override.Service == nil {

--- a/pkg/openstack/redis.go
+++ b/pkg/openstack/redis.go
@@ -225,6 +225,14 @@ func reconcileRedis(
 		spec.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if spec.TopologyRef == nil {
+		spec.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), redis, func() error {
 		spec.DeepCopyInto(&redis.Spec.RedisSpecCore)
 		if tlsCert != "" {

--- a/pkg/openstack/swift.go
+++ b/pkg/openstack/swift.go
@@ -50,6 +50,14 @@ func ReconcileSwift(ctx context.Context, instance *corev1beta1.OpenStackControlP
 		instance.Spec.Swift.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Swift.Template.TopologyRef == nil {
+		instance.Spec.Swift.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	// add selector to service overrides
 	for _, endpointType := range []service.Endpoint{service.EndpointPublic, service.EndpointInternal} {
 		if instance.Spec.Swift.Template.SwiftProxy.Override.Service == nil {

--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -63,6 +63,14 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Spec.Telemetry.Template.NodeSelector = &instance.Spec.NodeSelector
 	}
 
+	// When there's no Topology referenced in the Service Template, inject the
+	// top-level one
+	// NOTE: This does not check the Service subCRs: by default the generated
+	// subCRs inherit the top-level TopologyRef unless an override is present
+	if instance.Spec.Telemetry.Template.TopologyRef == nil {
+		instance.Spec.Telemetry.Template.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	if err := helper.GetClient().Get(ctx, types.NamespacedName{Name: "telemetry", Namespace: instance.Namespace}, telemetry); err != nil {
 		if !k8s_errors.IsNotFound(err) {
 			return ctrl.Result{}, err

--- a/tests/functional/ctlplane/suite_test.go
+++ b/tests/functional/ctlplane/suite_test.go
@@ -62,6 +62,7 @@ import (
 
 	ocp_configv1 "github.com/openshift/api/config/v1"
 	infra_test "github.com/openstack-k8s-operators/infra-operator/apis/test/helpers"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	keystone_test "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	certmanager_test "github.com/openstack-k8s-operators/lib-common/modules/certmanager/test/helpers"
 	common_test "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
@@ -273,6 +274,8 @@ var _ = BeforeSuite(func() {
 	err = networkv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = ocp_configv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = topologyv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme


### PR DESCRIPTION
In the general use case, where there are no hard constraints to the services deployed by the openstack-operator, we might want to reference `TopologyRef` only once, and not override it ~20 times with the same value in the CR.
Because we have default `labelSelectors`, creating a Topology like the following:

```
apiVersion: v1
items:
- apiVersion: topology.openstack.org/v1beta1
  kind: Topology
...
  spec:
    topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: topology.kubernetes.io/hostname
      whenUnsatisfiable: ScheduleAnyway

```

might be a good example where each service applies its own label selector.
This patch adds the `TopoRef` parameter at the openstack-operator top-level, so that updating the spec like the following:

```
apiVersion: core.openstack.org/v1beta1
kind: OpenStackControlPlane
...
spec:
  topologyRef:
     name: foo
  barbican:
  cinder:
  ....
 ````
 applies the `foo` spec to the underlying services unless an override is present.
 By doing this we can define the basic scenario without asking to repeat the same parameter multiple times.