### PR TITLE
drop use of RELATED_IMAGES some test-operator IMGs

### DIFF
--- a/config/operator/default_images.yaml
+++ b/config/operator/default_images.yaml
@@ -181,11 +181,12 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-swift-proxy-server:current-podified
         - name: RELATED_IMAGE_TEST_TEMPEST_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-tempest-all:current-podified
-        - name: RELATED_IMAGE_TEST_TOBIKO_IMAGE_URL_DEFAULT
+          # NOTE: TEST_ images below do not get released downstream. They should not be prefixed with RELATED
+        - name: TEST_TOBIKO_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
-        - name: RELATED_IMAGE_TEST_ANSIBLETEST_IMAGE_URL_DEFAULT
+        - name: TEST_ANSIBLETEST_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ansible-tests:current-podified
-        - name: RELATED_IMAGE_TEST_HORIZONTEST_IMAGE_URL_DEFAULT
+        - name: TEST_HORIZONTEST_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-horizontest:current-podified
         - name: RELATED_IMAGE_OPENSTACK_MUST_GATHER_DEFAULT
           value: quay.io/openstack-k8s-operators/openstack-must-gather:latest

--- a/controllers/core/openstackversion_controller.go
+++ b/controllers/core/openstackversion_controller.go
@@ -55,6 +55,10 @@ func SetupVersionDefaults() {
 		if strings.HasPrefix(envArr[0], "RELATED_IMAGE_") {
 			localVars[envArr[0]] = &envArr[1]
 		}
+		// we have some TEST_ env vars which specify images that aren't released downstream
+		if strings.HasPrefix(envArr[0], "TEST_") {
+			localVars[envArr[0]] = &envArr[1]
+		}
 	}
 	envAvailableVersion = corev1beta1.GetOpenStackReleaseVersion(os.Environ())
 	envContainerImages = localVars

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -87,7 +87,8 @@ export RELATED_IMAGE_EDPM_OPENSTACK_NETWORK_EXPORTER_IMAGE_URL_DEFAULT=quay.io/o
 export RELATED_IMAGE_EDPM_KEPLER_IMAGE_URL_DEFAULT=quay.io/sustainable_computing_io/kepler:release-0.7.12
 export RELATED_IMAGE_EDPM_PODMAN_EXPORTER_IMAGE_URL_DEFAULT=quay.io/navidys/prometheus-podman-exporter:v1.10.1
 export RELATED_IMAGE_TEST_TEMPEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-tempest-all:current-podified
-export RELATED_IMAGE_TEST_TOBIKO_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
-export RELATED_IMAGE_TEST_ANSIBLETEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ansible-tests:current-podified
-export RELATED_IMAGE_TEST_HORIZONTEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-horizontest:current-podified
+#NOTE: TEST_ images below do not get released downstream. They should not be prefixed with RELATED
+export TEST_TOBIKO_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
+export TEST_ANSIBLETEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ansible-tests:current-podified
+export TEST_HORIZONTEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-horizontest:current-podified
 export RELATED_IMAGE_OPENSTACK_MUST_GATHER_DEFAULT=quay.io/openstack-k8s-operators/openstack-must-gather:latest

--- a/pkg/openstack/version.go
+++ b/pkg/openstack/version.go
@@ -60,6 +60,17 @@ func InitializeOpenStackVersionImageDefaults(ctx context.Context, envImages map[
 	if envImages["RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT"] != nil {
 		defaults.InfraDnsmasqImage = envImages["RELATED_IMAGE_NEUTRON_API_IMAGE_URL_DEFAULT"]
 	}
+	// custom TEST_ images which aren't released downstream
+	if envImages["TEST_TOBIKO_IMAGE_URL_DEFAULT"] != nil {
+		defaults.TestTobikoImage = envImages["TEST_TOBIKO_IMAGE_URL_DEFAULT"]
+	}
+	if envImages["TEST_ANSIBLETEST_IMAGE_URL_DEFAULT"] != nil {
+		defaults.TestAnsibletestImage = envImages["TEST_ANSIBLETEST_IMAGE_URL_DEFAULT"]
+	}
+	if envImages["TEST_HORIZONTEST_IMAGE_URL_DEFAULT"] != nil {
+		defaults.TestHorizontestImage = envImages["TEST_HORIZONTEST_IMAGE_URL_DEFAULT"]
+	}
+
 	Log.Info("Initialize OpenStackVersion return defaults")
 	return defaults
 

--- a/tests/functional/ctlplane/openstackversion_controller_test.go
+++ b/tests/functional/ctlplane/openstackversion_controller_test.go
@@ -183,6 +183,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(version.Status.ContainerImages.SwiftContainerImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.SwiftObjectImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.SwiftProxyImage).ShouldNot(BeNil())
+				g.Expect(version.Status.ContainerImages.TestTempestImage).ShouldNot(BeNil())
+				g.Expect(version.Status.ContainerImages.TestTobikoImage).ShouldNot(BeNil())
+				g.Expect(version.Status.ContainerImages.TestHorizontestImage).ShouldNot(BeNil())
+				g.Expect(version.Status.ContainerImages.TestAnsibletestImage).ShouldNot(BeNil())
 
 			}, timeout, interval).Should(Succeed())
 		})


### PR DESCRIPTION
Drop use of the RELATED_IMAGES env naming convention for test-operator images that we do not release
downstream and instead just use normal Env variables. This should resolve bundle validation issues with
these related images not existing...

The normal ENV variables can be used upstream for
tests.

Jira: OSPRH-14450