### PR TITLE
Support IDMS for disconnected automation

### DIFF
--- a/bindata/rbac/rbac.yaml
+++ b/bindata/rbac/rbac.yaml
@@ -244,6 +244,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - imagedigestmirrorsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - networks
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -201,6 +201,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - imagedigestmirrorsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - networks
   verbs:
   - get

--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -125,6 +125,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) GetLogger(ctx context.Context) log
 
 // RBAC for ImageContentSourcePolicy and MachineConfig
 // +kubebuilder:rbac:groups="operator.openshift.io",resources=imagecontentsourcepolicies,verbs=get;list;watch
+// +kubebuilder:rbac:groups="config.openshift.io",resources=imagedigestmirrorsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="machineconfiguration.openshift.io",resources=machineconfigs,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/docs/assemblies/proc_deploying-in-disconnected-environments.adoc
+++ b/docs/assemblies/proc_deploying-in-disconnected-environments.adoc
@@ -8,9 +8,9 @@ Deploying in disconnected environments can be achieved largely by following the 
 == Technical Implementation
 The details provided in this section are for informational purposes only. Users should not need to interact with anything additional after completing the above mentioned OLM mirroring process.
 
-The `openstack-operator` contains a list of related images that will ensure all required images for the deployment are mirrored following the above OpenShift process. Once images are mirrored, the `ImageContentSourcePolicy` custom resource (CR) is created. This process results in a `MachineConfig` called `99-master-genereted-registries` being updated in the cluster. The `99-master-generated-registries` `MachineConfig` contains a `registries.conf` file that is applied to all of the OpenShift nodes in the cluster.
+The `openstack-operator` contains a list of related images that will ensure all required images for the deployment are mirrored following the above OpenShift process. Once images are mirrored, either an `ImageContentSourcePolicy` custom resource (CR), or a `ImageDigestMirrorSet` CR is created. This process results in a `MachineConfig` called `99-master-genereted-registries` being updated in the cluster. The `99-master-generated-registries` `MachineConfig` contains a `registries.conf` file that is applied to all of the OpenShift nodes in the cluster.
 
-In order for dataplane nodes to integrate cleanly with this process, openstack-operator checks for the existence of an `ImageContentSourcePolicy`. If one is found, it will read the `registries.conf` file from the `99-master-generated-registries` `MachineConfig`. The openstack-operator will then set two variables in the Ansible inventory for the nodes.
+In order for dataplane nodes to integrate cleanly with this process, openstack-operator checks for the existence of an `ImageContentSourcePolicy` or an `ImageDigestMirrorSet`. If one is found, it will read the `registries.conf` file from the `99-master-generated-registries` `MachineConfig`. The openstack-operator will then set two variables in the Ansible inventory for the nodes.
 
 [,yaml]
 ----

--- a/tests/functional/dataplane/suite_test.go
+++ b/tests/functional/dataplane/suite_test.go
@@ -106,6 +106,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ShouldNot(HaveOccurred())
 	imageContentSourcePolicyCRDs, err := test.GetCRDDirFromModule("github.com/openshift/api", gomod, "operator/v1alpha1/zz_generated.crd-manifests/")
 	Expect(err).ShouldNot(HaveOccurred())
+	imageDigestMirrorSetCRDs, err := test.GetCRDDirFromModule("github.com/openshift/api", gomod, "config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml")
+	Expect(err).ShouldNot(HaveOccurred())
 	machineConfigCRDs, err := test.GetCRDDirFromModule("github.com/openshift/api", gomod, "machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigs.crd.yaml")
 	Expect(err).ShouldNot(HaveOccurred())
 
@@ -118,6 +120,7 @@ var _ = BeforeSuite(func() {
 			certmgrv1CRDs,
 			openstackCRDs,
 			imageContentSourcePolicyCRDs,
+			imageDigestMirrorSetCRDs,
 			machineConfigCRDs,
 		},
 		WebhookInstallOptions: envtest.WebhookInstallOptions{


### PR DESCRIPTION
This change adds support for IDMS in addition to ICSP when determining whether the OCP cluster is in a disconnected state.