### PR TITLE
Default Horizon secret to ControlPlane secret

### DIFF
--- a/apis/core/v1beta1/openstackcontrolplane_webhook.go
+++ b/apis/core/v1beta1/openstackcontrolplane_webhook.go
@@ -920,6 +920,10 @@ func (r *OpenStackControlPlane) DefaultServices() {
 			r.Spec.Horizon.Template = &horizonv1.HorizonSpecCore{}
 		}
 
+		if r.Spec.Horizon.Template.Secret == "" {
+			r.Spec.Horizon.Template.Secret = r.Spec.Secret
+		}
+
 		r.Spec.Horizon.Template.Default()
 	}
 


### PR DESCRIPTION
If the user doesn't provide a secret for the Horizon template, we will default to the global secret for the OpenStackControlPlane.