### PR TITLE
Create TLS certs for OVN exporter services

### DIFF
--- a/tests/functional/ctlplane/base_test.go
+++ b/tests/functional/ctlplane/base_test.go
@@ -90,6 +90,7 @@ type Names struct {
 	OVNControllerCertName              types.NamespacedName
 	OVNDbServerNBName                  types.NamespacedName
 	OVNDbServerSBName                  types.NamespacedName
+	OVNMetricsCertName                 types.NamespacedName
 	NeutronOVNCertName                 types.NamespacedName
 	OpenStackTopology                  []types.NamespacedName
 	WatcherCertPublicRouteName         types.NamespacedName
@@ -261,6 +262,10 @@ func CreateNames(openstackControlplaneName types.NamespacedName) Names {
 		OVNControllerCertName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,
 			Name:      "cert-ovncontroller-ovndbs",
+		},
+		OVNMetricsCertName: types.NamespacedName{
+			Namespace: openstackControlplaneName.Namespace,
+			Name:      "cert-ovn-metrics",
 		},
 		NeutronOVNCertName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -850,6 +850,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			// create cert secrets for ovn instance
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNNorthdCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNControllerCertName))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNMetricsCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.NeutronOVNCertName))
 			DeferCleanup(
 				th.DeleteInstance,


### PR DESCRIPTION
As part of Metrics TLS support in the Related-Issue, exporter will
be enabled per pod, so created a dedicated cert for this.

Related-Issue: [OSPRH-12568](https://issues.redhat.com//browse/OSPRH-12568)