### PR TITLE
[cert] cleanup cert when service annotation gets removed

### DIFF
--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -451,6 +451,15 @@ func (ed *EndpointDetail) ensureRoute(
 				// Delete any other owner refs from ref list to not block deletion until owners are gone
 				r.SetOwnerReferences([]metav1.OwnerReference{instanceRef})
 
+				// Delete certificate for the route
+				if ed.Service.TLS.Enabled {
+					err = DeleteCertificate(ctx, helper, instance.Namespace, ed.Route.TLS.CertName)
+					if err != nil && !k8s_errors.IsNotFound(err) {
+						err = fmt.Errorf("Error deleting route certificate %s: %w", ed.Route.TLS.CertName, err)
+						return ctrl.Result{}, err
+					}
+				}
+
 				// Delete route
 				err := helper.GetClient().Delete(ctx, &r)
 				if err != nil && !k8s_errors.IsNotFound(err) {


### PR DESCRIPTION
When the service annotation to expose it via route gets changed, the route get cleaned up, but its certificate remains. This change will also delete the corresponding certificated.