### PR TITLE
[test] Fix race condition in watcher disable test

### DIFF
--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -2257,9 +2257,11 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(watcher).Should(Not(BeNil()))
 			}, timeout, interval).Should(Succeed())
 
-			OSCtlplane := GetOpenStackControlPlane(names.OpenStackControlplaneName)
-			OSCtlplane.Spec.Watcher.Enabled = false
-			Expect(th.K8sClient.Update(th.Ctx, OSCtlplane)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				OSCtlplane := GetOpenStackControlPlane(names.OpenStackControlplaneName)
+				OSCtlplane.Spec.Watcher.Enabled = false
+				g.Expect(th.K8sClient.Update(th.Ctx, OSCtlplane)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				instance := &watcherv1.Watcher{}


### PR DESCRIPTION
Wrap OpenStackControlPlane spec update in Eventually block to handle potential conflicts from concurrent updates.

Fixes HTTP 409 conflict error: 'the object has been modified; please apply your changes to the latest version and try again' randomly seen in running the functional test.