### PR TITLE
[kuttl] remove job CR conditions due to change with 4.18

### DIFF
--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -169,9 +169,6 @@ spec:
             path: inventory-0
           secretName: dataplanenodeset-edpm-compute-global
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   succeeded: 1
   uncountedTerminatedPods: {}
 ---
@@ -268,9 +265,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-global
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
@@ -369,14 +363,10 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-global
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
   uncountedTerminatedPods: {}
-
 ---
 apiVersion: batch/v1
 kind: Job
@@ -471,14 +461,10 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-global
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
   uncountedTerminatedPods: {}
-
 ---
 apiVersion: batch/v1
 kind: Job
@@ -573,14 +559,10 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-global
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
   uncountedTerminatedPods: {}
-
 ---
 apiVersion: batch/v1
 kind: Job
@@ -675,14 +657,10 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-global
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
   uncountedTerminatedPods: {}
-
 ---
 apiVersion: batch/v1
 kind: Job

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
@@ -164,9 +164,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-beta-nodeset
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
@@ -264,9 +261,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-beta-nodeset
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
@@ -225,9 +225,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-openstack-edpm-tls
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   succeeded: 1
   uncountedTerminatedPods: {}
 ---
@@ -329,8 +326,5 @@ spec:
             path: inventory
           secretName: dataplanenodeset-openstack-edpm-tls
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   succeeded: 1
   uncountedTerminatedPods: {}

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -160,9 +160,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-no-nodes
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
@@ -262,9 +259,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-no-nodes
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
@@ -365,9 +359,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-no-nodes
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
@@ -468,9 +459,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-no-nodes
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
@@ -571,9 +559,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-no-nodes
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
@@ -103,9 +103,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-no-nodes
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -172,9 +172,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-no-nodes
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
@@ -163,9 +163,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-beta-nodeset
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
@@ -266,9 +263,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-edpm-compute-beta-nodeset
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -262,9 +262,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-openstack-edpm-tls
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
@@ -371,9 +368,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-openstack-edpm-tls
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -241,9 +241,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-openstack-edpm-tls
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0
@@ -349,9 +346,6 @@ spec:
             path: inventory
           secretName: dataplanenodeset-openstack-edpm-tls
 status:
-  conditions:
-  - status: "True"
-    type: Complete
   ready: 0
   succeeded: 1
   terminating: 0


### PR DESCRIPTION
With OCP 4.16 a successful finished job status condition only has a single Complete condition type in the condition list, e.g.:

~~~
status:
  completionTime: "2025-03-12T07:59:15Z"
  conditions:
  - lastProbeTime: "2025-03-12T07:59:15Z"
    lastTransitionTime: "2025-03-12T07:59:15Z"
    status: "True"
    type: Complete
  ready: 0
  startTime: "2025-03-12T07:59:09Z"
  succeeded: 1
  terminating: 0
  uncountedTerminatedPods: {}
~~~

Starting with OCP 4.18 there is another condition, CompletionsReached`, e.g.:

~~~
status:
  completionTime: "2025-03-11T17:37:14Z"
  conditions:
  - lastProbeTime: "2025-03-11T17:37:14Z"
    lastTransitionTime: "2025-03-11T17:37:14Z"
    message: Reached expected number of succeeded pods
    reason: CompletionsReached
    status: "True"
    type: SuccessCriteriaMet
  - lastProbeTime: "2025-03-11T17:37:14Z"
    lastTransitionTime: "2025-03-11T17:37:14Z"
    message: Reached expected number of succeeded pods
    reason: CompletionsReached
    status: "True"
    type: Complete
  ready: 0
  startTime: "2025-03-11T17:37:07Z"
  succeeded: 1
  terminating: 0
  uncountedTerminatedPods: {}
~~~

As a result switching to OCP 4.18 make the dataplane kuttl tests to fail because kuttl can not validate a single entry from a list.

~~~
         status:
        +  completionTime: "2025-03-11T19:02:07Z"
           conditions:
        -  - status: "True"
        +  - lastProbeTime: "2025-03-11T19:02:07Z"
        +    lastTransitionTime: "2025-03-11T19:02:07Z"
        +    message: Reached expected number of succeeded pods
        +    reason: CompletionsReached
        +    status: "True"
        +    type: SuccessCriteriaMet
        +  - lastProbeTime: "2025-03-11T19:02:07Z"
        +    lastTransitionTime: "2025-03-11T19:02:07Z"
        +    message: Reached expected number of succeeded pods
        +    reason: CompletionsReached
        +    status: "True"
             type: Complete
           ready: 0
        +  startTime: "2025-03-11T19:02:02Z"
           succeeded: 1
           terminating: 0
           uncountedTerminatedPods: {}

    case.go:380: resource Job:openstack-kuttl-tests/configure-os-edpm-compute-global-edpm-compute-global: .status.conditions: slice length mismatch: 1 != 2
~~~

This PR removes the conditions on the job asserts since the succeeded:1 should be enough to validate that the job ran successful.