### PR TITLE
Bump memory resources for openstack-operator-controller-manager

### DIFF
--- a/bindata/operator/operator.yaml
+++ b/bindata/operator/operator.yaml
@@ -107,10 +107,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 1Gi
           requests:
             cpu: 10m
-            memory: 128Mi
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,9 +76,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 1Gi
           requests:
             cpu: 10m
-            memory: 128Mi
+            memory: 512Mi
       serviceAccountName: openstack-operator-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
In tests it was seen that the openstack-operator controller manager reaches just bellow the current set limit of 256Mi. This change bumps the request to 512Mi and the limit to 1Gi for the openstack-operator-controller-operator.

Jira: [OSPRH-16802](https://issues.redhat.com//browse/OSPRH-16802)