### PR TITLE
Leader election lease tunables

### DIFF
--- a/bindata/operator/managers.yaml
+++ b/bindata/operator/managers.yaml
@@ -1,5 +1,8 @@
 {{ $namespace := .OperatorNamespace }}
 {{ $kubeRbacProxyImage := .KubeRbacProxyImage }}
+{{ $leaseDuration := .LeaseDuration }}
+{{ $renewDeadline := .RenewDeadline }}
+{{ $retryPeriod := .RetryPeriod }}
 {{ range $operatorName, $operatorImage := .OperatorImages }}
 apiVersion: apps/v1
 kind: Deployment
@@ -36,6 +39,12 @@ spec:
 {{ else }}
           value: 'false'
 {{ end }}
+        - name: LEASE_DURATION
+          value: '{{ $leaseDuration }}'
+        - name: RENEW_DEADLINE
+          value: '{{ $renewDeadline }}'
+        - name: RETRY_PERIOD
+          value: '{{ $retryPeriod }}'
         image: {{ $operatorImage }}
         livenessProbe:
           httpGet:

--- a/bindata/operator/operator.yaml
+++ b/bindata/operator/operator.yaml
@@ -76,6 +76,12 @@ spec:
         env:
         - name: OPENSTACK_RELEASE_VERSION
           value: '{{ .OpenstackReleaseVersion }}'
+        - name: LEASE_DURATION
+          value: '{{ .LeaseDuration }}'
+        - name: RENEW_DEADLINE
+          value: '{{ .RenewDeadline }}'
+        - name: RETRY_PERIOD
+          value: '{{ .RetryPeriod }}'
 {{ range $envName, $envValue := .OpenStackServiceRelatedImages }}
         - name: {{ $envName }}
           value: {{ $envValue }}

--- a/bindata/operator/rabbit.yaml
+++ b/bindata/operator/rabbit.yaml
@@ -27,6 +27,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: LEASE_DURATION
+          value: '{{ .LeaseDuration }}'
+        - name: RENEW_DEADLINE
+          value: '{{ .RenewDeadline }}'
+        - name: RETRY_PERIOD
+          value: '{{ .RetryPeriod }}'
         image: {{ .RabbitmqImage }}
         name: operator
         ports:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -42,6 +42,7 @@ import (
 
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/operator"
 	operatorv1beta1 "github.com/openstack-k8s-operators/openstack-operator/apis/operator/v1beta1"
 	operatorcontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/operator"
 )
@@ -87,7 +88,7 @@ func main() {
 		c.NextProtos = []string{"http/1.1"}
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	options := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -111,7 +112,15 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	err = operator.SetManagerOptions(&options, setupLog)
+	if err != nil {
+		setupLog.Error(err, "unable to set manager options")
+		os.Exit(1)
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,6 +44,12 @@ spec:
         env:
         - name: OPENSTACK_RELEASE_VERSION
           value: '{{ .OpenstackReleaseVersion }}'
+        - name: LEASE_DURATION
+          value: '{{ .LeaseDuration }}'
+        - name: RENEW_DEADLINE
+          value: '{{ .RenewDeadline }}'
+        - name: RETRY_PERIOD
+          value: '{{ .RetryPeriod }}'
         envCustomImage: replace_me #NOTE: this is used via the Makefile to inject a custom template loop that kustomize won't allow
         image: '{{ .OperatorImage }}'
         name: manager

--- a/config/operator/deployment/deployment.yaml
+++ b/config/operator/deployment/deployment.yaml
@@ -69,6 +69,12 @@ spec:
           value: quay.io/openstack-k8s-operators/openstack-operator:latest
         - name: ENABLE_WEBHOOKS
           value: false
+        - name: LEASE_DURATION
+          value: 30
+        - name: RENEW_DEADLINE
+          value: 20
+        - name: RETRY_PERIOD
+          value: 5
         image: controller:latest
         name: operator
         securityContext:

--- a/config/operator/managers.yaml
+++ b/config/operator/managers.yaml
@@ -1,5 +1,8 @@
 {{ $namespace := .OperatorNamespace }}
 {{ $kubeRbacProxyImage := .KubeRbacProxyImage }}
+{{ $leaseDuration := .LeaseDuration }}
+{{ $renewDeadline := .RenewDeadline }}
+{{ $retryPeriod := .RetryPeriod }}
 {{ range $operatorName, $operatorImage := .OperatorImages }}
 apiVersion: apps/v1
 kind: Deployment
@@ -36,6 +39,12 @@ spec:
 {{ else }}
           value: 'false'
 {{ end }}
+        - name: LEASE_DURATION
+          value: '{{ $leaseDuration }}'
+        - name: RENEW_DEADLINE
+          value: '{{ $renewDeadline }}'
+        - name: RETRY_PERIOD
+          value: '{{ $retryPeriod }}'
         image: {{ $operatorImage }}
         livenessProbe:
           httpGet:

--- a/config/operator/rabbit.yaml
+++ b/config/operator/rabbit.yaml
@@ -27,6 +27,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: LEASE_DURATION
+          value: '{{ .LeaseDuration }}'
+        - name: RENEW_DEADLINE
+          value: '{{ .RenewDeadline }}'
+        - name: RETRY_PERIOD
+          value: '{{ .RetryPeriod }}'
         image: {{ .RabbitmqImage }}
         name: operator
         ports:

--- a/controllers/operator/openstack_controller.go
+++ b/controllers/operator/openstack_controller.go
@@ -71,6 +71,9 @@ var (
 	operatorImage                    string
 	kubeRbacProxyImage               string
 	openstackReleaseVersion          string
+	leaseDuration                    string
+	renewDeadline                    string
+	retryPeriod                      string
 )
 
 // SetupEnv -
@@ -100,7 +103,14 @@ func SetupEnv() {
 			operatorImage = envArr[1]
 		} else if envArr[0] == "OPENSTACK_RELEASE_VERSION" {
 			openstackReleaseVersion = envArr[1]
+		} else if envArr[0] == "LEASE_DURATION" {
+			leaseDuration = envArr[1]
+		} else if envArr[0] == "RENEW_DEADLINE" {
+			renewDeadline = envArr[1]
+		} else if envArr[0] == "RETRY_PERIOD" {
+			retryPeriod = envArr[1]
 		}
+
 	}
 }
 
@@ -454,6 +464,9 @@ func (r *OpenStackReconciler) applyOperator(ctx context.Context, instance *opera
 	data.Data["OperatorImage"] = operatorImage
 	data.Data["KubeRbacProxyImage"] = kubeRbacProxyImage
 	data.Data["OpenstackReleaseVersion"] = openstackReleaseVersion
+	data.Data["LeaseDuration"] = leaseDuration
+	data.Data["RenewDeadline"] = renewDeadline
+	data.Data["RetryPeriod"] = retryPeriod
 	data.Data["OpenStackServiceRelatedImages"] = envRelatedOpenStackServiceImages
 	return r.renderAndApply(ctx, instance, data, "operator", true)
 }

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/operator"
 	manilav1 "github.com/openstack-k8s-operators/manila-operator/api/v1beta1"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	neutronv1 "github.com/openstack-k8s-operators/neutron-operator/api/v1beta1"
@@ -165,7 +166,7 @@ func main() {
 		c.NextProtos = []string{"http/1.1"}
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	options := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -189,7 +190,15 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	err = operator.SetManagerOptions(&options, setupLog)
+	if err != nil {
+		setupLog.Error(err, "unable to set manager options")
+		os.Exit(1)
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
Set leader election LeaseDuration, RenewDealine and RetryPeriod via env variables.

The values used are the ones mentioned as recommended in:
  https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#high-availability

Co-authored-by: Dan Prince <dprince@redhat.com>

Jira: [OSPRH-16335](https://issues.redhat.com//browse/OSPRH-16335)