### PR TITLE
upgrade catalog: use digest

### DIFF
--- a/.github/workflows/catalog-openstack-operator-upgrades.yaml
+++ b/.github/workflows/catalog-openstack-operator-upgrades.yaml
@@ -87,3 +87,25 @@ jobs:
         registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
+        digestfile: digest.txt
+
+    # tag the quay.io image with the digest so it is preserved
+    - name: Set OPERATOR_INDEX_IMAGE_DIGEST for Operator and tag
+      shell: bash
+      run: |
+        DIGEST=$(cat digest.txt | sed -e 's|sha256:||')
+        echo "OPERATOR_INDEX_IMAGE_DIGEST=$DIGEST" >> $GITHUB_ENV
+        podman tag "${REGISTRY}/${IMAGE}:${GITHUB_SHA}" "${REGISTRY}/${IMAGE}:${DIGEST}"
+      env:
+        REGISTRY:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
+        IMAGE: openstack-operator-index-upgrade
+        GITHUB_SHA: ${{ github.sha }}
+
+    - name: Push tag with digest ${{ env.OPERATOR_INDEX_IMAGE_DIGEST }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: openstack-operator-index-upgrade
+        tags: ${{ env.OPERATOR_INDEX_IMAGE_DIGEST }}
+        registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}

--- a/hack/catalog-build-olm-upgrade.sh
+++ b/hack/catalog-build-olm-upgrade.sh
@@ -2,6 +2,14 @@
 #NOTE: this script is used by the catalog-openstack-operator-upgrades.yaml
 set -ex
 
+function toDigestURL {
+local URL=$1
+
+DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://$URL)
+echo $URL | sed -e "s|:.*|@$DIGEST|"
+
+}
+
 MAIN_VERSION=${MAIN_VERSION:-"0.4.0"}
 FEATURE_RELEASE_VERSION=${FEATURE_RELEASE_VERSION:-"0.3.0"}
 FEATURE_RELEASE_BRANCH=${FEATURE_RELEASE_BRANCH:-"18.0-fr3"}
@@ -14,9 +22,10 @@ mkdir catalog
 opm generate dockerfile ./catalog -i registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
 opm init openstack-operator --default-channel=stable-v1.0 --output yaml > catalog/index.yaml
 
-opm render ${BUNDLE} --output yaml >> catalog/index.yaml
+#opm render ${BUNDLE} --output yaml >> catalog/index.yaml
+opm render $(toDigestURL $BUNDLE) --output yaml >> catalog/index.yaml
 # always default to use the FR release from openstack-k8s-operators
-opm render quay.io/openstack-k8s-operators/openstack-operator-bundle:${FEATURE_RELEASE_BRANCH}-latest --output yaml >> catalog/index.yaml
+opm render $(toDigestURL quay.io/openstack-k8s-operators/openstack-operator-bundle:${FEATURE_RELEASE_BRANCH}-latest) --output yaml >> catalog/index.yaml
 
   cat >> catalog/index.yaml << EOF_CAT
 ---


### PR DESCRIPTION
This PR does 2 things:

-converts image URLS into digest versions. This should pin the
 references to when they got built

-adds a sha/digest tag to the catalog index. This should fix
 persistence issues and make it possible to use a catalog
 from a specific sha/digest without it getting deleted on quay.io