### PR TITLE
[OSPRH-18744] Handle variant apiVersions for refData cleanup

### DIFF
--- a/controllers/operator/openstack_controller.go
+++ b/controllers/operator/openstack_controller.go
@@ -874,11 +874,19 @@ func (r *OpenStackReconciler) postCleanupObsoleteResources(ctx context.Context, 
 						obj.SetNamespace(namespace.(string))
 					}
 
-					apiParts := strings.Split(refData["apiVersion"].(string), "/")
+					apiVersion := refData["apiVersion"].(string)
+					apiParts := strings.Split(apiVersion, "/")
 					objGvk := schema.GroupVersionResource{
-						Group:    apiParts[0],
-						Version:  apiParts[1],
 						Resource: refData["kind"].(string),
+					}
+					// Some of the references have an apiVersion that lacks a group prefix
+					if len(apiParts) > 1 {
+						objGvk.Group = apiParts[0]
+						objGvk.Version = apiParts[1]
+						Log.Info("postCleanupObsoleteResources: Found apiVersion with group prefix", "apiVersion", apiVersion)
+					} else {
+						objGvk.Version = apiParts[0]
+						Log.Info("postCleanupObsoleteResources: Found apiVersion without group prefix", "apiVersion", apiVersion)
 					}
 					obj.SetGroupVersionKind(objGvk.GroupVersion().WithKind(refData["kind"].(string)))
 


### PR DESCRIPTION
Some `refData` in `Operator` resources can lack a group in its `apiVersion`.  We need to adjust our `Operator` clean-up logic to account for this.

Jira: https://issues.redhat.com/browse/OSPRH-18744