### PR TITLE
bindata has hard coded kube-rbac-proxy URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ bindata: kustomize yq ## Call sync bindata script
 	$(KUSTOMIZE) build config/crd > bindata/crds/crds.yaml
 	$(KUSTOMIZE) build config/default > bindata/operator/operator.yaml
 	sed -i bindata/operator/operator.yaml -e "/envCustomImage/c\\{{ range \$$envName, \$$envValue := .OpenStackServiceRelatedImages }}\n        - name: {{ \$$envName }}\n          value: {{ \$$envValue }}\n{{ end }}"
+	sed -i bindata/operator/operator.yaml -e "s|kube-rbac-proxy:replace_me.*|'{{ .KubeRbacProxyImage }}'|"
 	cp config/operator/managers.yaml bindata/operator/
 	cp config/operator/rabbit.yaml bindata/operator/
 	$(KUSTOMIZE) build config/rbac > bindata/rbac/rbac.yaml

--- a/bindata/operator/managers.yaml
+++ b/bindata/operator/managers.yaml
@@ -1,4 +1,5 @@
 {{ $namespace := .OperatorNamespace }}
+{{ $kubeRbacProxyImage := .KubeRbacProxyImage }}
 {{ range $operatorName, $operatorImage := .OperatorImages }}
 apiVersion: apps/v1
 kind: Deployment
@@ -69,7 +70,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: quay.io/openstack-k8s-operators/kube-rbac-proxy:v0.16.0
+        image: {{ $kubeRbacProxyImage }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/bindata/operator/operator.yaml
+++ b/bindata/operator/operator.yaml
@@ -116,7 +116,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: quay.io/openstack-k8s-operators/kube-rbac-proxy:v0.16.0
+        image: '{{ .KubeRbacProxyImage }}'
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: quay.io/openstack-k8s-operators/kube-rbac-proxy:v0.16.0
+        image: kube-rbac-proxy:replace_me
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/operator/default_images.yaml
+++ b/config/operator/default_images.yaml
@@ -188,3 +188,8 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-horizontest:current-podified
         - name: RELATED_IMAGE_OPENSTACK_MUST_GATHER_DEFAULT
           value: quay.io/openstack-k8s-operators/openstack-must-gather:latest
+          # will already be part of relatedImages as it is also directly set in the deployment in the
+          # bundle CSV. We also need an environment variable here to propagate this to the
+          # controller-manager and to other operators that require the same image to be set
+        - name: KUBE_RBAC_PROXY
+          value: quay.io/openstack-k8s-operators/kube-rbac-proxy:v0.16.0

--- a/config/operator/managers.yaml
+++ b/config/operator/managers.yaml
@@ -1,4 +1,5 @@
 {{ $namespace := .OperatorNamespace }}
+{{ $kubeRbacProxyImage := .KubeRbacProxyImage }}
 {{ range $operatorName, $operatorImage := .OperatorImages }}
 apiVersion: apps/v1
 kind: Deployment
@@ -69,7 +70,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: quay.io/openstack-k8s-operators/kube-rbac-proxy:v0.16.0
+        image: {{ $kubeRbacProxyImage }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/controllers/operator/openstack_controller.go
+++ b/controllers/operator/openstack_controller.go
@@ -69,6 +69,7 @@ var (
 	envRelatedOpenStackServiceImages (map[string]*string) // full_related_image_name -> image
 	rabbitmqImage                    string
 	operatorImage                    string
+	kubeRbacProxyImage               string
 	openstackReleaseVersion          string
 )
 
@@ -93,6 +94,8 @@ func SetupEnv() {
 			log.Log.Info("Found operator related image", "operator", operatorName, "image", envArr[1])
 		} else if strings.HasPrefix(envArr[0], "RELATED_IMAGE_") {
 			envRelatedOpenStackServiceImages[envArr[0]] = &envArr[1]
+		} else if envArr[0] == "KUBE_RBAC_PROXY" {
+			kubeRbacProxyImage = envArr[1]
 		} else if envArr[0] == "OPERATOR_IMAGE_URL" {
 			operatorImage = envArr[1]
 		} else if envArr[0] == "OPENSTACK_RELEASE_VERSION" {
@@ -449,6 +452,7 @@ func (r *OpenStackReconciler) applyOperator(ctx context.Context, instance *opera
 	data.Data["OperatorImages"] = envRelatedOperatorImages
 	data.Data["RabbitmqImage"] = rabbitmqImage
 	data.Data["OperatorImage"] = operatorImage
+	data.Data["KubeRbacProxyImage"] = kubeRbacProxyImage
 	data.Data["OpenstackReleaseVersion"] = openstackReleaseVersion
 	data.Data["OpenStackServiceRelatedImages"] = envRelatedOpenStackServiceImages
 	return r.renderAndApply(ctx, instance, data, "operator", true)


### PR DESCRIPTION
This updates the bindata templates for controller-manager and service operators so that a variable is used for the kube-rbac-proxy URL

A new environment variable is added to the CSV for kube-rbac-proxy as this is required to propagate this image to these deployments.

Jira: [OSPRH-14715](https://issues.redhat.com//browse/OSPRH-14715)