### PR TITLE
Use long form OpenStackDataPlaneDeployment in Ready Waiting

### DIFF
--- a/apis/dataplane/v1beta1/conditions.go
+++ b/apis/dataplane/v1beta1/conditions.go
@@ -93,7 +93,7 @@ const (
 	NodeSetDeploymentReadyCondition condition.Type = "NodeSetDeploymentReady"
 
 	// NodeSetDeploymentReadyWaitingMessage not yet ready
-	NodeSetDeploymentReadyWaitingMessage = "NodeSet setup ready, waiting for Deployment..."
+	NodeSetDeploymentReadyWaitingMessage = "NodeSet setup ready, waiting for OpenStackDataPlaneDeployment..."
 
 	// NodeSetServiceDeploymentReadyMessage ready
 	NodeSetServiceDeploymentReadyMessage = "Deployment ready for %s service"

--- a/docs/assemblies/proc_creating-a-set-of-data-plane-nodes.adoc
+++ b/docs/assemblies/proc_creating-a-set-of-data-plane-nodes.adoc
@@ -308,7 +308,7 @@ $ oc create -f openstack-edpm.yaml
 ----
 $ oc get openstackdataplanenodeset
 NAME           		STATUS MESSAGE
-openstack-edpm-ipam 	False  NodeSet setup ready, waiting for Deployment...
+openstack-edpm-ipam 	False  NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
 ----
 
 . Verify that the `Secret` resource was created for the node set:

--- a/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-assert.yaml
@@ -79,11 +79,11 @@ status:
       tenant: 172.19.0.100
   ctlplaneSearchDomain: ctlplane.example.com
   conditions:
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: Ready
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: DeploymentReady

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-assert.yaml
@@ -106,12 +106,12 @@ spec:
 status:
   observedGeneration: 1
   conditions:
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     severity: Info
     status: "False"
     type: Ready
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     severity: Info
     status: "False"

--- a/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-multiple-secrets/00-assert.yaml
@@ -123,11 +123,11 @@ spec:
 status:
   observedGeneration: 1
   conditions:
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: Ready
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: DeploymentReady

--- a/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-no-nodes-test/00-assert.yaml
@@ -38,11 +38,11 @@ spec:
 status:
   observedGeneration: 1
   conditions:
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: Ready
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: DeploymentReady

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-assert.yaml
@@ -94,11 +94,11 @@ spec:
 status:
   observedGeneration: 1
   conditions:
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: Ready
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: DeploymentReady

--- a/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-assert.yaml
+++ b/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-assert.yaml
@@ -28,11 +28,11 @@ status:
   observedGeneration: 1
   ctlplaneSearchDomain: ctlplane.example.com
   conditions:
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: Ready
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: DeploymentReady

--- a/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/01-assert.yaml
+++ b/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/01-assert.yaml
@@ -17,11 +17,11 @@ status:
       tenant: 172.19.0.150
   ctlplaneSearchDomain: ctlplane.example.com
   conditions:
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: Ready
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: DeploymentReady

--- a/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/02-assert.yaml
+++ b/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/02-assert.yaml
@@ -27,11 +27,11 @@ status:
       tenant: 172.19.0.151
   ctlplaneSearchDomain: ctlplane.example.com
   conditions:
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: Ready
-  - message: NodeSet setup ready, waiting for Deployment...
+  - message: NodeSet setup ready, waiting for OpenStackDataPlaneDeployment...
     reason: Requested
     status: "False"
     type: DeploymentReady


### PR DESCRIPTION
It's not clear to some users exactly what we're waiting for after the NodeSet setup is Ready and Waiting. This change uses the full CR name for OpenStackDataPlaneDeployment instead of the abreviation.