### PR TITLE
Add CRD sync check badge for olive

### DIFF
--- a/.github/workflows/crd-sync-check-olive.yaml
+++ b/.github/workflows/crd-sync-check-olive.yaml
@@ -1,0 +1,13 @@
+name: CRD sync check olive branch
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # every 2 hours
+  workflow_dispatch:
+
+jobs:
+  call-build-workflow:
+    if: github.repository_owner == 'openstack-k8s-operators'
+    uses: ./.github/workflows/crd-sync-check.yaml
+    with:
+      branch_name: olive

--- a/.github/workflows/crd-sync-check.yaml
+++ b/.github/workflows/crd-sync-check.yaml
@@ -5,6 +5,15 @@ on:
   schedule:
     - cron: '0 */2 * * *' # every 2 hours
   workflow_dispatch:
+    inputs:
+      branch_name:
+        default: 'main'
+        type: string
+  workflow_call:
+    inputs:
+      branch_name:
+        default: 'main'
+        type: string
 
 jobs:
 
@@ -14,21 +23,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+    - name: Set branch
+      id: set_branch
+      run: |
+        BRANCH_NAME="${{ inputs.branch_name || github.ref_name }}"
+        echo "branch name set to: $BRANCH_NAME"
+        echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.ref_name }}
+        ref: ${{ steps.set_branch.outputs.branch_name  }}
 
     - name: run make force-bump
       shell: bash
       run: |
-        BRANCH='${{ github.ref_name }}' make force-bump
+        BRANCH='${{ steps.set_branch.outputs.branch_name }}' make force-bump
 
     - name: run make bindata
       shell: bash
       run: |
         make bindata
 
-    - name: Fail if there are local CRD changes requiring a CRD sync
+    - name: Fail if there are local CRD changes in bindata/crds
       run: |
         git diff --quiet bindata/crds

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # openstack-operator
 
 [![CodeQL](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/codeql.yml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/codeql.yml)
-[![CRD sync check](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check.yaml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check.yaml)
+[![CRD sync check main](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check.yaml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check.yaml)
+[![CRD sync check olive](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check-olive.yaml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check-olive.yaml)
 
 This is the primary operator for OpenStack. It is a "meta" operator, meaning it
 serves to coordinate the other operators for OpenStack by watching and configuring


### PR DESCRIPTION
Rework the workflow slightly to accommodate implementation via 2 files which will allow both badges to show up in the main README.