### PR TITLE
Do not update status when reconciler exits due to panic

### DIFF
--- a/controllers/client/openstackclient_controller.go
+++ b/controllers/client/openstackclient_controller.go
@@ -122,6 +122,11 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
+			panic(r)
+		}
 		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
 		// update the Ready condition based on the sub conditions
 		if instance.Status.Conditions.AllSubConditionIsTrue() {

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -168,6 +168,11 @@ func (r *OpenStackControlPlaneReconciler) Reconcile(ctx context.Context, req ctr
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
+			panic(r)
+		}
 		//Log all the conditions
 
 		// update the Ready condition based on the sub conditions

--- a/controllers/core/openstackversion_controller.go
+++ b/controllers/core/openstackversion_controller.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -128,6 +129,11 @@ func (r *OpenStackVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
+			panic(r)
+		}
 		// update the Ready condition based on the sub conditions
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(

--- a/controllers/dataplane/openstackdataplanedeployment_controller.go
+++ b/controllers/dataplane/openstackdataplanedeployment_controller.go
@@ -129,6 +129,11 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() { // update the Ready condition based on the sub conditions
+		// Don't update the status, if reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
+			panic(r)
+		}
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, condition.ReadyMessage)

--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -183,6 +183,11 @@ func (r *OpenStackDataPlaneNodeSetReconciler) Reconcile(ctx context.Context, req
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() { // update the Ready condition based on the sub conditions
+		// Don't update the status, if reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
+			panic(r)
+		}
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
 				condition.ReadyCondition, dataplanev1.NodeSetReadyMessage)

--- a/controllers/operator/openstack_controller.go
+++ b/controllers/operator/openstack_controller.go
@@ -179,6 +179,11 @@ func (r *OpenStackReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
+			panic(r)
+		}
 		// update the Ready condition based on the sub conditions
 		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(


### PR DESCRIPTION
Currently we use deferred call to always update the status field when Reconcile call exits, which seems correct for any other error except when Reconciler exits due to panic.

This change adds a call to recover function and try to handle panic and log error.

Closes: OSPRH-17071