### PR TITLE
minor update: update rabbit/galara/keystone in sequence

### DIFF
--- a/apis/core/v1beta1/conditions.go
+++ b/apis/core/v1beta1/conditions.go
@@ -467,13 +467,19 @@ const (
 	OpenStackControlPlaneInstanceHaCMReadyMessage = "OpenStackControlPlane InstanceHa CM is available"
 )
 
-// Version Conditions used by API objects.
+// Version Conditions used by to drive minor updates
 const (
 	OpenStackVersionInitialized condition.Type = "Initialized"
 
 	OpenStackVersionMinorUpdateOVNDataplane condition.Type = "MinorUpdateOVNDataplane"
 
 	OpenStackVersionMinorUpdateOVNControlplane condition.Type = "MinorUpdateOVNControlplane"
+
+	OpenStackVersionMinorUpdateRabbitMQ condition.Type = "MinorUpdateRabbitMQ"
+
+	OpenStackVersionMinorUpdateMariaDB condition.Type = "MinorUpdateMariaDB"
+
+	OpenStackVersionMinorUpdateKeystone condition.Type = "MinorUpdateKeystone"
 
 	OpenStackVersionMinorUpdateControlplane condition.Type = "MinorUpdateControlplane"
 

--- a/pkg/openstack/rabbitmq.go
+++ b/pkg/openstack/rabbitmq.go
@@ -285,7 +285,7 @@ func reconcileRabbitMQ(
 	}
 
 	if rabbitmq.Status.ObservedGeneration == rabbitmq.Generation && rabbitmq.IsReady() {
-		instance.Status.ContainerImages.InfraMemcachedImage = version.Status.ContainerImages.InfraMemcachedImage
+		instance.Status.ContainerImages.RabbitmqImage = version.Status.ContainerImages.RabbitmqImage
 		return mqReady, ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
Change the minor update workflow so that RabbitMQ, Galara, and Keystone are updated in sequence ahead of the rest of the controlplane services.

Jira: [OSPRH-16109](https://issues.redhat.com//browse/OSPRH-16109)