### PR TITLE
Remove proxy-rolebindings from all operator RBAC configurations

### DIFF
--- a/bindata/rbac/barbican-operator-rbac.yaml
+++ b/bindata/rbac/barbican-operator-rbac.yaml
@@ -402,19 +402,6 @@ subjects:
   name: barbican-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: barbican-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: barbican-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: barbican-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/cinder-operator-rbac.yaml
+++ b/bindata/rbac/cinder-operator-rbac.yaml
@@ -446,19 +446,6 @@ subjects:
   name: cinder-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cinder-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cinder-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: cinder-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/designate-operator-rbac.yaml
+++ b/bindata/rbac/designate-operator-rbac.yaml
@@ -555,19 +555,6 @@ subjects:
   name: designate-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: designate-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: designate-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: designate-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/glance-operator-rbac.yaml
+++ b/bindata/rbac/glance-operator-rbac.yaml
@@ -393,19 +393,6 @@ subjects:
   name: glance-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: glance-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: glance-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: glance-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/heat-operator-rbac.yaml
+++ b/bindata/rbac/heat-operator-rbac.yaml
@@ -403,19 +403,6 @@ subjects:
   name: heat-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: heat-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: heat-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: heat-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/horizon-operator-rbac.yaml
+++ b/bindata/rbac/horizon-operator-rbac.yaml
@@ -275,19 +275,6 @@ subjects:
   name: horizon-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: horizon-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: horizon-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: horizon-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/infra-operator-rbac.yaml
+++ b/bindata/rbac/infra-operator-rbac.yaml
@@ -576,19 +576,6 @@ subjects:
   name: infra-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: infra-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: infra-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: infra-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/ironic-operator-rbac.yaml
+++ b/bindata/rbac/ironic-operator-rbac.yaml
@@ -481,19 +481,6 @@ subjects:
   name: ironic-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: ironic-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: ironic-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: ironic-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/keystone-operator-rbac.yaml
+++ b/bindata/rbac/keystone-operator-rbac.yaml
@@ -385,19 +385,6 @@ subjects:
   name: keystone-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: keystone-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: keystone-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: keystone-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/manila-operator-rbac.yaml
+++ b/bindata/rbac/manila-operator-rbac.yaml
@@ -438,19 +438,6 @@ subjects:
   name: manila-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: manila-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: manila-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: manila-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/mariadb-operator-rbac.yaml
+++ b/bindata/rbac/mariadb-operator-rbac.yaml
@@ -344,19 +344,6 @@ subjects:
   name: mariadb-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: mariadb-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: mariadb-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: mariadb-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/neutron-operator-rbac.yaml
+++ b/bindata/rbac/neutron-operator-rbac.yaml
@@ -333,19 +333,6 @@ subjects:
   name: neutron-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: neutron-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: neutron-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: neutron-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/nova-operator-rbac.yaml
+++ b/bindata/rbac/nova-operator-rbac.yaml
@@ -554,19 +554,6 @@ subjects:
   name: nova-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: nova-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: nova-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: nova-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/octavia-operator-rbac.yaml
+++ b/bindata/rbac/octavia-operator-rbac.yaml
@@ -470,19 +470,6 @@ subjects:
   name: octavia-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: octavia-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: octavia-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: octavia-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/openstack-baremetal-operator-rbac.yaml
+++ b/bindata/rbac/openstack-baremetal-operator-rbac.yaml
@@ -331,19 +331,6 @@ subjects:
   name: openstack-baremetal-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: openstack-baremetal-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: openstack-baremetal-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: openstack-baremetal-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/ovn-operator-rbac.yaml
+++ b/bindata/rbac/ovn-operator-rbac.yaml
@@ -365,19 +365,6 @@ subjects:
   name: ovn-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: ovn-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: ovn-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: ovn-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/placement-operator-rbac.yaml
+++ b/bindata/rbac/placement-operator-rbac.yaml
@@ -324,19 +324,6 @@ subjects:
   name: placement-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: placement-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: placement-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: placement-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/rabbitmq-cluster-operator-rbac.yaml
+++ b/bindata/rbac/rabbitmq-cluster-operator-rbac.yaml
@@ -200,19 +200,6 @@ subjects:
   name: rabbitmq-cluster-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: rabbitmq-cluster-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: rabbitmq-cluster-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: rabbitmq-cluster-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/swift-operator-rbac.yaml
+++ b/bindata/rbac/swift-operator-rbac.yaml
@@ -447,19 +447,6 @@ subjects:
   name: swift-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: swift-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: swift-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: swift-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/telemetry-operator-rbac.yaml
+++ b/bindata/rbac/telemetry-operator-rbac.yaml
@@ -564,19 +564,6 @@ subjects:
   name: telemetry-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: telemetry-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: telemetry-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: telemetry-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/test-operator-rbac.yaml
+++ b/bindata/rbac/test-operator-rbac.yaml
@@ -261,19 +261,6 @@ subjects:
   name: test-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: test-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: test-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: test-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/bindata/rbac/watcher-operator-rbac.yaml
+++ b/bindata/rbac/watcher-operator-rbac.yaml
@@ -427,19 +427,6 @@ subjects:
   name: watcher-operator-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: watcher-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: watcher-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: watcher-operator-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/hack/sync-bindata.sh
+++ b/hack/sync-bindata.sh
@@ -228,19 +228,6 @@ subjects:
   name: ${OPERATOR_NAME}-controller-manager
   namespace: '{{ .OperatorNamespace }}'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: ${OPERATOR_NAME}-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: ${OPERATOR_NAME}-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: ${OPERATOR_NAME}-controller-manager
-  namespace: '{{ .OperatorNamespace }}'
----
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Removes the ClusterRoleBinding resources for proxy roles across all OpenStack operators in the bindata RBAC templates. This cleanup removes unnecessary proxy role bindings that are no longer needed.

Jira: [OSPRH-19169](https://issues.redhat.com//browse/OSPRH-19169) 

Co-Authored-By: Claude <noreply@anthropic.com>
