### PR TITLE
Fix rabbitmq api version

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.13.0 // indirect
-	github.com/rabbitmq/cluster-operator/v2 v2.11.0 // indirect
+	github.com/rabbitmq/cluster-operator/v2 v2.9.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/crypto v0.33.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.6.1-0.20250623170302-7c7813a41b79
 	github.com/openstack-k8s-operators/test-operator/api v0.6.1-0.20250624082930-75288c9747ab
 	github.com/pkg/errors v0.9.1
-	github.com/rabbitmq/cluster-operator/v2 v2.11.0
+	github.com/rabbitmq/cluster-operator/v2 v2.9.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56


### PR DESCRIPTION
Should be v2.9.0 as we use a fork pinned to this version