### PR TITLE
Use structured logging

### DIFF
--- a/controllers/client/openstackclient_controller.go
+++ b/controllers/client/openstackclient_controller.go
@@ -62,7 +62,7 @@ type OpenStackClientReconciler struct {
 	Kclient kubernetes.Interface
 }
 
-// GetLog returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *OpenStackClientReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("OpenStackClient")
 }
@@ -515,7 +515,7 @@ func (r *OpenStackClientReconciler) SetupWithManager(
 func (r *OpenStackClientReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("OpenStackClient")
+	Log := r.GetLogger(context.Background())
 
 	for _, field := range allWatchFields {
 		crList := &clientv1.OpenStackClientList{}
@@ -525,12 +525,12 @@ func (r *OpenStackClientReconciler) findObjectsForSrc(ctx context.Context, src c
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -77,7 +77,7 @@ type OpenStackControlPlaneReconciler struct {
 	Kclient kubernetes.Interface
 }
 
-// GetLog returns a logger object with a prefix of "conroller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *OpenStackControlPlaneReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("OpenStackControlPlane")
 }
@@ -733,7 +733,7 @@ func (r *OpenStackControlPlaneReconciler) SetupWithManager(
 func (r *OpenStackControlPlaneReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("OpenStackControlPlane")
+	Log := r.GetLogger(ctx)
 
 	for _, field := range allWatchFields {
 		crList := &corev1beta1.OpenStackControlPlaneList{}
@@ -743,12 +743,12 @@ func (r *OpenStackControlPlaneReconciler) findObjectsForSrc(ctx context.Context,
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{

--- a/controllers/core/openstackversion_controller.go
+++ b/controllers/core/openstackversion_controller.go
@@ -70,7 +70,6 @@ type OpenStackVersionReconciler struct {
 	client.Client
 	Kclient kubernetes.Interface
 	Scheme  *runtime.Scheme
-	Log     logr.Logger
 }
 
 // GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields

--- a/controllers/dataplane/openstackdataplanedeployment_controller.go
+++ b/controllers/dataplane/openstackdataplanedeployment_controller.go
@@ -154,7 +154,7 @@ func (r *OpenStackDataPlaneDeploymentReconciler) Reconcile(ctx context.Context, 
 	}()
 
 	// Ensure NodeSets
-	nodeSets, err := r.listNodeSets(ctx, &Log, instance)
+	nodeSets, err := r.listNodeSets(ctx, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			return ctrl.Result{RequeueAfter: time.Second * time.Duration(instance.Spec.DeploymentRequeueTime)}, nil
@@ -493,10 +493,12 @@ func (r *OpenStackDataPlaneDeploymentReconciler) SetupWithManager(mgr ctrl.Manag
 		Complete(r)
 }
 
-func (r *OpenStackDataPlaneDeploymentReconciler) listNodeSets(ctx context.Context, Log *logr.Logger, instance *dataplanev1.OpenStackDataPlaneDeployment) (*dataplanev1.OpenStackDataPlaneNodeSetList, error) {
+func (r *OpenStackDataPlaneDeploymentReconciler) listNodeSets(ctx context.Context, instance *dataplanev1.OpenStackDataPlaneDeployment) (*dataplanev1.OpenStackDataPlaneNodeSetList, error) {
 
 	var nodeSets = dataplanev1.OpenStackDataPlaneNodeSetList{}
 	var err error
+
+	Log := r.GetLogger(ctx)
 
 	for _, nodeSet := range instance.Spec.NodeSets {
 

--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -72,7 +72,7 @@ const (
 	caCertSelector = "ca-cert"
 )
 
-// GetLog returns a logger object with a prefix of "controller.name" and aditional controller context fields
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("OpenstackControlPlane")
 }


### PR DESCRIPTION
This change uses GetLogger instead of direct use of log.FromContext to support structured logging.