### PR TITLE
Ignore 'crc-storage-*' pods in KUTTL test checks

### DIFF
--- a/tests/kuttl/tests/ctlplane-nodeselectors/02-assert-nodeselector.yaml
+++ b/tests/kuttl/tests/ctlplane-nodeselectors/02-assert-nodeselector.yaml
@@ -4,7 +4,7 @@ commands:
   - script: |
       echo "Checking all pods have expected nodeselector"
       EXPECTED_NODE_SELECTOR="beta.kubernetes.io/os:linux node-role.kubernetes.io/worker:"
-      BAD_OR_MISSING_NODE_SELECTOR=$(oc get pods -n $NAMESPACE -l service!=dnsmasq -o=go-template --template='{{ range .items }}{{ .metadata.name}}: {{ .spec.nodeSelector }}{{"\n"}}{{ end }}' | grep -v 'ovn-controller-.*-config' | sed -e '\!map\['"$EXPECTED_NODE_SELECTOR"'\]$!d')
+      BAD_OR_MISSING_NODE_SELECTOR=$(oc get pods -n $NAMESPACE -l service!=dnsmasq -o=go-template --template='{{ range .items }}{{ .metadata.name}}: {{ .spec.nodeSelector }}{{"\n"}}{{ end }}' | grep -v 'ovn-controller-.*-config' | grep -v 'crc-storage-*' | sed -e '\!map\['"$EXPECTED_NODE_SELECTOR"'\]$!d')
       BAD_OR_MISSING_NODE_SELECTOR_COUNT=$(echo -n "$BAD_OR_MISSING_NODE_SELECTOR" | wc -l)
       if [ $BAD_OR_MISSING_NODE_SELECTOR_COUNT -ne 0 ]; then
         echo "Found $BAD_OR_MISSING_NODE_SELECTOR_COUNT pods with bad or missing nodeselector:"
@@ -14,7 +14,7 @@ commands:
   - script: |
       echo "Checking all cronjobs have expected nodeselector"
       EXPECTED_NODE_SELECTOR="node-role.kubernetes.io/worker:"
-      BAD_OR_MISSING_NODE_SELECTOR=$(oc get cronjobs -n $NAMESPACE -o=go-template --template='{{ range .items }}{{ .metadata.name}}: {{ .spec.jobTemplate.spec.template.spec.nodeSelector }}{{"\n"}}{{ end }}' | grep -v 'ovn-controller-.*-config' | sed -e '\!map\['"$EXPECTED_NODE_SELECTOR"'\]$!d')
+      BAD_OR_MISSING_NODE_SELECTOR=$(oc get cronjobs -n $NAMESPACE -o=go-template --template='{{ range .items }}{{ .metadata.name}}: {{ .spec.jobTemplate.spec.template.spec.nodeSelector }}{{"\n"}}{{ end }}' | grep -v 'ovn-controller-.*-config' | grep -v 'crc-storage-*' | sed -e '\!map\['"$EXPECTED_NODE_SELECTOR"'\]$!d')
       BAD_OR_MISSING_NODE_SELECTOR_COUNT=$(echo -n "$BAD_OR_MISSING_NODE_SELECTOR" | wc -l)
       if [ $BAD_OR_MISSING_NODE_SELECTOR_COUNT -ne 0 ]; then
         echo "Found $BAD_OR_MISSING_NODE_SELECTOR_COUNT cronjobs with bad or missing nodeselector:"

--- a/tests/kuttl/tests/ctlplane-nodeselectors/04-assert-nodeselector.yaml
+++ b/tests/kuttl/tests/ctlplane-nodeselectors/04-assert-nodeselector.yaml
@@ -4,7 +4,7 @@ commands:
   - script: |
       echo "Checking all running pods have new nodeselector"
       EXPECTED_NODE_SELECTOR="beta.kubernetes.io/os:linux kubernetes.io/os:linux"
-      BAD_OR_MISSING_NODE_SELECTOR=$(oc get pods -n $NAMESPACE -l service!=dnsmasq --field-selector=status.phase=Running -o=go-template --template='{{ range .items }}{{ .metadata.name}}: {{ .spec.nodeSelector }}{{"\n"}}{{ end }}' | grep -v 'ovn-controller-.*-config' | sed -e '\!map\['"$EXPECTED_NODE_SELECTOR"'\]$!d')
+      BAD_OR_MISSING_NODE_SELECTOR=$(oc get pods -n $NAMESPACE -l service!=dnsmasq --field-selector=status.phase=Running -o=go-template --template='{{ range .items }}{{ .metadata.name}}: {{ .spec.nodeSelector }}{{"\n"}}{{ end }}' | grep -v 'ovn-controller-.*-config' | grep -v 'crc-storage-*' | sed -e '\!map\['"$EXPECTED_NODE_SELECTOR"'\]$!d')
       BAD_OR_MISSING_NODE_SELECTOR_COUNT=$(echo -n "$BAD_OR_MISSING_NODE_SELECTOR" | wc -l)
       if [ $BAD_OR_MISSING_NODE_SELECTOR_COUNT -ne 0 ]; then
         echo "Found $BAD_OR_MISSING_NODE_SELECTOR_COUNT pods with bad or missing nodeselector:"
@@ -14,7 +14,7 @@ commands:
   - script: |
       echo "Checking all cronjobs have expected nodeselector"
       EXPECTED_NODE_SELECTOR="kubernetes.io/os:linux"
-      BAD_OR_MISSING_NODE_SELECTOR=$(oc get cronjobs -n $NAMESPACE -o=go-template --template='{{ range .items }}{{ .metadata.name}}: {{ .spec.jobTemplate.spec.template.spec.nodeSelector }}{{"\n"}}{{ end }}' | grep -v 'ovn-controller-.*-config' | sed -e '\!map\['"$EXPECTED_NODE_SELECTOR"'\]$!d')
+      BAD_OR_MISSING_NODE_SELECTOR=$(oc get cronjobs -n $NAMESPACE -o=go-template --template='{{ range .items }}{{ .metadata.name}}: {{ .spec.jobTemplate.spec.template.spec.nodeSelector }}{{"\n"}}{{ end }}' | grep -v 'ovn-controller-.*-config' | grep -v 'crc-storage-*' | sed -e '\!map\['"$EXPECTED_NODE_SELECTOR"'\]$!d')
       BAD_OR_MISSING_NODE_SELECTOR_COUNT=$(echo -n "$BAD_OR_MISSING_NODE_SELECTOR" | wc -l)
       if [ $BAD_OR_MISSING_NODE_SELECTOR_COUNT -ne 0 ]; then
         echo "Found $BAD_OR_MISSING_NODE_SELECTOR_COUNT cronjobs with bad or missing nodeselector:"


### PR DESCRIPTION
With the introduction of [1] to try to mitigate `make crc_storage` CI hiccups, an OpenStack operator KUTTL test needs to be adjusted so as to ignore the pods created by [1].

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/1039