### PR TITLE
Add valid-subscription annotation to CSV

### DIFF
--- a/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operatorframework.io/suggested-namespace: openstack-operators
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/internal-objects: '["openstackclients.client.openstack.org","openstackdataplaneservices.dataplane.openstack.org"]'

--- a/config/operator/manifests/bases/openstack-operator.clusterserviceversion.yaml
+++ b/config/operator/manifests/bases/openstack-operator.clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operatorframework.io/suggested-namespace: openstack-operators
     operatorframework.io/initialization-resource: '{"apiVersion":"operator.openstack.org/v1beta1","kind":"OpenStack","metadata":{"name":"openstack","namespace":"openstack-operators"},"spec":{}}'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0


### PR DESCRIPTION
This annotation is technically optional, but it's needed for downstream productization[1]:

> Free-form array for listing any specific subscriptions that are
> required to use the Operator

Adding it here simplifies downstream CSV post-processing.

[RELDEL-7851](https://issues.redhat.com//browse/RELDEL-7851)

[1] https://docs.okd.io/4.18/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-other_osdk-generating-csvs