### PR TITLE
Add CA cert to bootstrap service

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_bootstrap.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   playbook: osp.edpm.bootstrap
   edpmServiceType: bootstrap
+  caCerts: combined-ca-bundle

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -166,6 +166,16 @@ func CreateSSHSecret(name types.NamespacedName) *corev1.Secret {
 	)
 }
 
+// Create CABundleSecret
+func CreateCABundleSecret(name types.NamespacedName) *corev1.Secret {
+	return th.CreateSecret(
+		types.NamespacedName{Namespace: name.Namespace, Name: name.Name},
+		map[string][]byte{
+			"tls-ca-bundle.pem": []byte("blah"),
+		},
+	)
+}
+
 // Create OpenStackVersion
 func CreateOpenStackVersion(name types.NamespacedName) *unstructured.Unstructured {
 	raw := DefaultOpenStackVersion(name)

--- a/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	var dataplaneDeploymentName types.NamespacedName
 	var dataplaneNodeSetName types.NamespacedName
 	var dataplaneSSHSecretName types.NamespacedName
+	var caBundleSecretName types.NamespacedName
 	var neutronOvnMetadataSecretName types.NamespacedName
 	var novaNeutronMetadataSecretName types.NamespacedName
 	var novaCellComputeConfigSecretName types.NamespacedName
@@ -58,6 +59,10 @@ var _ = Describe("Dataplane Deployment Test", func() {
 		dataplaneSSHSecretName = types.NamespacedName{
 			Namespace: namespace,
 			Name:      "dataplane-ansible-ssh-private-key-secret",
+		}
+		caBundleSecretName = types.NamespacedName{
+			Namespace: namespace,
+			Name:      "combined-ca-bundle",
 		}
 		neutronOvnMetadataSecretName = types.NamespacedName{
 			Namespace: namespace,
@@ -110,6 +115,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	When("A dataplaneDeployment is created with matching NodeSet", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -249,6 +255,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	When("A dataplaneDeployment is created with two NodeSets", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -430,9 +437,9 @@ var _ = Describe("Dataplane Deployment Test", func() {
 					}
 					ansibleEE := GetAnsibleee(ansibleeeName)
 					if service.Spec.DeployOnAllNodeSets {
-						g.Expect(ansibleEE.Spec.Template.Spec.Volumes).Should(HaveLen(4))
+						g.Expect(ansibleEE.Spec.Template.Spec.Volumes).Should(HaveLen(5))
 					} else {
-						g.Expect(ansibleEE.Spec.Template.Spec.Volumes).Should(HaveLen(2))
+						g.Expect(ansibleEE.Spec.Template.Spec.Volumes).Should(HaveLen(3))
 					}
 					ansibleEE.Status.Succeeded = 1
 					g.Expect(th.K8sClient.Status().Update(th.Ctx, ansibleEE)).To(Succeed())
@@ -469,9 +476,9 @@ var _ = Describe("Dataplane Deployment Test", func() {
 					}
 					ansibleEE := GetAnsibleee(ansibleeeName)
 					if service.Spec.DeployOnAllNodeSets {
-						g.Expect(ansibleEE.Spec.Template.Spec.Volumes).Should(HaveLen(4))
+						g.Expect(ansibleEE.Spec.Template.Spec.Volumes).Should(HaveLen(5))
 					} else {
-						g.Expect(ansibleEE.Spec.Template.Spec.Volumes).Should(HaveLen(2))
+						g.Expect(ansibleEE.Spec.Template.Spec.Volumes).Should(HaveLen(3))
 					}
 					ansibleEE.Status.Succeeded = 1
 					g.Expect(th.K8sClient.Status().Update(th.Ctx, ansibleEE)).To(Succeed())
@@ -501,6 +508,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	When("A dataplaneDeployment is created with a missing nodeset", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -638,6 +646,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 		BeforeEach(func() {
 			CreateDataplaneServicesWithSameServiceType(dataplaneServiceName)
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -720,6 +729,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	When("A dataplaneDeployment is created with two NodeSets both containing same globalservice", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -951,6 +961,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 		BeforeEach(func() {
 			CreateDataplaneServicesWithSameServiceType(dataplaneServiceName)
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -1051,6 +1062,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	When("A dataplaneDeployment is created with serviceoverride containing single global service", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -1258,6 +1270,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	When("A dataplaneDeployment is created with serviceoverride containing global service", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -1480,6 +1493,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	When("A dataplaneDeployment is created with non-existent service in nodeset", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -1575,6 +1589,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	When("A user sets TLSEnabled to true with control plane with PodLevel TLS disabled", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))
@@ -1674,6 +1689,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 	When("A user sets TLSEnabled to true with control plane PodLevel TLS enabled", func() {
 		BeforeEach(func() {
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			DeferCleanup(th.DeleteInstance, th.CreateSecret(neutronOvnMetadataSecretName, map[string][]byte{
 				"fake_keys": []byte("blih"),
 			}))

--- a/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 	var dataplaneNodeSetName types.NamespacedName
 	var dataplaneSecretName types.NamespacedName
 	var dataplaneSSHSecretName types.NamespacedName
+	var caBundleSecretName types.NamespacedName
 	var dataplaneNetConfigName types.NamespacedName
 	var dnsMasqName types.NamespacedName
 	var dataplaneNodeName types.NamespacedName
@@ -92,6 +93,10 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		dataplaneSSHSecretName = types.NamespacedName{
 			Namespace: namespace,
 			Name:      "dataplane-ansible-ssh-private-key-secret",
+		}
+		caBundleSecretName = types.NamespacedName{
+			Namespace: namespace,
+			Name:      "combined-ca-bundle",
 		}
 		dataplaneNetConfigName = types.NamespacedName{
 			Namespace: namespace,
@@ -571,6 +576,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(tlsEnabled)))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -597,6 +603,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(tlsEnabled)))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -616,6 +623,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, CustomServiceImageSpec()))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -635,6 +643,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(tlsEnabled)))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -654,6 +663,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, CustomServiceImageSpec()))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -675,6 +685,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -727,6 +738,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -753,6 +765,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -772,6 +785,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(tlsEnabled)))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneDeployment(dataplaneDeploymentName, DefaultDataPlaneDeploymentSpec()))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -979,6 +993,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(tlsEnabled)))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1005,6 +1020,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(tlsEnabled)))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1024,6 +1040,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, CustomServiceImageSpec()))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1043,6 +1060,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(tlsEnabled)))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1062,6 +1080,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, CustomServiceImageSpec()))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1083,6 +1102,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1135,6 +1155,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1161,6 +1182,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1180,6 +1202,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(tlsEnabled)))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneDeployment(dataplaneDeploymentName, DefaultDataPlaneDeploymentSpec()))
 				CreateSSHSecret(dataplaneSSHSecretName)
+				CreateCABundleSecret(caBundleSecretName)
 				SimulateDNSMasqComplete(dnsMasqName)
 				SimulateIPSetComplete(dataplaneNodeName)
 				SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1258,6 +1281,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			DeferCleanup(th.DeleteInstance, CreateOpenStackVersion(openstackVersionName))
 
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			SimulateDNSMasqComplete(dnsMasqName)
 			SimulateIPSetComplete(dataplaneNodeName)
 			SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1292,6 +1316,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
 			DeferCleanup(th.DeleteInstance, CreateDataplaneDeployment(dataplaneDeploymentName, DefaultDataPlaneDeploymentSpec()))
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			SimulateDNSMasqComplete(dnsMasqName)
 			SimulateIPSetComplete(dataplaneNodeName)
 			SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1307,12 +1332,14 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					Namespace: namespace,
 				}
 				ansibleEE := GetAnsibleee(ansibleeeName)
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes).To(HaveLen(2))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[0].Name).To(Equal("ssh-key"))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].Name).To(Equal("inventory"))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName).To(Equal("dataplane-ansible-ssh-private-key-secret"))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.Items[0].Path).To(Equal("ssh_key"))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.Items[0].Key).To(Equal("ssh-privatekey"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes).To(HaveLen(3))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[0].Name).To(Equal("bootstrap-combined-ca-bundle"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].Name).To(Equal("ssh-key"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[2].Name).To(Equal("inventory"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName).To(Equal("combined-ca-bundle"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.SecretName).To(Equal("dataplane-ansible-ssh-private-key-secret"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.Items[0].Path).To(Equal("ssh_key"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.Items[0].Key).To(Equal("ssh-privatekey"))
 
 			}, th.Timeout, th.Interval).Should(Succeed())
 		})
@@ -1356,6 +1383,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
 			DeferCleanup(th.DeleteInstance, CreateDataplaneDeployment(dataplaneDeploymentName, DefaultDataPlaneDeploymentSpec()))
 			CreateSSHSecret(dataplaneSSHSecretName)
+			CreateCABundleSecret(caBundleSecretName)
 			SimulateDNSMasqComplete(dnsMasqName)
 			SimulateIPSetComplete(dataplaneNodeName)
 			SimulateDNSDataComplete(dataplaneNodeSetName)
@@ -1371,14 +1399,16 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					Namespace: namespace,
 				}
 				ansibleEE := GetAnsibleee(ansibleeeName)
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes).To(HaveLen(3))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes).To(HaveLen(4))
 				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[0].Name).To(Equal("edpm-ansible"))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].Name).To(Equal("ssh-key"))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[2].Name).To(Equal("inventory"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].Name).To(Equal("bootstrap-combined-ca-bundle"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[2].Name).To(Equal("ssh-key"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[3].Name).To(Equal("inventory"))
 				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName).To(Equal("edpm-ansible"))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.SecretName).To(Equal("dataplane-ansible-ssh-private-key-secret"))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.Items[0].Path).To(Equal("ssh_key"))
-				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.Items[0].Key).To(Equal("ssh-privatekey"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.SecretName).To(Equal("combined-ca-bundle"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[2].VolumeSource.Secret.SecretName).To(Equal("dataplane-ansible-ssh-private-key-secret"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[2].VolumeSource.Secret.Items[0].Path).To(Equal("ssh_key"))
+				g.Expect(ansibleEE.Spec.Template.Spec.Volumes[2].VolumeSource.Secret.Items[0].Key).To(Equal("ssh-privatekey"))
 
 			}, th.Timeout, th.Interval).Should(Succeed())
 		})

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -141,6 +141,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/custom-global-service
+          name: custom-global-service-combined-ca-bundle
         - mountPath: /runner/env/ssh_key/ssh_key_edpm-compute-global
           name: ssh-key-edpm-compute-global
           subPath: ssh_key_edpm-compute-global
@@ -154,6 +156,10 @@ spec:
       serviceAccountName: edpm-compute-global
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: custom-global-service-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key-edpm-compute-global
         secret:
           defaultMode: 420
@@ -335,6 +341,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/bootstrap
+          name: bootstrap-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -348,6 +356,10 @@ spec:
       serviceAccountName: edpm-compute-global
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: bootstrap-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -727,6 +739,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/bootstrap
+          name: bootstrap-combined-ca-bundle
         - mountPath: /var/lib/openstack/cacerts/ovn
           name: ovn-combined-ca-bundle
         - mountPath: /var/lib/openstack/cacerts/neutron-metadata
@@ -756,6 +770,10 @@ spec:
       serviceAccountName: edpm-compute-global
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: bootstrap-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ovn-combined-ca-bundle
         secret:
           defaultMode: 420
@@ -871,6 +889,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/ovn/ovsdb-config
           name: ovncontroller-config-0
           subPath: ovsdb-config
+        - mountPath: /var/lib/openstack/cacerts/ovn
+          name: ovn-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -891,6 +911,10 @@ spec:
             path: ovsdb-config
           name: ovncontroller-config
         name: ovncontroller-config-0
+      - name: ovn-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -983,6 +1007,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/neutron-metadata/nova-metadata-config.json
           name: nova-metadata-neutron-config-2
           subPath: nova-metadata-config.json
+        - mountPath: /var/lib/openstack/cacerts/neutron-metadata
+          name: neutron-metadata-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1024,6 +1050,10 @@ spec:
           - key: nova-metadata-config.json
             path: nova-metadata-config.json
           secretName: nova-metadata-neutron-config
+      - name: neutron-metadata-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1107,6 +1137,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/neutron-ovn/10-neutron-ovn.conf
           name: neutron-ovn-agent-neutron-config-0
           subPath: 10-neutron-ovn.conf
+        - mountPath: /var/lib/openstack/cacerts/neutron-ovn
+          name: neutron-ovn-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1127,6 +1159,10 @@ spec:
           - key: 10-neutron-ovn.conf
             path: 10-neutron-ovn.conf
           secretName: neutron-ovn-agent-neutron-config
+      - name: neutron-ovn-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1210,6 +1246,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/neutron-sriov/10-neutron-sriov.conf
           name: neutron-sriov-agent-neutron-config-0
           subPath: 10-neutron-sriov.conf
+        - mountPath: /var/lib/openstack/cacerts/neutron-sriov
+          name: neutron-sriov-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1230,6 +1268,10 @@ spec:
           - key: 10-neutron-sriov.conf
             path: 10-neutron-sriov.conf
           secretName: neutron-sriov-agent-neutron-config
+      - name: neutron-sriov-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1313,6 +1355,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/neutron-dhcp/10-neutron-dhcp.conf
           name: neutron-dhcp-agent-neutron-config-0
           subPath: 10-neutron-dhcp.conf
+        - mountPath: /var/lib/openstack/cacerts/neutron-dhcp
+          name: neutron-dhcp-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1333,6 +1377,10 @@ spec:
           - key: 10-neutron-dhcp.conf
             path: 10-neutron-dhcp.conf
           secretName: neutron-dhcp-agent-neutron-config
+      - name: neutron-dhcp-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1416,6 +1464,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/libvirt/LibvirtPassword
           name: libvirt-secret-0
           subPath: LibvirtPassword
+        - mountPath: /var/lib/openstack/cacerts/libvirt
+          name: libvirt-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1436,6 +1486,10 @@ spec:
           - key: LibvirtPassword
             path: LibvirtPassword
           secretName: libvirt-secret
+      - name: libvirt-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1528,6 +1582,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/nova/ssh-publickey
           name: nova-migration-ssh-key-1
           subPath: ssh-publickey
+        - mountPath: /var/lib/openstack/cacerts/nova
+          name: nova-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1569,6 +1625,10 @@ spec:
           - key: ssh-publickey
             path: ssh-publickey
           secretName: nova-migration-ssh-key
+      - name: nova-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
@@ -233,6 +233,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/bootstrap
+          name: bootstrap-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -246,6 +248,10 @@ spec:
       serviceAccountName: edpm-compute-beta-nodeset
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: bootstrap-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
@@ -298,6 +298,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/generic-service1
+          name: generic-service1-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -311,6 +313,10 @@ spec:
       serviceAccountName: openstack-edpm-tls
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: generic-service1-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -231,6 +231,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/bootstrap
+          name: bootstrap-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -244,6 +246,10 @@ spec:
       serviceAccountName: edpm-compute-no-nodes
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: bootstrap-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -631,6 +637,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/bootstrap
+          name: bootstrap-combined-ca-bundle
         - mountPath: /var/lib/openstack/cacerts/ovn
           name: ovn-combined-ca-bundle
         - mountPath: /var/lib/openstack/cacerts/neutron-metadata
@@ -658,6 +666,10 @@ spec:
       serviceAccountName: edpm-compute-no-nodes
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: bootstrap-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ovn-combined-ca-bundle
         secret:
           defaultMode: 420
@@ -770,6 +782,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/ovn/ovsdb-config
           name: ovncontroller-config-0
           subPath: ovsdb-config
+        - mountPath: /var/lib/openstack/cacerts/ovn
+          name: ovn-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -790,6 +804,10 @@ spec:
             path: ovsdb-config
           name: ovncontroller-config
         name: ovncontroller-config-0
+      - name: ovn-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -883,6 +901,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/neutron-metadata/nova-metadata-config.json
           name: nova-metadata-neutron-config-2
           subPath: nova-metadata-config.json
+        - mountPath: /var/lib/openstack/cacerts/neutron-metadata
+          name: neutron-metadata-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -924,6 +944,10 @@ spec:
           - key: nova-metadata-config.json
             path: nova-metadata-config.json
           secretName: nova-metadata-neutron-config
+      - name: neutron-metadata-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1008,6 +1032,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/neutron-ovn/10-neutron-ovn.conf
           name: neutron-ovn-agent-neutron-config-0
           subPath: 10-neutron-ovn.conf
+        - mountPath: /var/lib/openstack/cacerts/neutron-ovn
+          name: neutron-ovn-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1028,6 +1054,10 @@ spec:
           - key: 10-neutron-ovn.conf
             path: 10-neutron-ovn.conf
           secretName: neutron-ovn-agent-neutron-config
+      - name: neutron-ovn-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1112,6 +1142,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/neutron-sriov/10-neutron-sriov.conf
           name: neutron-sriov-agent-neutron-config-0
           subPath: 10-neutron-sriov.conf
+        - mountPath: /var/lib/openstack/cacerts/neutron-sriov
+          name: neutron-sriov-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1132,6 +1164,10 @@ spec:
           - key: 10-neutron-sriov.conf
             path: 10-neutron-sriov.conf
           secretName: neutron-sriov-agent-neutron-config
+      - name: neutron-sriov-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1216,6 +1252,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/neutron-dhcp/10-neutron-dhcp.conf
           name: neutron-dhcp-agent-neutron-config-0
           subPath: 10-neutron-dhcp.conf
+        - mountPath: /var/lib/openstack/cacerts/neutron-dhcp
+          name: neutron-dhcp-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1236,6 +1274,10 @@ spec:
           - key: 10-neutron-dhcp.conf
             path: 10-neutron-dhcp.conf
           secretName: neutron-dhcp-agent-neutron-config
+      - name: neutron-dhcp-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1320,6 +1362,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/libvirt/LibvirtPassword
           name: libvirt-secret-0
           subPath: LibvirtPassword
+        - mountPath: /var/lib/openstack/cacerts/libvirt
+          name: libvirt-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1340,6 +1384,10 @@ spec:
           - key: LibvirtPassword
             path: LibvirtPassword
           secretName: libvirt-secret
+      - name: libvirt-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -1433,6 +1481,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/nova/ssh-publickey
           name: nova-migration-ssh-key-1
           subPath: ssh-publickey
+        - mountPath: /var/lib/openstack/cacerts/nova
+          name: nova-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -1474,6 +1524,10 @@ spec:
           - key: ssh-publickey
             path: ssh-publickey
           secretName: nova-migration-ssh-key
+      - name: nova-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -136,6 +136,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/ovn/ovsdb-config
           name: ovncontroller-config-0
           subPath: ovsdb-config
+        - mountPath: /var/lib/openstack/cacerts/ovn
+          name: ovn-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -157,6 +159,10 @@ spec:
             path: ovsdb-config
           name: ovncontroller-config
         name: ovncontroller-config-0
+      - name: ovn-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
@@ -135,6 +135,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/bootstrap
+          name: bootstrap-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
         - mountPath: /runner/inventory/hosts
@@ -148,6 +150,10 @@ spec:
       serviceAccountName: edpm-compute-beta-nodeset
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: bootstrap-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -340,6 +340,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/tls-dnsnames
+          name: tls-dnsnames-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -353,6 +355,10 @@ spec:
       serviceAccountName: openstack-edpm-tls
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: tls-dnsnames-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -213,6 +213,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/tls-dns-ips
+          name: tls-dns-ips-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -226,6 +228,10 @@ spec:
       serviceAccountName: openstack-edpm-tls
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: tls-dns-ips-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420
@@ -318,6 +324,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/custom-tls-dns
+          name: custom-tls-dns-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -331,6 +339,10 @@ spec:
       serviceAccountName: openstack-edpm-tls
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: custom-tls-dns-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-extramounts/00-assert.yaml
@@ -93,6 +93,8 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/ansible/collections/ansible_collections/osp/edpm
           name: edpm-ansible
+        - mountPath: /var/lib/openstack/cacerts/test-service
+          name: test-service-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -111,6 +113,10 @@ spec:
         persistentVolumeClaim:
           claimName: edpm-ansible
           readOnly: true
+      - name: test-service-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-config/00-assert.yaml
@@ -101,6 +101,8 @@ spec:
         - mountPath: /var/lib/openstack/configs/kuttl-service/30-kuttl-service.conf
           name: kuttl-service-cm-2-0
           subPath: 30-kuttl-service.conf
+        - mountPath: /var/lib/openstack/cacerts/kuttl-service
+          name: kuttl-service-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -164,6 +166,10 @@ spec:
             path: 30-kuttl-service.conf
           name: kuttl-service-cm-2
         name: kuttl-service-cm-2-0
+      - name: kuttl-service-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -119,6 +119,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/custom-img-svc
+          name: custom-img-svc-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -133,6 +135,10 @@ spec:
       serviceAccountName: edpm-no-nodes-custom-svc
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: custom-img-svc-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420

--- a/tests/kuttl/tests/dataplane-service-failure/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-service-failure/00-assert.yaml
@@ -80,6 +80,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        - mountPath: /var/lib/openstack/cacerts/failed-service
+          name: failed-service-combined-ca-bundle
         - mountPath: /runner/env/ssh_key
           name: ssh-key
           subPath: ssh_key
@@ -94,6 +96,10 @@ spec:
       serviceAccountName: edpm-compute-no-nodes
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: failed-service-combined-ca-bundle
+        secret:
+          defaultMode: 420
+          secretName: combined-ca-bundle
       - name: ssh-key
         secret:
           defaultMode: 420


### PR DESCRIPTION
We want to add and trust the combined-ca-cert-bundle to the compute nodes to ensure that any third party certs are trusted.  Lets use the bootstrap service to do this.  This change will make sure that that bootsrap service has the combined-ca-cert bundle is mounted to /var/lib/openstack/cacerts/bootstrap.

Jira: [OSPRH-14205](https://issues.redhat.com//browse/OSPRH-14205)