### PR TITLE
[WIP] Migrate network openstack dataplane service

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_migrate_network.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_migrate_network.yaml
@@ -1,0 +1,7 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: migrate-network
+spec:
+  playbook: osp.edpm.migrate_network
+  edpmServiceType: migrate-network


### PR DESCRIPTION
This change is to create the openstack dataplane service for migrate network from ifcfg to nmstate os-net-config provider.