### PR TITLE
Add retry on getting ISSUER name

### DIFF
--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/02-assert-service-certs-issuers.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/02-assert-service-certs-issuers.yaml
@@ -8,7 +8,7 @@ commands:
 
   - script: |
       echo "Checking issuer of internal certificates..."
-      oc exec -i openstackclient -n $NAMESPACE -- bash -s < ../../common/osp_check_cert_issuer.sh "issuer=CN=rootca-internal-custom" "internal"
+      oc exec -i openstackclient -n $NAMESPACE -- bash -s < ../../common/osp_check_cert_issuer.sh "rootca-internal-custom" "internal"
 
   - script: |
       echo "Checking issuer of ingress certificates..."

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/04-assert-service-certs-default-issuers.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/04-assert-service-certs-default-issuers.yaml
@@ -12,7 +12,7 @@ commands:
 
   - script: |
       echo "Checking issuer of internal certificates..."
-      oc exec -i openstackclient -n $NAMESPACE -- bash -s < ../../common/osp_check_cert_issuer.sh "issuer=CN=rootca-internal" "internal"
+      oc exec -i openstackclient -n $NAMESPACE -- bash -s < ../../common/osp_check_cert_issuer.sh "rootca-internal" "internal"
 
   - script: |
       echo "Checking issuer of ingress certificates..."

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/07-assert-service-certs-default-issuers.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/07-assert-service-certs-default-issuers.yaml
@@ -8,7 +8,7 @@ commands:
 
   - script: |
       echo "Checking issuer of internal certificates..."
-      oc exec -i openstackclient -n $NAMESPACE -- bash -s < ../../common/osp_check_cert_issuer.sh "issuer=CN=rootca-internal" "internal"
+      oc exec -i openstackclient -n $NAMESPACE -- bash -s < ../../common/osp_check_cert_issuer.sh "rootca-internal" "internal"
 
   - script: |
       echo "Checking issuer of ingress certificates..."

--- a/tests/kuttl/tests/ctlplane-tls-custom-issuers/10-assert-service-certs-issuers.yaml
+++ b/tests/kuttl/tests/ctlplane-tls-custom-issuers/10-assert-service-certs-issuers.yaml
@@ -12,7 +12,7 @@ commands:
 
   - script: |
       echo "Checking issuer of internal certificates..."
-      oc exec -i openstackclient -n $NAMESPACE -- bash -s < ../../common/osp_check_cert_issuer.sh "issuer=CN=rootca-internal-custom" "internal"
+      oc exec -i openstackclient -n $NAMESPACE -- bash -s < ../../common/osp_check_cert_issuer.sh "rootca-internal-custom" "internal"
 
   - script: |
       echo "Checking issuer of ingress certificates..."


### PR DESCRIPTION
It happens on some infras that the issuer is empty. Probably it does not have enough time to apply changes.
This commit adds retry for getting the ISSUER name.