### PR TITLE
Bump default memory limit for controller manager to 512Mi

### DIFF
--- a/bindata/operator/managers.yaml
+++ b/bindata/operator/managers.yaml
@@ -3,6 +3,7 @@
 {{ $leaseDuration := .LeaseDuration }}
 {{ $renewDeadline := .RenewDeadline }}
 {{ $retryPeriod := .RetryPeriod }}
+{{ $managerMemoryLimit := .ManagerMemoryLimit }}
 {{ range $operatorName, $operatorImage := .OperatorImages }}
 apiVersion: apps/v1
 kind: Deployment
@@ -62,7 +63,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: '{{ $managerMemoryLimit }}'
           requests:
             cpu: 10m
             memory: 128Mi

--- a/bindata/operator/operator.yaml
+++ b/bindata/operator/operator.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: '{{ .ManagerMemoryLimit }}'
           requests:
             cpu: 10m
             memory: 128Mi

--- a/bindata/operator/rabbit.yaml
+++ b/bindata/operator/rabbit.yaml
@@ -42,7 +42,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 500Mi
+            memory: '{{ .ManagerMemoryLimit }}'
           requests:
             cpu: 5m
             memory: 64Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: '{{ .ManagerMemoryLimit }}'
           requests:
             cpu: 10m
             memory: 128Mi

--- a/config/operator/deployment/deployment.yaml
+++ b/config/operator/deployment/deployment.yaml
@@ -75,6 +75,8 @@ spec:
           value: 20
         - name: RETRY_PERIOD
           value: 5
+        - name: MANAGER_MEMORY_LIMIT
+          value: 512Mi
         image: controller:latest
         name: operator
         securityContext:

--- a/config/operator/managers.yaml
+++ b/config/operator/managers.yaml
@@ -3,6 +3,7 @@
 {{ $leaseDuration := .LeaseDuration }}
 {{ $renewDeadline := .RenewDeadline }}
 {{ $retryPeriod := .RetryPeriod }}
+{{ $managerMemoryLimit := .ManagerMemoryLimit }}
 {{ range $operatorName, $operatorImage := .OperatorImages }}
 apiVersion: apps/v1
 kind: Deployment
@@ -62,7 +63,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: '{{ $managerMemoryLimit }}'
           requests:
             cpu: 10m
             memory: 128Mi

--- a/config/operator/rabbit.yaml
+++ b/config/operator/rabbit.yaml
@@ -42,7 +42,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 500Mi
+            memory: '{{ .ManagerMemoryLimit }}'
           requests:
             cpu: 5m
             memory: 64Mi

--- a/controllers/operator/openstack_controller.go
+++ b/controllers/operator/openstack_controller.go
@@ -74,6 +74,7 @@ var (
 	leaseDuration                    string
 	renewDeadline                    string
 	retryPeriod                      string
+	managerMemoryLimit               string
 )
 
 // SetupEnv -
@@ -109,8 +110,9 @@ func SetupEnv() {
 			renewDeadline = envArr[1]
 		} else if envArr[0] == "RETRY_PERIOD" {
 			retryPeriod = envArr[1]
+		} else if envArr[0] == "MANAGER_MEMORY_LIMIT" {
+			managerMemoryLimit = envArr[1]
 		}
-
 	}
 }
 
@@ -467,6 +469,7 @@ func (r *OpenStackReconciler) applyOperator(ctx context.Context, instance *opera
 	data.Data["LeaseDuration"] = leaseDuration
 	data.Data["RenewDeadline"] = renewDeadline
 	data.Data["RetryPeriod"] = retryPeriod
+	data.Data["ManagerMemoryLimit"] = managerMemoryLimit
 	data.Data["OpenStackServiceRelatedImages"] = envRelatedOpenStackServiceImages
 	return r.renderAndApply(ctx, instance, data, "operator", true)
 }


### PR DESCRIPTION
In tests it was seen that the openstack-operator controller manager reaches just bellow the current set limit of 256Mi. This change bumps the default to 512Mi for all controller managers, except the openstack-operator-controller-operator which could be customized using the CSV. It also introduces a MANAGER_MEMORY_LIMIT env var in the CSV which can be used to change the memory limit of all the other controller managers.

Jira: [OSPRH-16802](https://issues.redhat.com//browse/OSPRH-16802)