### PR TITLE
Add new update data plane service CRs into openstack-operator

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_update_services.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_update_services.yaml
@@ -1,0 +1,7 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: update-services
+spec:
+  playbook: osp.edpm.update_services
+  edpmServiceType: update-services

--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_update_system.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_update_system.yaml
@@ -1,0 +1,7 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: update-system
+spec:
+  playbook: osp.edpm.update_system
+  edpmServiceType: update-system

--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -540,7 +540,7 @@ func checkDeployment(ctx context.Context, helper *helper.Helper,
 					services = instance.Spec.Services
 				}
 
-				// For each service, check if EDPMServiceType is "update", and
+				// For each service, check if EDPMServiceType is "update" or "update-services", and
 				// if so, copy Deployment.Status.DeployedVersion to
 				// NodeSet.Status.DeployedVersion
 				for _, serviceName := range services {
@@ -555,11 +555,11 @@ func checkDeployment(ctx context.Context, helper *helper.Helper,
 						return isDeploymentReady, isDeploymentRunning, isDeploymentFailed, failedDeploymentName, err
 					}
 
-					if service.Spec.EDPMServiceType != "update" {
+					if service.Spec.EDPMServiceType != "update" && service.Spec.EDPMServiceType != "update-services" {
 						continue
 					}
 
-					// An "update" service Deployment has been completed, so
+					// An "update" or "update-services" service Deployment has been completed, so
 					// set the NodeSet's DeployedVersion to the Deployment's
 					// DeployedVersion.
 					instance.Status.DeployedVersion = deployment.Status.DeployedVersion

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -316,6 +316,15 @@ func MinorUpdateDataPlaneDeploymentSpec() map[string]interface{} {
 	}
 }
 
+func MinorUpdateServicesDataPlaneDeploymentSpec() map[string]interface{} {
+	return map[string]interface{}{
+		"nodeSets": []string{
+			"edpm-compute-nodeset",
+		},
+		"servicesOverride": []string{"update-services"},
+	}
+}
+
 // Build OpenStackDataPlnaeDeploymentSpec with duplicate services
 func DuplicateServiceDeploymentSpec() map[string]interface{} {
 	return map[string]interface{}{


### PR DESCRIPTION
Add services for edpm_update_services and edpm_update_system playbooks.[1]
For update-services EDPMServiceType add logic to indicate that minor update
is complete post service deployment, mirroring the behavior of
'update' EDPMServiceType.

Functional test for new update-service is the same as for previous
update EDPMServiceType.

[OSPRH-16789](https://issues.redhat.com//browse/OSPRH-16789)

[1]https://github.com/openstack-k8s-operators/edpm-ansible/pull/962