### PR TITLE
Add Nova and dependencies deployment func tests

### DIFF
--- a/tests/functional/ctlplane/base_test.go
+++ b/tests/functional/ctlplane/base_test.go
@@ -57,6 +57,7 @@ type Names struct {
 	NeutronName                        types.NamespacedName
 	HorizonName                        types.NamespacedName
 	HeatName                           types.NamespacedName
+	NovaName                           types.NamespacedName
 	TelemetryName                      types.NamespacedName
 	DBName                             types.NamespacedName
 	DBCertName                         types.NamespacedName
@@ -175,6 +176,10 @@ func CreateNames(openstackControlplaneName types.NamespacedName) Names {
 		TelemetryName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,
 			Name:      "telemetry",
+		},
+		NovaName: types.NamespacedName{
+			Namespace: openstackControlplaneName.Namespace,
+			Name:      "nova",
 		},
 		DBName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,
@@ -614,9 +619,7 @@ func GetDefaultOpenStackControlPlaneSpec() map[string]interface{} {
 		"barbican": map[string]interface{}{
 			"enabled": false,
 		},
-		// "openstackclient": map[string]interface{}{
-		// 	"enabled": true,
-		// },
+		"openstackclient": map[string]interface{}{},
 		"manila": map[string]interface{}{
 			"enabled":  true,
 			"template": manilaTemplate,

--- a/tests/functional/ctlplane/base_test.go
+++ b/tests/functional/ctlplane/base_test.go
@@ -614,7 +614,9 @@ func GetDefaultOpenStackControlPlaneSpec() map[string]interface{} {
 		"barbican": map[string]interface{}{
 			"enabled": false,
 		},
-		"openstackclient": map[string]interface{}{},
+		// "openstackclient": map[string]interface{}{
+		// 	"enabled": true,
+		// },
 		"manila": map[string]interface{}{
 			"enabled":  true,
 			"template": manilaTemplate,


### PR DESCRIPTION
Add Nova and dependencies deployment func tests                                                                                                                                                               

Extracts Nova bits from
https://github.com/openstack-k8s-operators/openstack-operator/pull/831

Ensure that Nova and dependencies service's code path is executed and
should catch any potential issues before services are enabled in
integration testing.

Fix openstackclient spec in OSCP func tests.

Related https://github.com/openstack-k8s-operators/openstack-operator/pull/1424
