### PR TITLE
Add node failure tolerations to all service operators and openstackclient

### DIFF
--- a/bindata/operator/managers.yaml
+++ b/bindata/operator/managers.yaml
@@ -85,6 +85,15 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ .Name }}-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
 {{- if isEnvVarTrue .Deployment.Manager.Env "ENABLE_WEBHOOKS" }}
       volumes:
       - name: cert

--- a/bindata/operator/operator.yaml
+++ b/bindata/operator/operator.yaml
@@ -133,6 +133,15 @@ spec:
         runAsNonRoot: true
       serviceAccountName: openstack-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 120
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 120
       volumes:
       - name: cert
         secret:

--- a/bindata/operator/rabbit.yaml
+++ b/bindata/operator/rabbit.yaml
@@ -46,3 +46,12 @@ spec:
             memory: {{ .RabbitmqOperator.Deployment.Manager.Resources.Requests.Memory }}
       serviceAccountName: rabbitmq-cluster-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,3 +72,12 @@ spec:
             customRequests: replace_me #NOTE: this is used via the Makefile to inject a custom template that kustomize won't allow
       serviceAccountName: openstack-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120

--- a/config/operator/deployment/deployment.yaml
+++ b/config/operator/deployment/deployment.yaml
@@ -106,3 +106,12 @@ spec:
             memory: 128Mi
       serviceAccountName: openstack-operator-controller-operator
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120

--- a/config/operator/managers.yaml
+++ b/config/operator/managers.yaml
@@ -85,6 +85,15 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ .Name }}-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
 {{- if isEnvVarTrue .Deployment.Manager.Env "ENABLE_WEBHOOKS" }}
       volumes:
       - name: cert

--- a/config/operator/rabbit.yaml
+++ b/config/operator/rabbit.yaml
@@ -46,3 +46,12 @@ spec:
             memory: {{ .RabbitmqOperator.Deployment.Manager.Resources.Requests.Memory }}
       serviceAccountName: rabbitmq-cluster-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120

--- a/pkg/openstackclient/funcs.go
+++ b/pkg/openstackclient/funcs.go
@@ -95,6 +95,20 @@ func ClientPodSpec(
 				VolumeMounts: volumeMounts,
 			},
 		},
+		Tolerations: []corev1.Toleration{
+			{
+				Key:               "node.kubernetes.io/not-ready",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: &[]int64{120}[0],
+			},
+			{
+				Key:               "node.kubernetes.io/unreachable",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: &[]int64{120}[0],
+			},
+		},
 	}
 
 	if instance.Spec.NodeSelector != nil {


### PR DESCRIPTION
This change adds 120s tolerations for node.kubernetes.io/not-ready and unreachable taints to reduce pod failover during a node failure.
    
The total eviction time is  ~160s (5min+ default). 120s was choosen to prevents pod rescheduling e.g. on kubelet restarts or network issues

Also fix OpenStackClient pod relocation during node failures
    
These changes ensure OpenStackClient pods are automatically rescheduled when nodes fail, instead of requiring manual intervention to delete stuck pods. The 120-second tolerations provide faster failover compared to the 5min default, while the stuck pod detection handles edge cases where normal eviction fails.

- Adds tolerations for faster pod eviction (120s vs 5min default)
  * Handle node.kubernetes.io/not-ready taints
  * Handle node.kubernetes.io/unreachable taints
- Force delete stuck pods with grace period 0

Note: going lower then 120s could be too aggressive and result in pod eviction e.g. during a network issue, or kubelet restarts
    
Jira: [OSPRH-18450](https://issues.redhat.com//browse/OSPRH-18450)