### PR TITLE
Temporarily skip ListMustHaveSSATags

### DIFF
--- a/hack/crd-schema-checker.sh
+++ b/hack/crd-schema-checker.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 CHECKER=$INSTALL_DIR/crd-schema-checker
 
-DISABLED_VALIDATORS=NoMaps,NoBools # TODO: https://issues.redhat.com/browse/OSPRH-12254
+DISABLED_VALIDATORS=NoMaps,NoBools,ListsMustHaveSSATags # TODO: https://issues.redhat.com/browse/OSPRH-12254
 
 CHECKER_ARGS=""
 if [[ ${DISABLED_VALIDATORS:+x} ]]; then


### PR DESCRIPTION
We recently introduced extraMounts in keystone, where we skip `ListMustHaveSSATags`. The reason behind that is related to the fact that `extraMounts`, as per the `crd-schema-checker`, require this tag, which is not defined in the most inner `VolumeSource` type that we import in `lib-common`. To avoid addition work and complication, and to not block any other patch in `opentstack- operator`, this patch skips the `ListMustHaveSSATags` validator the same way we do in `keystone-operator` [1].

[1] https://github.com/openstack-k8s-operators/keystone-operator/blob/main/hack/crd-schema-checker.sh#L5C35-L5C56