### PR TITLE
Make script input vars mandatory

### DIFF
--- a/hack/catalog-build-olm-upgrade.sh
+++ b/hack/catalog-build-olm-upgrade.sh
@@ -10,9 +10,11 @@ echo $URL | sed -e "s|:.*|@$DIGEST|"
 
 }
 
-MAIN_VERSION=${MAIN_VERSION:-"0.4.0"}
-FEATURE_RELEASE_VERSION=${FEATURE_RELEASE_VERSION:-"0.3.0"}
-FEATURE_RELEASE_BRANCH=${FEATURE_RELEASE_BRANCH:-"18.0-fr3"}
+# These variables are mandatory. The script will exit if they are not set.
+MAIN_VERSION=${MAIN_VERSION:?"Error: MAIN_VERSION must be set."}
+FEATURE_RELEASE_VERSION=${FEATURE_RELEASE_VERSION:?"Error: FEATURE_RELEASE_VERSION must be set."}
+FEATURE_RELEASE_BRANCH=${FEATURE_RELEASE_BRANCH:?"Error: FEATURE_RELEASE_BRANCH must be set."}
+
 BUNDLE=${BUNDLE:-"quay.io/openstack-k8s-operators/openstack-operator-bundle:latest"}
 
 [ -d "catalog" ] && rm -Rf catalog


### PR DESCRIPTION
Make MAIN_VERSION, FEATURE_RELEASE_VERSION, and FEATURE_RELEASE_BRANCH mandatory.

When run via the job, those vars get set in the workflow [1]. Lets make them mandatory, instead of bumping them in the workflow and the script on a new feature branch. If run manually they should be set.

[1] https://github.com/openstack-k8s-operators/openstack-operator/blob/5f8fbc7cd3b79a363d9fc2016e6e3c5b239b4d5a/.github/workflows/catalog-openstack-operator-upgrades.yaml#L68

Jira: [OSPRH-18397](https://issues.redhat.com//browse/OSPRH-18397)