### PR TITLE
Convert floats to ints after unmarshalling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 CRD_MARKDOWN ?= $(LOCALBIN)/crd-to-markdown
 GINKGO ?= $(LOCALBIN)/ginkgo
-GINKGO_TESTS ?= ./tests/... ./apis/client/... ./apis/core/... ./apis/dataplane/...
+GINKGO_TESTS ?= ./tests/... ./apis/client/... ./apis/core/... ./apis/dataplane/... ./pkg/dataplane/...
 
 KUTTL ?= $(LOCALBIN)/kubectl-kuttl
 

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/openstack-k8s-operators/test-operator/api v0.6.1-0.20250415132754-51bb16559bed
 	github.com/pkg/errors v0.9.1
 	github.com/rabbitmq/cluster-operator/v2 v2.11.0
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	gopkg.in/yaml.v3 v3.0.1
@@ -84,6 +85,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20250423055245-3cb2ae8df6f0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.53.0 // indirect

--- a/pkg/dataplane/inventory_test.go
+++ b/pkg/dataplane/inventory_test.go
@@ -1,0 +1,166 @@
+package deployment
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessConfigMapData_NumbersAsInts(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         map[string]string
+		prefix       string
+		expected     map[string]interface{}
+		expectedType any
+	}{
+		{
+			name: "string value remains string",
+			data: map[string]string{
+				"foo": "bar",
+			},
+			prefix: "",
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+			expectedType: "",
+		},
+		{
+			name: "integer number decoded correctly",
+			data: map[string]string{
+				"intVal": "123",
+			},
+			prefix: "",
+			expected: map[string]interface{}{
+				"intVal": json.Number("123"),
+			},
+			expectedType: json.Number("1"),
+		},
+		{
+			name: "float number decoded correctly",
+			data: map[string]string{
+				"floatVal": "123.45",
+			},
+			prefix: "",
+			expected: map[string]interface{}{
+				"floatVal": json.Number("123.45"),
+			},
+			expectedType: json.Number("1"),
+		},
+		{
+			name: "with prefix",
+			data: map[string]string{
+				"somekey": "42",
+			},
+			prefix: "myprefix-",
+			expected: map[string]interface{}{
+				"myprefix-somekey": json.Number("42"),
+			},
+			expectedType: json.Number("1"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := make(map[string]any)
+			err := processConfigMapData(tt.data, tt.prefix, result)
+			assert.NoError(t, err)
+
+			for k, v := range tt.expected {
+				actual, ok := result[k]
+				assert.True(t, ok, "key %s should exist", k)
+
+				assert.IsType(t, tt.expectedType, actual)
+
+				expectedVal, ok1 := v.(json.Number)
+				actualVal, ok2 := actual.(json.Number)
+
+				if ok1 && ok2 {
+					assert.Equal(t, expectedVal, actualVal)
+				} else {
+					assert.Equal(t, v, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessSecretData_NumbersAsInts(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         map[string][]byte
+		prefix       string
+		expected     map[string]interface{}
+		expectedType any
+	}{
+		{
+			name: "string value remains string",
+			data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+			prefix: "",
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+			expectedType: "",
+		},
+		{
+			name: "integer number decoded correctly",
+			data: map[string][]byte{
+				"intVal": []byte("123"),
+			},
+			prefix: "",
+			expected: map[string]interface{}{
+				"intVal": json.Number("123"),
+			},
+			expectedType: json.Number("1"),
+		},
+		{
+			name: "float number decoded correctly",
+			data: map[string][]byte{
+				"floatVal": []byte("123.45"),
+			},
+			prefix: "",
+			expected: map[string]interface{}{
+				"floatVal": json.Number("123.45"),
+			},
+			expectedType: json.Number("1"),
+		},
+		{
+			name: "with prefix",
+			data: map[string][]byte{
+				"somekey": []byte("42"),
+			},
+			prefix: "myprefix-",
+			expected: map[string]interface{}{
+				"myprefix-somekey": json.Number("42"),
+			},
+			expectedType: json.Number("1"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := make(map[string]any)
+			err := processSecretData(tt.data, tt.prefix, result)
+			assert.NoError(t, err)
+
+			for k, v := range tt.expected {
+				actual, ok := result[k]
+				assert.True(t, ok, "key %s should exist", k)
+
+				assert.IsType(t, tt.expectedType, actual)
+
+				expectedVal, ok1 := v.(json.Number)
+				actualVal, ok2 := actual.(json.Number)
+
+				if ok1 && ok2 {
+					assert.Equal(t, expectedVal, actualVal)
+				} else {
+					assert.Equal(t, v, actual)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When unmarshalling values from json input, all numbers are set to floats. This has unexpected side effects when passing them to Ansible where Ansible is expecting integers. This change adds a helper function to convert all float values to integers.

Jira: https://issues.redhat.com/browse/OSPRH-15097