### PR TITLE
Re-add "redhat" service in default service list

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -862,6 +862,7 @@ spec:
                 type: integer
               services:
                 default:
+                - redhat
                 - download-cache
                 - bootstrap
                 - configure-network

--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -61,7 +61,7 @@ type OpenStackDataPlaneNodeSetSpec struct {
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={download-cache,bootstrap,configure-network,validate-network,install-os,configure-os,ssh-known-hosts,run-os,reboot-os,install-certs,ovn,neutron-metadata,libvirt,nova,telemetry}
+	// +kubebuilder:default={redhat,download-cache,bootstrap,configure-network,validate-network,install-os,configure-os,ssh-known-hosts,run-os,reboot-os,install-certs,ovn,neutron-metadata,libvirt,nova,telemetry}
 	// Services list
 	Services []string `json:"services"`
 

--- a/bindata/crds/crds.yaml
+++ b/bindata/crds/crds.yaml
@@ -19349,6 +19349,7 @@ spec:
                 type: integer
               services:
                 default:
+                - redhat
                 - download-cache
                 - bootstrap
                 - configure-network

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -862,6 +862,7 @@ spec:
                 type: integer
               services:
                 default:
+                - redhat
                 - download-cache
                 - bootstrap
                 - configure-network

--- a/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
+++ b/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
@@ -8,6 +8,7 @@ spec:
     - name: ANSIBLE_FORCE_COLOR
       value: "True"
   services:
+    - redhat
     - bootstrap
     - download-cache
     - configure-network

--- a/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
@@ -314,6 +314,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				}
 				Expect(dataplaneNodeSetInstance.Spec.Nodes).Should(Equal(nodes))
 				services := []string{
+					"redhat",
 					"download-cache",
 					"bootstrap",
 					"configure-network",
@@ -363,6 +364,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			BeforeEach(func() {
 				nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(tlsEnabled)
 				nodeSetSpec["services"] = []string{
+					"redhat",
 					"download-cache",
 					"bootstrap",
 					"configure-network",
@@ -414,6 +416,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				}
 				Expect(dataplaneNodeSetInstance.Spec.Nodes).Should(Equal(nodes))
 				services := []string{
+					"redhat",
 					"download-cache",
 					"bootstrap",
 					"configure-network",
@@ -827,6 +830,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				}
 				Expect(dataplaneNodeSetInstance.Spec.Nodes).Should(Equal(nodes))
 				services := []string{
+					"redhat",
 					"download-cache",
 					"bootstrap",
 					"configure-network",


### PR DESCRIPTION
This patch reverts #1229 by re-adding the "redhat" service in default
service list for openstackdataplanenodeset.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/932
Related-Issue: [OSPRH-15644](https://issues.redhat.com//browse/OSPRH-15644)
Related-Issue: [OSPNW-930](https://issues.redhat.com//browse/OSPNW-930)
