### PR TITLE
[OSPRH-17456] Fix namespace handling for operator references

### DIFF
--- a/controllers/operator/openstack_controller.go
+++ b/controllers/operator/openstack_controller.go
@@ -697,7 +697,12 @@ func (r *OpenStackReconciler) postCleanupObsoleteResources(ctx context.Context, 
 					Log.Info("Deleting operator reference", "Reference", ref)
 					obj := uns.Unstructured{}
 					obj.SetName(refData["name"].(string))
-					obj.SetNamespace(refData["namespace"].(string))
+
+					// Some of the references are not namespaced, so we need to check if the namespace is present
+					if namespace, ok := refData["namespace"]; ok {
+						obj.SetNamespace(namespace.(string))
+					}
+
 					apiParts := strings.Split(refData["apiVersion"].(string), "/")
 					objGvk := schema.GroupVersionResource{
 						Group:    apiParts[0],


### PR DESCRIPTION
Problem:
The `postCleanupObsoleteResources` function was attempting to unconditionally set the namespace for all operator references using `obj.SetNamespace(refData["namespace"].(string))`. This caused a panic when processing cluster-scoped resources that don't have a namespace field in their reference data.

Solution:
Added a safety check to only set the namespace if it exists in the reference data:

```
// Some of the references are not namespaced, so we need to check if the namespace is present
if namespace, ok := refData["namespace"]; ok {
    obj.SetNamespace(namespace.(string))
}
```

Changes:
Modified the namespace handling logic in `postCleanupObsoleteResources()` function
Added conditional check for namespace existence before setting it on the object
Added explanatory comment about cluster-scoped vs namespaced resources

Testing:
Prevents panic when processing operator references that include cluster-scoped resources
Maintains existing functionality for namespaced resources
Allows cleanup process to continue successfully for mixed reference types

Files Changed:
`controllers/operator/openstack_controller.go`
This fix ensures robust handling of both namespaced and cluster-scoped operator references during the cleanup process.

Generated-By: cursor with claude-4-sonnet model

Jira: https://issues.redhat.com/browse/OSPRH-17456