### PR TITLE
[OSPCIX-797] Log which operators are pending during OpenStack init

### DIFF
--- a/apis/operator/v1beta1/conditions.go
+++ b/apis/operator/v1beta1/conditions.go
@@ -23,12 +23,15 @@ import (
 const (
 	// OpenStackOperatorReadyCondition Status=True condition which indicates if operators have been deployed
 	OpenStackOperatorReadyCondition condition.Type = "OpenStackOperatorReadyCondition"
+
+	// OpenStackOperatorDeploymentsReadyCondition Status=True condition which indicates if operator deployments are ready
+	OpenStackOperatorDeploymentsReadyCondition condition.Type = "OpenStackOperatorDeploymentsReadyCondition"
 )
 
 // Common Messages used by Openstack operator
 const (
 	//
-	// OpenStackOperator condition messages
+	// OpenStackOperatorReady condition messages
 	//
 
 	// OpenStackOperatorErrorMessage
@@ -42,4 +45,20 @@ const (
 
 	// OpenStackOperatorReadyMessage
 	OpenStackOperatorReadyMessage = "OpenStackOperator completed"
+
+	//
+	// OpenStackOperatorDeploymentsReady condition messages
+	//
+
+	// OpenStackOperatorDeploymentsErrorMessage
+	OpenStackOperatorDeploymentsErrorMessage = "OpenStackOperatorDeployments error occured %s"
+
+	// OpenStackOperatorDeploymentsReadyInitMessage
+	OpenStackOperatorDeploymentsReadyInitMessage = "OpenStackOperatorDeployments not started"
+
+	// OpenStackOperatorDeploymentsReadyRunningMessage
+	OpenStackOperatorDeploymentsReadyRunningMessage = "OpenStackOperatorDeployments still in progress: %s"
+
+	// OpenStackOperatorDeploymentsReadyMessage
+	OpenStackOperatorDeploymentsReadyMessage = "OpenStackOperatorDeployments completed"
 )


### PR DESCRIPTION
This will help provide greater insight into what is happening when OpenStack initialization is stuck.  Specifically, as we investigate CI failures in the context of https://issues.redhat.com/browse/OSPCIX-797, it will drastically increase the speed at which we can find which operators are hanging.  Currently we have to look at each `Deployment` YAML in the `must-gather` and find those which lack `readyReplicas: 1`, which takes a few minutes to do.