### PR TITLE
Renovate: add hack/export_operator_related_images.sh to fileFilter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   ],
   "postUpgradeTasks": {
     "commands": ["make gowork", "make tidy", "make manifests generate", "make bindata"],
-    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
+    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml", "hack/*.sh"],
     "executionMode": "update"
   }
 }


### PR DESCRIPTION
The hack export_operator_related_images.sh is auto generated and needs to be added to the fileFilter in order for it to get picked up.