### PR TITLE
Bump memory resources for infra-operator-controller-manager

### DIFF
--- a/bindata/operator/managers.yaml
+++ b/bindata/operator/managers.yaml
@@ -60,12 +60,21 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
+{{ if (eq $operatorName "infra") }}
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 512Mi
+{{ else }}
           limits:
             cpu: 500m
             memory: 256Mi
           requests:
             cpu: 10m
             memory: 128Mi
+{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
 {{ if or (eq $operatorName "infra") (eq $operatorName "openstack-baremetal") }}

--- a/config/operator/managers.yaml
+++ b/config/operator/managers.yaml
@@ -60,12 +60,21 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
+{{ if (eq $operatorName "infra") }}
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 512Mi
+{{ else }}
           limits:
             cpu: 500m
             memory: 256Mi
           requests:
             cpu: 10m
             memory: 128Mi
+{{ end }}
         securityContext:
           allowPrivilegeEscalation: false
 {{ if or (eq $operatorName "infra") (eq $operatorName "openstack-baremetal") }}


### PR DESCRIPTION
This change bumps the request to 512Mi and the limit to 1Gi for the infra-operator-controller-operator.

Jira: [OSPRH-17187](https://issues.redhat.com//browse/OSPRH-17187)