### PR TITLE
Add github workflow to create upgrades OLM catalog

### DIFF
--- a/.github/workflows/catalog-openstack-operator-upgrades.yaml
+++ b/.github/workflows/catalog-openstack-operator-upgrades.yaml
@@ -1,0 +1,89 @@
+name: Build catalog for OLM upgrade testing
+
+on:
+  workflow_run:
+    workflows: ["openstack operator image builder"]
+    types:
+      - completed
+    secrets:
+      IMAGENAMESPACE:
+        required: true
+      QUAY_USERNAME:
+        required: true
+      QUAY_PASSWORD:
+        required: true
+      REDHATIO_USERNAME:
+        required: true
+      REDHATIO_PASSWORD:
+        required: true
+
+env:
+  imageregistry: 'quay.io'
+  imagenamespace: ${{ secrets.IMAGENAMESPACE || secrets.QUAY_USERNAME }}
+  latesttag: latest
+
+jobs:
+  build-catalog:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ inputs.go_version }}
+        cache: false
+
+    - name: Checkout openstack-operator repository
+      uses: actions/checkout@v4
+      with:
+        path: ./openstack-operator
+
+    - name: Install opm
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        source: github
+        opm: 'latest'
+
+    - name: Log in to Quay Registry
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: ${{ env.imageregistry }}
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Log in to Red Hat Registry
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: registry.redhat.io
+        username: ${{ secrets.REDHATIO_USERNAME }}
+        password: ${{ secrets.REDHATIO_PASSWORD }}
+
+    - name: Create the catalog index
+      shell: bash
+      run: ./openstack-operator/hack/catalog-build-olm-upgrade.sh
+      env:
+        #FIXME: these should be pulled from a YAML config in the main operator directory?
+        MAIN_VERSION: 0.3.0
+        FEATURE_RELEASE_VERSION: 0.2.0
+        FEATURE_RELEASE_BRANCH: 18.0-fr2
+        BUNDLE:  ${{ env.imageregistry }}/${{ env.imagenamespace }}/openstack-operator-bundle:${{ github.sha }}
+
+    - name: Buildah Action
+      id: build-operator-index-upgrade
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: openstack-operator-index-upgrade
+        tags: ${{ env.latesttag }} ${{ github.sha }}
+        containerfiles: |
+          ./catalog.Dockerfile
+
+    - name: Push openstack-operator-index-upgrade To ${{ env.imageregistry }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-operator-index-upgrade.outputs.image }}
+        tags: ${{ steps.build-operator-index-upgrade.outputs.tags }}
+        registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}

--- a/hack/catalog-build-olm-upgrade.sh
+++ b/hack/catalog-build-olm-upgrade.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#NOTE: this script is used by the catalog-openstack-operator-upgrades.yaml
+set -ex
+
+MAIN_VERSION=${MAIN_VERSION:-"0.3.0"}
+FEATURE_RELEASE_VERSION=${FEATURE_RELEASE_VERSION:-"0.2.0"}
+FEATURE_RELEASE_BRANCH=${FEATURE_RELEASE_BRANCH:-"18.0-fr2"}
+BUNDLE=${BUNDLE:-"quay.io/openstack-k8s-operators/openstack-operator-bundle:latest"}
+
+[ -d "catalog" ] && rm -Rf catalog
+[ -e "catalog.Dockerfile" ] && rm catalog.Dockerfile
+mkdir catalog
+
+opm generate dockerfile ./catalog -i registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
+opm init openstack-operator --default-channel=stable-v1.0 --output yaml > catalog/index.yaml
+
+opm render ${BUNDLE} --output yaml >> catalog/index.yaml
+# always default to use the FR release from openstack-k8s-operators
+opm render quay.io/openstack-k8s-operators/openstack-operator-bundle:${FEATURE_RELEASE_BRANCH}-latest --output yaml >> catalog/index.yaml
+
+  cat >> catalog/index.yaml << EOF_CAT
+---
+schema: olm.channel
+package: openstack-operator
+name: stable-v1.0
+entries:
+  - name: openstack-operator.v${FEATURE_RELEASE_VERSION}
+  - name: openstack-operator.v${MAIN_VERSION}
+    replaces: openstack-operator.v${FEATURE_RELEASE_VERSION}
+EOF_CAT
+opm validate catalog


### PR DESCRIPTION
The upgrades OLM catalog/index has 2 releases in it to facilitate testing operator updates from the last feature release to main.

Jira: OSPRH-14819