### PR TITLE
Add delay on checking BAD_OR_MISSING_NODE_SELECTOR_COUNT or service certs

### DIFF
--- a/tests/kuttl/common/osp_check_noapi_service_certs.sh
+++ b/tests/kuttl/common/osp_check_noapi_service_certs.sh
@@ -73,6 +73,7 @@ for database in "${!database_secrets[@]}"; do
 
     for port in $ports; do
         echo "Connecting to $database on port $port..."
+        sleep 5
 
         pod_cert=$(oc rsh -n "$NAMESPACE" openstackclient openssl s_client -starttls mysql -connect "$cluster_ip:$port" </dev/null 2>/dev/null | sed -ne '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p')
 

--- a/tests/kuttl/tests/ctlplane-nodeselectors/02-assert-nodeselector.yaml
+++ b/tests/kuttl/tests/ctlplane-nodeselectors/02-assert-nodeselector.yaml
@@ -10,6 +10,8 @@ commands:
         echo "Found $BAD_OR_MISSING_NODE_SELECTOR_COUNT pods with bad or missing nodeselector:"
         echo "$BAD_OR_MISSING_NODE_SELECTOR"
         exit 1
+      else
+        sleep 5
       fi
   - script: |
       echo "Checking all cronjobs have expected nodeselector"
@@ -20,4 +22,6 @@ commands:
         echo "Found $BAD_OR_MISSING_NODE_SELECTOR_COUNT cronjobs with bad or missing nodeselector:"
         echo "$BAD_OR_MISSING_NODE_SELECTOR"
         exit 1
+      else
+        sleep 5
       fi

--- a/tests/kuttl/tests/ctlplane-nodeselectors/04-assert-nodeselector.yaml
+++ b/tests/kuttl/tests/ctlplane-nodeselectors/04-assert-nodeselector.yaml
@@ -10,6 +10,8 @@ commands:
         echo "Found $BAD_OR_MISSING_NODE_SELECTOR_COUNT pods with bad or missing nodeselector:"
         echo "$BAD_OR_MISSING_NODE_SELECTOR"
         exit 1
+      else
+        sleep 5
       fi
   - script: |
       echo "Checking all cronjobs have expected nodeselector"
@@ -20,4 +22,6 @@ commands:
         echo "Found $BAD_OR_MISSING_NODE_SELECTOR_COUNT cronjobs with bad or missing nodeselector:"
         echo "$BAD_OR_MISSING_NODE_SELECTOR"
         exit 1
+      else
+        sleep 5
       fi


### PR DESCRIPTION
The script might make some troubles for OpenShift API to reply
when there is no delay on repeating command.
Also add few seconds delay on checking service certs to avoid errors on
some infrastructures like:

        case.go:398: command "echo \"Checking rotation of non API service certificates...\"
        NAMES..." exceeded 3 sec timeout, context deadline exceeded