### PR TITLE
Propagate RELATED_IMAGE to openstack-baremetal-operator

### DIFF
--- a/bindata/operator/managers.yaml
+++ b/bindata/operator/managers.yaml
@@ -3,6 +3,7 @@
 {{ $leaseDuration := .LeaseDuration }}
 {{ $renewDeadline := .RenewDeadline }}
 {{ $retryPeriod := .RetryPeriod }}
+{{ $openstackServiceRelatedImages := .OpenStackServiceRelatedImages }}
 {{ range $operatorName, $operatorImage := .OperatorImages }}
 apiVersion: apps/v1
 kind: Deployment
@@ -45,6 +46,12 @@ spec:
           value: '{{ $renewDeadline }}'
         - name: RETRY_PERIOD
           value: '{{ $retryPeriod }}'
+{{ if (eq $operatorName "openstack-baremetal") }}
+{{ range $envName, $envValue := $openstackServiceRelatedImages }}
+        - name: {{ $envName }}
+          value: {{ $envValue }}
+{{ end }}
+{{ end }}
         image: {{ $operatorImage }}
         livenessProbe:
           httpGet:

--- a/config/operator/managers.yaml
+++ b/config/operator/managers.yaml
@@ -3,6 +3,7 @@
 {{ $leaseDuration := .LeaseDuration }}
 {{ $renewDeadline := .RenewDeadline }}
 {{ $retryPeriod := .RetryPeriod }}
+{{ $openstackServiceRelatedImages := .OpenStackServiceRelatedImages }}
 {{ range $operatorName, $operatorImage := .OperatorImages }}
 apiVersion: apps/v1
 kind: Deployment
@@ -45,6 +46,12 @@ spec:
           value: '{{ $renewDeadline }}'
         - name: RETRY_PERIOD
           value: '{{ $retryPeriod }}'
+{{ if (eq $operatorName "openstack-baremetal") }}
+{{ range $envName, $envValue := $openstackServiceRelatedImages }}
+        - name: {{ $envName }}
+          value: {{ $envValue }}
+{{ end }}
+{{ end }}
         image: {{ $operatorImage }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This should resolve a regression since the new initialization resource was implemented where provision server is missing default settings from the openstack-operator CSV

Jira: [OSPRH-17188](https://issues.redhat.com//browse/OSPRH-17188)