### PR TITLE
Fix functional test race condition in nova template configuration

### DIFF
--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -1946,8 +1946,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 		})
 
 		It("should have configured nova from the service template", func() {
-			OSCtlplane := GetOpenStackControlPlane(names.OpenStackControlplaneName)
 			Eventually(func(g Gomega) {
+				OSCtlplane := GetOpenStackControlPlane(names.OpenStackControlplaneName)
 				OSCtlplane.Spec.Nova.Template.APIDatabaseInstance = "custom-db"
 				g.Expect(k8sClient.Update(ctx, OSCtlplane)).Should(Succeed())
 			}, timeout, interval).Should(Succeed())


### PR DESCRIPTION
The "should have configured nova from the service template" test was failing intermittently due to a stale object update pattern. The test was retrieving the OpenStackControlPlane object outside the Eventually block, then attempting to update it inside the block. This could fail with update conflicts if the controller modified the object between retrieval and update.

Move GetOpenStackControlPlane() inside the Eventually block to ensure a fresh object is retrieved on each retry attempt, matching the pattern used by other successful tests in the file.