### PR TITLE
More zuul and generate JUnitXML reports for KUTTL

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -6,9 +6,6 @@
 # ASSUMPTIONS:
 #
 # 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
-#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
-#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
-#    - chmod 755 /usr/local/bin/kubectl-kuttl
 # 2. An OCP 4.10+ CRC cluster with Podified Operators has been deployed
 # 3. CLI user has access to $KUBECONFIG
 # 4. The environment variable INSTALL_YAMLS is set to the the path of the
@@ -32,8 +29,9 @@ commands:
       -n openstack-kuttl-tests \
       -o yaml | \
       oc apply -f -
-reportFormat: JSON
-reportName: kuttl-test-openstack
+reportFormat: xml
+reportName: kuttl-report-openstack
+reportGranularity: test
 namespace: openstack-kuttl-tests
 timeout: 1380
 parallel: 1

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -8,6 +8,26 @@
       doc_available: false
 
 - job:
+    name: openstack-operator-kuttl
+    parent: cifmw-base-multinode-kuttl
+    dependencies: ["openstack-k8s-operators-content-provider"]
+    attempts: 1
+    required-projects:
+      - github.com/openstack-k8s-operators/openstack-operator
+    irrelevant-files:
+      - .*/*.md
+      - ^\..*$
+      - ^LICENSE$
+      - ^OWNERS$
+      - ^OWNERS_ALIASES$
+      - ^PROJECT$
+      - ^README.md$
+      - tests?\/functional
+    vars:
+      cifmw_kuttl_tests_operator_list:
+        - openstack
+
+- job:
     name: openstack-operator-tempest-multinode
     parent: podified-multinode-edpm-deployment-crc-3comp
     dependencies: ["openstack-k8s-operators-content-provider"]

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,3 +8,5 @@
       jobs:
         - openstack-operator-tempest-multinode
         - openstack-operator-docs-preview
+        - openstack-operator-kuttl:
+            voting: false


### PR DESCRIPTION
Add KUTTL zuul job (meant to replace the prow one in the long term)

KUTTL: generate JUnitXML reports
- switch the type to XML (the accepted value is 'xml' lowercase, not uppercase);
- tune the name a bit to highlight it is a report;
- add the new reportGranularity parameter which is supported by kuttl 0.20.0 and will restore the pre-1.17 JUnitXML format (granularity by test case, instead of by step).
- remove the URL of kuttl, so that it is not tied to a specific release.
