### PR TITLE
Add CRD sync check

### DIFF
--- a/.github/workflows/crd-sync-check.yaml
+++ b/.github/workflows/crd-sync-check.yaml
@@ -1,0 +1,34 @@
+# a simple boolean to check of a CRD sync check is needed
+name: CRD sync check
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # every 2 hours
+  workflow_dispatch:
+
+jobs:
+
+  crd-sync-check:
+    if: github.repository_owner == 'openstack-k8s-operators'
+    name: CRD sync check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+
+    - name: run make force-bump
+      shell: bash
+      run: |
+        BRANCH='${{ github.ref_name }}' make force-bump
+
+    - name: run make bindata
+      shell: bash
+      run: |
+        make bindata
+
+    - name: Fail if there are local CRD changes requiring a CRD sync
+      run: |
+        git diff --quiet bindata/crds

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # openstack-operator
 
 [![CodeQL](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/codeql.yml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/codeql.yml)
+[![CRD sync check](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check.yaml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check.yaml)
 
 This is the primary operator for OpenStack. It is a "meta" operator, meaning it
 serves to coordinate the other operators for OpenStack by watching and configuring

--- a/hack/fake_minor_update.sh
+++ b/hack/fake_minor_update.sh
@@ -1,9 +1,9 @@
 # A quick way to test a fake minor update. Run this script, and then once the
 # openstackversion reconciles (the CSV will redeploy the controller-manager)
 # you can set targetVersion == 0.0.2 for a quick test
-oc get csv openstack-operator.v0.0.1 -o yaml -n openstack-operators  > csv.yaml
+oc get csv openstack-operator.v0.3.0 -o yaml -n openstack-operators  > csv.yaml
 # bump them to current-podified
 sed -i csv.yaml -e "s|value: .*quay.io/podified-antelope-centos9/\(.*\)@.*|value: quay.io/podified-antelope-centos9/\1:current-podified|g"
 # also bump the OPENSTACK_RELEASE_VERSION value (it is the only field set like this)
-sed -i csv.yaml -e "s|value: 0.0.1|value: 0.0.2|"
+sed -i csv.yaml -e "s|value: 0.3.0|value: 0.3.1|"
 oc apply -n openstack-operators -f csv.yaml


### PR DESCRIPTION
This github action runs every 2 hours to check if CRDs are in sync by running 'force-bump, then bindata' and finally
checking if there are CRD changes in the bindata directory

Also adds a badge to display the workflow status on the README