### PR TITLE
Bump operator deployment memory request/limit defaults

### DIFF
--- a/apis/operator/v1beta1/openstack_types.go
+++ b/apis/operator/v1beta1/openstack_types.go
@@ -60,9 +60,9 @@ var (
 	// DefaultManagerCPURequests - Default controller manager container CPU requests
 	DefaultManagerCPURequests resource.Quantity = resource.MustParse("10m")
 	// DefaultManagerMemoryLimit - Default controller manager container memory limit
-	DefaultManagerMemoryLimit resource.Quantity = resource.MustParse("256Mi")
+	DefaultManagerMemoryLimit resource.Quantity = resource.MustParse("512Mi")
 	// DefaultManagerMemoryRequests - Default controller manager container memory requests
-	DefaultManagerMemoryRequests resource.Quantity = resource.MustParse("128Mi")
+	DefaultManagerMemoryRequests resource.Quantity = resource.MustParse("256Mi")
 	// DefaultRbacProxyCPULimit - Default kube rbac proxy container CPU limit
 	DefaultRbacProxyCPULimit resource.Quantity = resource.MustParse("500m")
 	// DefaultRbacProxyCPURequests - Default kube rbac proxy container CPU requests

--- a/pkg/operator/override_test.go
+++ b/pkg/operator/override_test.go
@@ -210,7 +210,7 @@ func TestApplyOperatorOverrides(t *testing.T) {
 			},
 			expectedRequests: &ResourceList{
 				CPU:    "1",
-				Memory: "128Mi", // the default must not be overridden if we just change the cpu
+				Memory: "256Mi", // the default must not be overridden if we just change the cpu
 			},
 		},
 		{


### PR DESCRIPTION
During start of the operators it is seen in some environments that the current defaults get reached during start/initialization. Checking the usage, most of them peaks at the startup, using between 350-380 MiB, other around 300MiB, for a short time and then it get stabilized at 200-210 MiB.

Jira: OSPRH-17785