### PR TITLE
[18.0-fr2] Propagate top-level extraMounts to Horizon

### DIFF
--- a/pkg/openstack/horizon.go
+++ b/pkg/openstack/horizon.go
@@ -157,6 +157,15 @@ func ReconcileHorizon(ctx context.Context, instance *corev1beta1.OpenStackContro
 			horizon.Spec.Secret = instance.Spec.Secret
 		}
 
+		// Append globally defined extraMounts to the service's own list.
+		for _, ev := range instance.Spec.ExtraMounts {
+			horizon.Spec.ExtraMounts = append(horizon.Spec.ExtraMounts, horizonv1.HorizonExtraVolMounts{
+				Name:      ev.Name,
+				Region:    ev.Region,
+				VolMounts: ev.VolMounts,
+			})
+		}
+
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), horizon, helper.GetScheme())
 		if err != nil {
 			return err


### PR DESCRIPTION
The other extraMounts consumers (Glance/Cinder/Neutron) already do this.

Jira: [OSPRH-15724](https://issues.redhat.com//browse/OSPRH-15724)

Cherry-pick of https://github.com/openstack-k8s-operators/openstack-operator/pull/1441