### PR TITLE
Fix nodeset status changes with BmhRef hash changes

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -91,6 +91,10 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              bmhRefHashes:
+                additionalProperties:
+                  type: string
+                type: object
               conditions:
                 items:
                   properties:

--- a/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -903,6 +903,8 @@ spec:
                     type: string
                   type: object
                 type: object
+              bmhRefHash:
+                type: string
               conditions:
                 items:
                   properties:

--- a/apis/dataplane/v1beta1/openstackdataplanedeployment_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanedeployment_types.go
@@ -90,6 +90,9 @@ type OpenStackDataPlaneDeploymentStatus struct {
 	// NodeSetHashes
 	NodeSetHashes map[string]string `json:"nodeSetHashes,omitempty" optional:"true"`
 
+	// BmhRefHashes
+	BmhRefHashes map[string]string `json:"bmhRefHashes,omitempty" optional:"true"`
+
 	// ContainerImages
 	ContainerImages map[string]string `json:"containerImages,omitempty"`
 
@@ -184,5 +187,8 @@ func (instance *OpenStackDataPlaneDeployment) InitHashesAndImages() {
 	}
 	if instance.Status.ContainerImages == nil {
 		instance.Status.ContainerImages = make(map[string]string)
+	}
+	if instance.Status.BmhRefHashes == nil {
+		instance.Status.BmhRefHashes = make(map[string]string)
 	}
 }

--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -155,6 +155,9 @@ type OpenStackDataPlaneNodeSetStatus struct {
 	// DeployedVersion
 	DeployedVersion string `json:"deployedVersion,omitempty"`
 
+	// bmhRefHash - Current hash of the BMHs
+	BmhRefHash string `json:"bmhRefHash,omitempty"`
+
 	//DeployedBmhHash - Hash of BMHs deployed
 	DeployedBmhHash string `json:"deployedBmhHash,omitempty"`
 }

--- a/apis/dataplane/v1beta1/zz_generated.deepcopy.go
+++ b/apis/dataplane/v1beta1/zz_generated.deepcopy.go
@@ -425,6 +425,13 @@ func (in *OpenStackDataPlaneDeploymentStatus) DeepCopyInto(out *OpenStackDataPla
 			(*out)[key] = val
 		}
 	}
+	if in.BmhRefHashes != nil {
+		in, out := &in.BmhRefHashes, &out.BmhRefHashes
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.ContainerImages != nil {
 		in, out := &in.ContainerImages, &out.ContainerImages
 		*out = make(map[string]string, len(*in))

--- a/bindata/crds/crds.yaml
+++ b/bindata/crds/crds.yaml
@@ -17922,6 +17922,10 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              bmhRefHashes:
+                additionalProperties:
+                  type: string
+                type: object
               conditions:
                 items:
                   properties:
@@ -18902,6 +18906,8 @@ spec:
                     type: string
                   type: object
                 type: object
+              bmhRefHash:
+                type: string
               conditions:
                 items:
                   properties:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanedeployments.yaml
@@ -91,6 +91,10 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              bmhRefHashes:
+                additionalProperties:
+                  type: string
+                type: object
               conditions:
                 items:
                   properties:

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -903,6 +903,8 @@ spec:
                     type: string
                   type: object
                 type: object
+              bmhRefHash:
+                type: string
               conditions:
                 items:
                   properties:

--- a/controllers/dataplane/openstackdataplanedeployment_controller.go
+++ b/controllers/dataplane/openstackdataplanedeployment_controller.go
@@ -320,6 +320,7 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 				dataplanev1.NodeSetDeploymentReadyCondition,
 				condition.DeploymentReadyMessage)
 			instance.Status.NodeSetHashes[nodeSet.Name] = nodeSet.Status.ConfigHash
+			instance.Status.BmhRefHashes[nodeSet.Name] = nodeSet.Status.BmhRefHash
 		}
 	}
 


### PR DESCRIPTION
Attempt 2:

The current logic is still flawed and it would never reach NodeSetReady after deleting BMHs and running a deployment.

Jira: https://issues.redhat.com/browse/OSPRH-14952