### PR TITLE
Remove spaces on getting ISSUER details

### DIFF
--- a/tests/kuttl/common/osp_check_cert_issuer.sh
+++ b/tests/kuttl/common/osp_check_cert_issuer.sh
@@ -61,9 +61,9 @@ for url in $(openstack endpoint list -c URL -f value | grep "$endpoint_filter");
 
     echo "Checking $host_port ..."
     if [[ "$ENDPOINT_TYPE" == "public" ]]; then
-        ISSUER=$(echo | openssl s_client -connect "$host_port" 2>/dev/null | openssl x509 -noout -issuer | sed -n 's/^.*CN=\([^,]*\).*$/\1/p')
+        ISSUER=$(echo | openssl s_client -connect "$host_port" 2>/dev/null | openssl x509 -noout -issuer | sed -n 's/^.*CN=\([^,]*\).*$/\1/p' | sed 's/ //g')
     else
-        ISSUER=$(openssl s_client -connect $host_port < /dev/null 2>/dev/null | openssl x509 -issuer -noout -in /dev/stdin)
+        ISSUER=$(openssl s_client -connect $host_port </dev/null 2>/dev/null | openssl x509 -issuer -noout -in /dev/stdin | sed 's/ //g')
     fi
 
     if [[ "$ISSUER" != "$EXPECTED_ISSUER" ]]; then


### PR DESCRIPTION
It happens that the cert issuer output contains spaces, which later in the condition where it is comparing with expected issuer it just fails.