### PR TITLE
Add edpmServiceType in all bundled dataplane service CRs

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
@@ -4,3 +4,4 @@ metadata:
   name: bootstrap
 spec:
   playbook: osp.edpm.bootstrap
+  edpmServiceType: bootstrap

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_client.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_client.yaml
@@ -4,3 +4,4 @@ metadata:
   name: ceph-client
 spec:
   playbook: osp.edpm.ceph_client
+  edpmServiceType: ceph-client

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ceph_hci_pre.yaml
@@ -4,3 +4,4 @@ metadata:
   name: ceph-hci-pre
 spec:
   playbook: osp.edpm.ceph_hci_pre
+  edpmServiceType: ceph-hci-pre

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_network.yaml
@@ -4,3 +4,4 @@ metadata:
   name: configure-network
 spec:
   playbook: osp.edpm.configure_network
+  edpmServiceType: configure-network

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_os.yaml
@@ -4,3 +4,4 @@ metadata:
   name: configure-os
 spec:
   playbook: osp.edpm.configure_os
+  edpmServiceType: configure-os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovs_dpdk.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_configure_ovs_dpdk.yaml
@@ -4,3 +4,4 @@ metadata:
   name: configure-ovs-dpdk
 spec:
   playbook: osp.edpm.configure_ovs_dpdk
+  edpmServiceType: configure-ovs-dpdk

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ddp_package_option.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ddp_package_option.yaml
@@ -4,3 +4,4 @@ metadata:
   name: ddp-package-option
 spec:
   playbook: osp.edpm.select_kernel_ddp_package
+  edpmServiceType: ddp-package-option

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_derive_pci_devicespec.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_derive_pci_devicespec.yaml
@@ -4,3 +4,4 @@ metadata:
   name: derive-pci-devicespec
 spec:
   playbook: osp.edpm.sriov_derive_device_spec
+  edpmServiceType: derive-pci-devicespec

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_download_cache.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_download_cache.yaml
@@ -4,3 +4,4 @@ metadata:
   name: download-cache
 spec:
   playbook: osp.edpm.download_cache
+  edpmServiceType: download-cache

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_fips_status.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_fips_status.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   label: fips-status
   playbook: osp.edpm.fips_status
+  edpmServiceType: fips-status

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_frr.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_frr.yaml
@@ -6,3 +6,4 @@ spec:
   playbook: osp.edpm.frr
   containerImageFields:
   - EdpmFrrImage
+  edpmServiceType: frr

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_certs.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_certs.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   playbook: osp.edpm.install_certs
   addCertMounts: True
+  edpmServiceType: install-certs

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_install_os.yaml
@@ -4,3 +4,4 @@ metadata:
   name: install-os
 spec:
   playbook: osp.edpm.install_os
+  edpmServiceType: install-os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_libvirt.yaml
@@ -23,3 +23,4 @@ spec:
         - client auth
       issuer: osp-rootca-issuer-libvirt
   caCerts: combined-ca-bundle
+  edpmServiceType: libvirt

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_logging.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_logging.yaml
@@ -7,3 +7,4 @@ spec:
     - secretRef:
         name: logging-compute-config-data
   playbook: osp.edpm.telemetry_logging
+  edpmServiceType: logging

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_dhcp.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_dhcp.yaml
@@ -10,3 +10,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmNeutronDhcpAgentImage
+  edpmServiceType: neutron-dhcp

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_metadata.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_metadata.yaml
@@ -24,3 +24,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmNeutronMetadataAgentImage
+  edpmServiceType: neutron-metadata

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_ovn.yaml
@@ -22,3 +22,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmNeutronOvnAgentImage
+  edpmServiceType: neutron-ovn

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_neutron_sriov.yaml
@@ -10,3 +10,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmNeutronSriovAgentImage
+  edpmServiceType: neutron-sriov

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_os_reboot.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_os_reboot.yaml
@@ -4,3 +4,4 @@ metadata:
   name: reboot-os
 spec:
   playbook: osp.edpm.reboot
+  edpmServiceType: reboot-os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn.yaml
@@ -23,3 +23,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - OvnControllerImage
+  edpmServiceType: ovn

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ovn_bgp_agent.yaml
@@ -23,3 +23,4 @@ spec:
   caCerts: combined-ca-bundle
   containerImageFields:
   - EdpmOvnBgpAgentImage
+  edpmServiceType: ovn-bgp-agent

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_redhat.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_redhat.yaml
@@ -4,3 +4,4 @@ metadata:
   name: redhat
 spec:
   playbook: osp.edpm.redhat
+  edpmServiceType: redhat

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_run_os.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_run_os.yaml
@@ -7,3 +7,4 @@ spec:
   containerImageFields:
   - EdpmLogrotateCrondImage
   - EdpmIscsidImage
+  edpmServiceType: run-os

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_ssh_known_hosts.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_ssh_known_hosts.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   playbook: osp.edpm.ssh_known_hosts
   deployOnAllNodeSets: true
+  edpmServiceType: ssh-known-hosts

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_swift.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_swift.yaml
@@ -11,3 +11,4 @@ spec:
         name: swift-storage-config-data
     - configMapRef:
         name: swift-ring-files
+  edpmServiceType: swift

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry.yaml
@@ -16,3 +16,4 @@ spec:
   containerImageFields:
   - CeilometerComputeImage
   - EdpmNodeExporterImage
+  edpmServiceType: telemetry

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry_power_monitoring.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_telemetry_power_monitoring.yaml
@@ -16,3 +16,4 @@ spec:
   containerImageFields:
   - CeilometerIpmiImage
   - EdpmKeplerImage
+  edpmServiceType: telemetry-power-monitoring

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_update.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_update.yaml
@@ -4,3 +4,4 @@ metadata:
   name: update
 spec:
   playbook: osp.edpm.update
+  edpmServiceType: update

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_validate_network.yaml
@@ -4,3 +4,4 @@ metadata:
   name: validate-network
 spec:
   playbook: osp.edpm.validate_network
+  edpmServiceType: validate-network

--- a/pkg/dataplane/service.go
+++ b/pkg/dataplane/service.go
@@ -196,7 +196,12 @@ func dedupe(ctx context.Context, helper *helper.Helper,
 			return dedupedServices, updatedglobalServices, err
 
 		}
-		if !slices.Contains(nodeSetServiceTypes, service.Spec.EDPMServiceType) && !slices.Contains(dedupedServices, svc) {
+
+		serviceType := service.Spec.EDPMServiceType
+		if serviceType == "" {
+			serviceType = service.Name
+		}
+		if !slices.Contains(nodeSetServiceTypes, serviceType) && !slices.Contains(dedupedServices, svc) {
 			if service.Spec.DeployOnAllNodeSets {
 				if !slices.Contains(globalServices, svc) {
 					updatedglobalServices = append(globalServices, svc)
@@ -204,7 +209,7 @@ func dedupe(ctx context.Context, helper *helper.Helper,
 					continue
 				}
 			}
-			nodeSetServiceTypes = append(nodeSetServiceTypes, service.Spec.EDPMServiceType)
+			nodeSetServiceTypes = append(nodeSetServiceTypes, serviceType)
 			dedupedServices = append(dedupedServices, svc)
 		}
 	}


### PR DESCRIPTION
edpmServiceType is already there for some services like nova, let's add it for others to avoid confusion. Also we've documented that it's required for all custom services.