### PR TITLE
Add NotificationsBusInstance API field

### DIFF
--- a/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/apis/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -9582,6 +9582,8 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              notificationsBusInstance:
+                type: string
               nova:
                 properties:
                   apiOverride:

--- a/apis/core/v1beta1/openstackcontrolplane_types.go
+++ b/apis/core/v1beta1/openstackcontrolplane_types.go
@@ -128,6 +128,13 @@ type OpenStackControlPlaneSpec struct {
 	Rabbitmq RabbitmqSection `json:"rabbitmq,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// NotificationsBusInstance - the name of RabbitMQ Cluster CR to select a Messaging
+	// Bus Service instance used by all services that produce or consume notifications.
+	// Avoid colocating it with RabbitMQ services used for PRC.
+	// That instance will be pushed down for services, unless overriden in templates.
+	NotificationsBusInstance *string `json:"notificationsBusInstance,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// Memcached - Parameters related to the Memcached service
 	Memcached MemcachedSection `json:"memcached,omitempty"`

--- a/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1178,6 +1178,11 @@ func (in *OpenStackControlPlaneSpec) DeepCopyInto(out *OpenStackControlPlaneSpec
 	in.Cinder.DeepCopyInto(&out.Cinder)
 	in.Galera.DeepCopyInto(&out.Galera)
 	in.Rabbitmq.DeepCopyInto(&out.Rabbitmq)
+	if in.NotificationsBusInstance != nil {
+		in, out := &in.NotificationsBusInstance, &out.NotificationsBusInstance
+		*out = new(string)
+		**out = **in
+	}
 	in.Memcached.DeepCopyInto(&out.Memcached)
 	in.Ovn.DeepCopyInto(&out.Ovn)
 	in.Neutron.DeepCopyInto(&out.Neutron)

--- a/bindata/crds/crds.yaml
+++ b/bindata/crds/crds.yaml
@@ -9746,6 +9746,8 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              notificationsBusInstance:
+                type: string
               nova:
                 properties:
                   apiOverride:

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -9582,6 +9582,8 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              notificationsBusInstance:
+                type: string
               nova:
                 properties:
                   apiOverride:

--- a/pkg/openstack/cinder.go
+++ b/pkg/openstack/cinder.go
@@ -130,6 +130,12 @@ func ReconcileCinder(ctx context.Context, instance *corev1beta1.OpenStackControl
 		instance.Spec.Cinder.Template.TopologyRef = instance.Spec.TopologyRef
 	}
 
+	// When no NotificationsBusInstance is referenced in the subCR (override)
+	// try to inject the top-level one if defined
+	if instance.Spec.Cinder.Template.NotificationsBusInstance == nil {
+		instance.Spec.Cinder.Template.NotificationsBusInstance = instance.Spec.NotificationsBusInstance
+	}
+
 	Log.Info("Reconciling Cinder", "Cinder.Namespace", instance.Namespace, "Cinder.Name", cinderName)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), cinder, func() error {
 		instance.Spec.Cinder.Template.CinderSpecBase.DeepCopyInto(&cinder.Spec.CinderSpecBase)

--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -74,6 +74,12 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 		instance.Spec.Glance.Template.TopologyRef = instance.Spec.TopologyRef
 	}
 
+	// When no NotificationsBusInstance is referenced in the subCR (override)
+	// try to inject the top-level one if defined
+	if instance.Spec.Glance.Template.NotificationBusInstance == nil {
+		instance.Spec.Glance.Template.NotificationBusInstance = instance.Spec.NotificationsBusInstance
+	}
+
 	// When component services got created check if there is the need to create a route
 	if err := helper.GetClient().Get(ctx, types.NamespacedName{Name: glanceName, Namespace: instance.Namespace}, glance); err != nil {
 		if !k8s_errors.IsNotFound(err) {

--- a/pkg/openstack/manila.go
+++ b/pkg/openstack/manila.go
@@ -118,6 +118,12 @@ func ReconcileManila(ctx context.Context, instance *corev1beta1.OpenStackControl
 		instance.Spec.Manila.Template.TopologyRef = instance.Spec.TopologyRef
 	}
 
+	// When no NotificationsBusInstance is referenced in the subCR (override)
+	// try to inject the top-level one if defined
+	if instance.Spec.Manila.Template.NotificationsBusInstance == nil {
+		instance.Spec.Manila.Template.NotificationsBusInstance = instance.Spec.NotificationsBusInstance
+	}
+
 	Log.Info("Reconciling Manila", "Manila.Namespace", instance.Namespace, "Manila.Name", "manila")
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), manila, func() error {
 		instance.Spec.Manila.Template.ManilaSpecBase.DeepCopyInto(&manila.Spec.ManilaSpecBase)


### PR DESCRIPTION
This patch introduces the `notificationsBusInstance` (optional) parameter at `API` level.
When an override is not defined, it is propagated to the underlying storage components where this field is implemented.