### PR TITLE
Propagate top-level extraMounts to Horizon and Keystone

### DIFF
--- a/pkg/openstack/horizon.go
+++ b/pkg/openstack/horizon.go
@@ -157,6 +157,15 @@ func ReconcileHorizon(ctx context.Context, instance *corev1beta1.OpenStackContro
 			horizon.Spec.Secret = instance.Spec.Secret
 		}
 
+		// Append globally defined extraMounts to the service's own list.
+		for _, ev := range instance.Spec.ExtraMounts {
+			horizon.Spec.ExtraMounts = append(horizon.Spec.ExtraMounts, horizonv1.HorizonExtraVolMounts{
+				Name:      ev.Name,
+				Region:    ev.Region,
+				VolMounts: ev.VolMounts,
+			})
+		}
+
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), horizon, helper.GetScheme())
 		if err != nil {
 			return err

--- a/pkg/openstack/keystone.go
+++ b/pkg/openstack/keystone.go
@@ -128,6 +128,15 @@ func ReconcileKeystoneAPI(ctx context.Context, instance *corev1beta1.OpenStackCo
 			keystoneAPI.Spec.DatabaseInstance = "openstack" //FIXME: see above
 		}
 
+		// Append globally defined extraMounts to the service's own list.
+		for _, ev := range instance.Spec.ExtraMounts {
+			keystoneAPI.Spec.ExtraMounts = append(keystoneAPI.Spec.ExtraMounts, keystonev1.KeystoneExtraMounts{
+				Name:      ev.Name,
+				Region:    ev.Region,
+				VolMounts: ev.VolMounts,
+			})
+		}
+
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), keystoneAPI, helper.GetScheme())
 		if err != nil {
 			return err


### PR DESCRIPTION
The other extraMounts consumers (Glance/Cinder/Neutron) already do this.

Jira: OSPRH-15724