### PR TITLE
Add AtLatestKnown condition

### DIFF
--- a/apis/core/v1beta1/conditions.go
+++ b/apis/core/v1beta1/conditions.go
@@ -509,6 +509,8 @@ const (
 	OpenStackVersionMinorUpdateDataplane condition.Type = "MinorUpdateDataplane"
 
 	OpenStackVersionMinorUpdateAvailable condition.Type = "MinorUpdateAvailable"
+
+	OpenStackVersionAtLatestKnown condition.Type = "AtLatestKnown"
 )
 
 // Version Messages used by API objects.
@@ -540,4 +542,7 @@ const (
 
 	// OpenStackVersionMinorUpdateAvailableMessage
 	OpenStackVersionMinorUpdateAvailableMessage = "update available"
+
+	// OpenStackVersionMinorUpdateAtLatestKnownMessage
+	OpenStackVersionMinorUpdateAtLatestKnownMessage = "at latest known"
 )

--- a/controllers/core/openstackversion_controller.go
+++ b/controllers/core/openstackversion_controller.go
@@ -392,12 +392,26 @@ func (r *OpenStackVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Log.Info("Setting DeployedVersion")
 		instance.Status.DeployedVersion = &instance.Spec.TargetVersion
 	}
-	if instance.Status.DeployedVersion != nil &&
-		*instance.Status.AvailableVersion != *instance.Status.DeployedVersion {
-		instance.Status.Conditions.Set(condition.TrueCondition(
-			corev1beta1.OpenStackVersionMinorUpdateAvailable,
-			corev1beta1.OpenStackVersionMinorUpdateAvailableMessage))
+
+	if instance.Status.DeployedVersion != nil {
+
+		if *instance.Status.AvailableVersion != *instance.Status.DeployedVersion {
+			instance.Status.Conditions.Remove(corev1beta1.OpenStackVersionAtLatestKnown)
+
+			instance.Status.Conditions.Set(condition.TrueCondition(
+				corev1beta1.OpenStackVersionMinorUpdateAvailable,
+				corev1beta1.OpenStackVersionMinorUpdateAvailableMessage))
+
+		} else {
+			instance.Status.Conditions.Remove(corev1beta1.OpenStackVersionMinorUpdateAvailable)
+
+			instance.Status.Conditions.Set(condition.TrueCondition(
+				corev1beta1.OpenStackVersionAtLatestKnown,
+				corev1beta1.OpenStackVersionMinorUpdateAtLatestKnownMessage))
+		}
+
 	} else {
+		instance.Status.Conditions.Remove(corev1beta1.OpenStackVersionAtLatestKnown)
 		instance.Status.Conditions.Remove(corev1beta1.OpenStackVersionMinorUpdateAvailable)
 	}
 

--- a/tests/functional/ctlplane/openstackversion_controller_test.go
+++ b/tests/functional/ctlplane/openstackversion_controller_test.go
@@ -407,6 +407,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(osversion.Generation).Should(Equal(osversion.Status.ObservedGeneration))
 
 				g.Expect(osversion.Status.DeployedVersion).Should(Equal(&initialVersion))
+				// Should not have OpenStackVersionAtLatestKnown
+				g.Expect(osversion.Status.Conditions.Has(corev1.OpenStackVersionAtLatestKnown)).To(BeFalse())
 
 			}, timeout, interval).Should(Succeed())
 
@@ -668,15 +670,24 @@ var _ = Describe("OpenStackOperator controller", func() {
 				osversion := GetOpenStackVersion(names.OpenStackVersionName)
 				g.Expect(osversion).Should(Not(BeNil()))
 				g.Expect(osversion.OwnerReferences).Should(HaveLen(1))
+				// The `AtLatestKnown` condition is True and MinorUpdateAvailable is not set
+				th.ExpectCondition(
+					names.OpenStackVersionName,
+					ConditionGetterFunc(OpenStackVersionConditionGetter),
+					corev1.OpenStackVersionAtLatestKnown,
+					k8s_corev1.ConditionTrue,
+				)
+				g.Expect(osversion.Status.Conditions.Has(corev1.OpenStackVersionMinorUpdateAvailable)).To(BeFalse())
+				g.Expect(osversion.Status.DeployedVersion).Should(Equal(&updatedVersion)) // we're done here
+
+				// Make sure the Ready condition is True, e.g. all conditions are True.
 				th.ExpectCondition(
 					names.OpenStackVersionName,
 					ConditionGetterFunc(OpenStackVersionConditionGetter),
 					condition.ReadyCondition,
 					k8s_corev1.ConditionTrue,
 				)
-				g.Expect(osversion.Status.DeployedVersion).Should(Equal(&updatedVersion)) // we're done here
-				// no condition which reflects an update is available
-				g.Expect(osversion.Status.Conditions.Has(corev1.OpenStackVersionMinorUpdateAvailable)).To(BeFalse())
+
 			}, timeout, interval).Should(Succeed())
 
 		})


### PR DESCRIPTION
Add a condition to indicate if we are AtLatestKnown version.
Condition is set to `True` if `AvailableVersion` == `DeployedVersion`, otherwize not set.
    
With this change we can do: `wait --for condition=MinorUpdateAvailable`, then patch the targetVersion and wait for: `wait --for condition=AtLatestKnown`.
    
It is a nuance, but I think this can be useful for automation using oc wait.