### PR TITLE
Fix ansible 2.19 jinja incompatibilities

### DIFF
--- a/config/samples/dataplane/base/files/nic-config.j2
+++ b/config/samples/dataplane/base/files/nic-config.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/config/samples/dataplane/bgp/values.yaml
+++ b/config/samples/dataplane/bgp/values.yaml
@@ -20,7 +20,7 @@ data:
             ---
             {% set mtu_list = [ctlplane_mtu] %}
             {% for network in nodeset_networks %}
-            {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+            {% set _= mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
             {%- endfor %}
             {% set min_viable_mtu = mtu_list | max %}
             network_config:

--- a/config/samples/dataplane/bgp_ovn_cluster/values.yaml
+++ b/config/samples/dataplane/bgp_ovn_cluster/values.yaml
@@ -20,7 +20,7 @@ data:
             ---
             {% set mtu_list = [ctlplane_mtu] %}
             {% for network in nodeset_networks %}
-            {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+            {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
             {%- endfor %}
             {% set min_viable_mtu = mtu_list | max %}
             network_config:

--- a/config/samples/dataplane/nmstate/values.yaml
+++ b/config/samples/dataplane/nmstate/values.yaml
@@ -15,7 +15,7 @@ data:
             ---
             {% set mtu_list = [ctlplane_mtu] %}
             {% for network in nodeset_networks %}
-            {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+            {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
             {%- endfor %}
             {% set min_viable_mtu = mtu_list | max %}
             dns-resolver:

--- a/config/samples/dataplane/ovs_dpdk/values.yaml
+++ b/config/samples/dataplane/ovs_dpdk/values.yaml
@@ -21,7 +21,7 @@ data:
             ---
             {% set mtu_list = [ctlplane_mtu] %}
             {% for network in nodeset_networks %}
-            {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+            {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
             {%- endfor %}
             {% set min_viable_mtu = mtu_list | max %}
             network_config:

--- a/config/samples/dataplane/post_ceph_hci/values.yaml
+++ b/config/samples/dataplane/post_ceph_hci/values.yaml
@@ -22,7 +22,7 @@ data:
             ---
             {% set mtu_list = [ctlplane_mtu] %}
             {% for network in nodeset_networks %}
-            {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+            {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
             {%- endfor %}
             {% set min_viable_mtu = mtu_list | max %}
             network_config:

--- a/config/samples/dataplane/pre_ceph_hci/values.yaml
+++ b/config/samples/dataplane/pre_ceph_hci/values.yaml
@@ -25,7 +25,7 @@ data:
             ---
             {% set mtu_list = [ctlplane_mtu] %}
             {% for network in nodeset_networks %}
-            {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+            {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
             {%- endfor %}
             {% set min_viable_mtu = mtu_list | max %}
             network_config:

--- a/config/samples/nic-config-samples/bonds_vlans/bonds_vlans.j2
+++ b/config/samples/nic-config-samples/bonds_vlans/bonds_vlans.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/config/samples/nic-config-samples/bonds_vlans/bonds_vlans_dpdk.j2
+++ b/config/samples/nic-config-samples/bonds_vlans/bonds_vlans_dpdk.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/config/samples/nic-config-samples/bonds_vlans/bonds_vlans_storage.j2
+++ b/config/samples/nic-config-samples/bonds_vlans/bonds_vlans_storage.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/config/samples/nic-config-samples/bonds_vlans/controller_no_external.j2
+++ b/config/samples/nic-config-samples/bonds_vlans/controller_no_external.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/config/samples/nic-config-samples/single_nic_vlans/controller_no_external.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/controller_no_external.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_bgp.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_bgp.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_bgp_ovn.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_bgp_ovn.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_storage.j2
+++ b/config/samples/nic-config-samples/single_nic_vlans/single_nic_vlans_storage.j2
@@ -1,7 +1,7 @@
 ---
 {% set mtu_list = [ctlplane_mtu] %}
 {% for network in nodeset_networks %}
-{{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+{% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
 {%- endfor %}
 {% set min_viable_mtu = mtu_list | max %}
 network_config:

--- a/docs/assemblies/common_configurations.adoc
+++ b/docs/assemblies/common_configurations.adoc
@@ -155,7 +155,7 @@ field that shows defining the variables that configure the
  	 ---
  	 {% set mtu_list = [ctlplane_mtu] %}
  	 {% for network in nodeset_networks %}
- 	 {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+ 	 {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
  	 {%- endfor %}
  	 {% set min_viable_mtu = mtu_list | max %}
  	 network_config:

--- a/docs/assemblies/ref_example-OpenStackDataPlaneNodeSet-CR-for-bare-metal-nodes.adoc
+++ b/docs/assemblies/ref_example-OpenStackDataPlaneNodeSet-CR-for-bare-metal-nodes.adoc
@@ -29,7 +29,7 @@ spec:
           ---
           {% set mtu_list = [ctlplane_mtu] %}
           {% for network in nodeset_networks %}
-          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
           {%- endfor %}
           {% set min_viable_mtu = mtu_list | max %}
           network_config:

--- a/docs/assemblies/ref_example-OpenStackDataPlaneNodeSet-CR-for-preprovisioned-nodes.adoc
+++ b/docs/assemblies/ref_example-OpenStackDataPlaneNodeSet-CR-for-preprovisioned-nodes.adoc
@@ -24,7 +24,7 @@ spec:
           ---
           {% set mtu_list = [ctlplane_mtu] %}
           {% for network in nodeset_networks %}
-          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
           {%- endfor %}
           {% set min_viable_mtu = mtu_list | max %}
           network_config:

--- a/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-create-test/00-dataplane-create.yaml
@@ -7,7 +7,7 @@ data:
     ---
     {% set mtu_list = [ctlplane_mtu] %}
     {% for network in nodeset_networks %}
-    {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+    {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
     {%- endfor %}
     {% set min_viable_mtu = mtu_list | max %}
     network_config:

--- a/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-global-service-test/00-dataplane-create.yaml
@@ -100,7 +100,7 @@ data:
     ---
     {% set mtu_list = [ctlplane_mtu] %}
     {% for network in nodeset_networks %}
-    {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+    {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
     {%- endfor %}
     {% set min_viable_mtu = mtu_list | max %}
     network_config:

--- a/tests/kuttl/tests/dataplane-deploy-tls-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-deploy-tls-test/00-dataplane-create.yaml
@@ -44,7 +44,7 @@ data:
     ---
     {% set mtu_list = [ctlplane_mtu] %}
     {% for network in nodeset_networks %}
-    {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+    {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
     {%- endfor %}
     {% set min_viable_mtu = mtu_list | max %}
     network_config:

--- a/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-dataplane-create.yaml
+++ b/tests/kuttl/tests/dataplane-multinode-nodeset-create-test/00-dataplane-create.yaml
@@ -7,7 +7,7 @@ data:
     ---
     {% set mtu_list = [ctlplane_mtu] %}
     {% for network in nodeset_networks %}
-    {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+    {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
     {%- endfor %}
     {% set min_viable_mtu = mtu_list | max %}
     network_config:


### PR DESCRIPTION
With ansible 2.19 it prints the return value of the mtu_list.append() `None` and the network config is not parseable with os-net-config and it fails with,

os_net_config.main No interfaces defined in config: /etc/os-net-config/config.yaml"]}

jira: [OSPRH-18609](https://issues.redhat.com//browse/OSPRH-18609)