### PR TITLE
Check if OctaviaRsyslogImage is not nil

### DIFF
--- a/pkg/openstack/instanceha.go
+++ b/pkg/openstack/instanceha.go
@@ -18,7 +18,6 @@ const (
 )
 
 func ReconcileInstanceHa(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, version *corev1beta1.OpenStackVersion, helper *helper.Helper) (ctrl.Result, error) {
-	missingImageDefault := ""
 	customData := map[string]string{
 		InstanceHaImageKey: *getImg(version.Status.ContainerImages.OpenstackClientImage, &missingImageDefault),
 	}

--- a/pkg/openstack/octavia.go
+++ b/pkg/openstack/octavia.go
@@ -190,7 +190,7 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 		octavia.Spec.OctaviaHealthManager.ContainerImage = *version.Status.ContainerImages.OctaviaHealthmanagerImage
 		octavia.Spec.OctaviaHousekeeping.ContainerImage = *version.Status.ContainerImages.OctaviaHousekeepingImage
 		octavia.Spec.ApacheContainerImage = *version.Status.ContainerImages.OctaviaApacheImage
-		octavia.Spec.OctaviaRsyslog.ContainerImage = *version.Status.ContainerImages.OctaviaRsyslogImage
+		octavia.Spec.OctaviaRsyslog.ContainerImage = *getImg(version.Status.ContainerImages.OctaviaRsyslogImage, &missingImageDefault)
 		octavia.Spec.OctaviaRsyslog.InitContainerImage = *version.Status.ContainerImages.OctaviaHealthmanagerImage
 
 		if octavia.Spec.Secret == "" {

--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -337,17 +337,8 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.NotifierImage = *version.Status.ContainerImages.AodhNotifierImage
 		telemetry.Spec.Autoscaling.AutoscalingSpec.Aodh.ListenerImage = *version.Status.ContainerImages.AodhListenerImage
 
-		if version.Status.ContainerImages.KsmImage != nil {
-			telemetry.Spec.Ceilometer.KSMImage = *version.Status.ContainerImages.KsmImage
-		} else {
-			telemetry.Spec.Ceilometer.KSMImage = ""
-		}
-
-		if version.Status.ContainerImages.CeilometerMysqldExporterImage != nil {
-			telemetry.Spec.Ceilometer.MysqldExporterImage = *version.Status.ContainerImages.CeilometerMysqldExporterImage
-		} else {
-			telemetry.Spec.Ceilometer.MysqldExporterImage = ""
-		}
+		telemetry.Spec.Ceilometer.KSMImage = *getImg(version.Status.ContainerImages.KsmImage, &missingImageDefault)
+		telemetry.Spec.Ceilometer.MysqldExporterImage = *getImg(version.Status.ContainerImages.CeilometerMysqldExporterImage, &missingImageDefault)
 
 		if telemetry.Spec.Ceilometer.Secret == "" {
 			telemetry.Spec.Ceilometer.Secret = instance.Spec.Secret

--- a/pkg/openstack/test.go
+++ b/pkg/openstack/test.go
@@ -25,7 +25,6 @@ const (
 )
 
 func ReconcileTest(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, version *corev1beta1.OpenStackVersion, helper *helper.Helper) (ctrl.Result, error) {
-	missingImageDefault := ""
 	customData := map[string]string{
 		TempestImageKey:     *getImg(version.Status.ContainerImages.TestTempestImage, &missingImageDefault),
 		TobikoImageKey:      *getImg(version.Status.ContainerImages.TestTobikoImage, &missingImageDefault),

--- a/pkg/openstack/version.go
+++ b/pkg/openstack/version.go
@@ -15,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+var (
+	missingImageDefault string
+)
+
 // InitializeOpenStackVersionImageDefaults - initializes OpenStackVersion CR with default container images
 func InitializeOpenStackVersionImageDefaults(ctx context.Context, envImages map[string]*string) *corev1beta1.ContainerDefaults {
 	Log := GetLogger(ctx)


### PR DESCRIPTION
OctaviaRsyslog was introduced in FR2 time frame. If there is an update with enabled octavia from before, the current targetVerion images won't have an OctaviaRsyslogImage which results in a nil ptr dereference error and the controller manage panics.

This adds a check, like done in other places if the images is non nil and otherwise falls back to an empty string.

Jira: [OSPRH-17647](https://issues.redhat.com//browse/OSPRH-17647)