### PR TITLE
[OSPRH-19707] Prioritize surfacing warn/error severity sub-statuses

### DIFF
--- a/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-operator.clusterserviceversion.yaml
@@ -11,8 +11,9 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operatorframework.io/suggested-namespace: openstack-operators
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/internal-objects: '["openstackclients.client.openstack.org","openstackdataplaneservices.dataplane.openstack.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/pkg/openstack/common.go
+++ b/pkg/openstack/common.go
@@ -913,3 +913,21 @@ func DeleteCertsAndRoutes(
 
 	return ctrl.Result{}, nil
 }
+
+// MirrorSubResourceCondition -
+//  1. Mirrors the condition of the highest priority from subResource to the instance,
+//     placing it in the condition of type targetCondition of the instance
+//  2. If passed, prepends the kind of the subResource to the message associated with the
+//     condition, which, while perhaps redundant for the targetCondition, will help provide
+//     clarity in the case that the targetCondition ends up being the highest priority
+//     condition in the OpenStackControlPlane (and thus appears in the
+//     OpenStackControlPlane's "Ready" condition at the end of the reconciliation loop)
+func MirrorSubResourceCondition(conditions condition.Conditions, targetCondition condition.Type, instance *corev1beta1.OpenStackControlPlane, subResource string) {
+	myCondition := conditions.Mirror(targetCondition)
+	if subResource != "" {
+		// Prepend the kind of the subResource to the message associated with the condition
+		// if one was passed
+		myCondition.Message = fmt.Sprintf("%s: %s", subResource, myCondition.Message)
+	}
+	instance.Status.Conditions.Set(myCondition)
+}

--- a/pkg/openstack/designate.go
+++ b/pkg/openstack/designate.go
@@ -186,6 +186,7 @@ func ReconcileDesignate(ctx context.Context, instance *corev1beta1.OpenStackCont
 	}
 
 	if designate.Status.ObservedGeneration == designate.Generation && designate.IsReady() {
+		helper.GetLogger().Info("Designate ready condition is true")
 		instance.Status.ContainerImages.DesignateAPIImage = version.Status.ContainerImages.DesignateAPIImage
 		instance.Status.ContainerImages.DesignateCentralImage = version.Status.ContainerImages.DesignateCentralImage
 		instance.Status.ContainerImages.DesignateMdnsImage = version.Status.ContainerImages.DesignateMdnsImage
@@ -196,11 +197,23 @@ func ReconcileDesignate(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Status.ContainerImages.NetUtilsImage = version.Status.ContainerImages.NetUtilsImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneDesignateReadyCondition, corev1beta1.OpenStackControlPlaneDesignateReadyMessage)
 	} else {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1beta1.OpenStackControlPlaneDesignateReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1beta1.OpenStackControlPlaneDesignateReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the Designate resource into the instance
+		// under the condition of type OpenStackControlPlaneDesignateReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(designate.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(designate.Status.Conditions, corev1beta1.OpenStackControlPlaneDesignateReadyCondition, instance, designate.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlaneDesignateReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1beta1.OpenStackControlPlaneDesignateReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/openstack/glance.go
+++ b/pkg/openstack/glance.go
@@ -220,14 +220,27 @@ func ReconcileGlance(ctx context.Context, instance *corev1beta1.OpenStackControl
 	}
 
 	if glance.Status.ObservedGeneration == glance.Generation && glance.IsReady() {
+		Log.Info("Glance ready condition is true")
 		instance.Status.ContainerImages.GlanceAPIImage = version.Status.ContainerImages.GlanceAPIImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneGlanceReadyCondition, corev1beta1.OpenStackControlPlaneGlanceReadyMessage)
 	} else {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1beta1.OpenStackControlPlaneGlanceReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1beta1.OpenStackControlPlaneGlanceReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the Glance resource into the instance
+		// under the condition of type OpenStackControlPlaneGlanceReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(glance.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(glance.Status.Conditions, corev1beta1.OpenStackControlPlaneGlanceReadyCondition, instance, glance.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlaneGlanceReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1beta1.OpenStackControlPlaneGlanceReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/openstack/horizon.go
+++ b/pkg/openstack/horizon.go
@@ -186,14 +186,27 @@ func ReconcileHorizon(ctx context.Context, instance *corev1beta1.OpenStackContro
 	}
 
 	if horizon.Status.ObservedGeneration == horizon.Generation && horizon.IsReady() {
+		Log.Info("Horizon ready condition is true")
 		instance.Status.ContainerImages.HorizonImage = version.Status.ContainerImages.HorizonImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneHorizonReadyCondition, corev1beta1.OpenStackControlPlaneHorizonReadyMessage)
 	} else {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1beta1.OpenStackControlPlaneHorizonReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1beta1.OpenStackControlPlaneHorizonReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the Horizon resource into the instance
+		// under the condition of type OpenStackControlPlaneHorizonReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(horizon.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(horizon.Status.Conditions, corev1beta1.OpenStackControlPlaneHorizonReadyCondition, instance, horizon.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlaneHorizonReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1beta1.OpenStackControlPlaneHorizonReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/openstack/manila.go
+++ b/pkg/openstack/manila.go
@@ -183,16 +183,29 @@ func ReconcileManila(ctx context.Context, instance *corev1beta1.OpenStackControl
 	}
 
 	if manila.Status.ObservedGeneration == manila.Generation && manila.IsReady() {
+		Log.Info("Manila ready condition is true")
 		instance.Status.ContainerImages.ManilaAPIImage = version.Status.ContainerImages.ManilaAPIImage
 		instance.Status.ContainerImages.ManilaSchedulerImage = version.Status.ContainerImages.ManilaSchedulerImage
 		instance.Status.ContainerImages.ManilaShareImages = version.Status.ContainerImages.ManilaShareImages
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneManilaReadyCondition, corev1beta1.OpenStackControlPlaneManilaReadyMessage)
 	} else {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1beta1.OpenStackControlPlaneManilaReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1beta1.OpenStackControlPlaneManilaReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the Manila resource into the instance
+		// under the condition of type OpenStackControlPlaneManilaReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(manila.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(manila.Status.Conditions, corev1beta1.OpenStackControlPlaneManilaReadyCondition, instance, manila.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlaneManilaReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1beta1.OpenStackControlPlaneManilaReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/openstack/neutron.go
+++ b/pkg/openstack/neutron.go
@@ -195,14 +195,27 @@ func ReconcileNeutron(ctx context.Context, instance *corev1beta1.OpenStackContro
 	}
 
 	if neutronAPI.Status.ObservedGeneration == neutronAPI.Generation && neutronAPI.IsReady() {
+		Log.Info("Neutron ready condition is true")
 		instance.Status.ContainerImages.NeutronAPIImage = version.Status.ContainerImages.NeutronAPIImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneNeutronReadyCondition, corev1beta1.OpenStackControlPlaneNeutronReadyMessage)
 	} else {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1beta1.OpenStackControlPlaneNeutronReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1beta1.OpenStackControlPlaneNeutronReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the Neutron resource into the instance
+		// under the condition of type OpenStackControlPlaneNeutronReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(neutronAPI.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(neutronAPI.Status.Conditions, corev1beta1.OpenStackControlPlaneNeutronReadyCondition, instance, neutronAPI.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlaneNeutronReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1beta1.OpenStackControlPlaneNeutronReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/openstack/octavia.go
+++ b/pkg/openstack/octavia.go
@@ -223,6 +223,7 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 	}
 
 	if octavia.Status.ObservedGeneration == octavia.Generation && octavia.IsReady() {
+		helper.GetLogger().Info("Octavia ready condition is true")
 		instance.Status.ContainerImages.OctaviaAPIImage = version.Status.ContainerImages.OctaviaAPIImage
 		instance.Status.ContainerImages.OctaviaWorkerImage = version.Status.ContainerImages.OctaviaWorkerImage
 		instance.Status.ContainerImages.OctaviaHealthmanagerImage = version.Status.ContainerImages.OctaviaHealthmanagerImage
@@ -231,11 +232,23 @@ func ReconcileOctavia(ctx context.Context, instance *corev1beta1.OpenStackContro
 		instance.Status.ContainerImages.OctaviaRsyslogImage = version.Status.ContainerImages.OctaviaRsyslogImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneOctaviaReadyCondition, corev1beta1.OpenStackControlPlaneOctaviaReadyMessage)
 	} else {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1beta1.OpenStackControlPlaneOctaviaReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1beta1.OpenStackControlPlaneOctaviaReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the Octavia resource into the instance
+		// under the condition of type OpenStackControlPlaneOctaviaReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(octavia.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(octavia.Status.Conditions, corev1beta1.OpenStackControlPlaneOctaviaReadyCondition, instance, octavia.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlaneOctaviaReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1beta1.OpenStackControlPlaneOctaviaReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/openstack/openstackclient.go
+++ b/pkg/openstack/openstackclient.go
@@ -87,12 +87,23 @@ func ReconcileOpenStackClient(ctx context.Context, instance *corev1.OpenStackCon
 		instance.Status.ContainerImages.OpenstackClientImage = version.Status.ContainerImages.OpenstackClientImage
 		instance.Status.Conditions.MarkTrue(corev1.OpenStackControlPlaneClientReadyCondition, corev1.OpenStackControlPlaneClientReadyMessage)
 	} else {
-		Log.Info("OpenStackClient ready condition is false")
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1.OpenStackControlPlaneClientReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1.OpenStackControlPlaneClientReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the OpenStackClient resource into the instance
+		// under the condition of type OpenStackControlPlaneClientReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(openstackclient.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(openstackclient.Status.Conditions, corev1.OpenStackControlPlaneClientReadyCondition, instance, openstackclient.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1.OpenStackControlPlaneClientReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1.OpenStackControlPlaneClientReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/openstack/placement.go
+++ b/pkg/openstack/placement.go
@@ -144,14 +144,27 @@ func ReconcilePlacementAPI(ctx context.Context, instance *corev1beta1.OpenStackC
 	}
 
 	if placementAPI.Status.ObservedGeneration == placementAPI.Generation && placementAPI.IsReady() {
+		Log.Info("PlacementAPI ready condition is true")
 		instance.Status.ContainerImages.PlacementAPIImage = version.Status.ContainerImages.PlacementAPIImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlanePlacementAPIReadyCondition, corev1beta1.OpenStackControlPlanePlacementAPIReadyMessage)
 	} else {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1beta1.OpenStackControlPlanePlacementAPIReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1beta1.OpenStackControlPlanePlacementAPIReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the PlacementAPI resource into the instance
+		// under the condition of type OpenStackControlPlanePlacementAPIReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(placementAPI.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(placementAPI.Status.Conditions, corev1beta1.OpenStackControlPlanePlacementAPIReadyCondition, instance, placementAPI.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlanePlacementAPIReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1beta1.OpenStackControlPlanePlacementAPIReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/openstack/telemetry.go
+++ b/pkg/openstack/telemetry.go
@@ -376,6 +376,7 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 	}
 
 	if telemetry.Status.ObservedGeneration == telemetry.Generation && telemetry.IsReady() {
+		helper.GetLogger().Info("Telemetry ready condition is true")
 		instance.Status.ContainerImages.CeilometerCentralImage = version.Status.ContainerImages.CeilometerCentralImage
 		instance.Status.ContainerImages.CeilometerComputeImage = version.Status.ContainerImages.CeilometerComputeImage
 		instance.Status.ContainerImages.CeilometerIpmiImage = version.Status.ContainerImages.CeilometerIpmiImage
@@ -390,11 +391,23 @@ func ReconcileTelemetry(ctx context.Context, instance *corev1beta1.OpenStackCont
 		instance.Status.ContainerImages.AodhListenerImage = version.Status.ContainerImages.AodhListenerImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneTelemetryReadyCondition, corev1beta1.OpenStackControlPlaneTelemetryReadyMessage)
 	} else {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1beta1.OpenStackControlPlaneTelemetryReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1beta1.OpenStackControlPlaneTelemetryReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the Telemetry resource into the instance
+		// under the condition of type OpenStackControlPlaneTelemetryReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(telemetry.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(telemetry.Status.Conditions, corev1beta1.OpenStackControlPlaneTelemetryReadyCondition, instance, telemetry.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlaneTelemetryReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1beta1.OpenStackControlPlaneTelemetryReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/openstack/watcher.go
+++ b/pkg/openstack/watcher.go
@@ -151,16 +151,29 @@ func ReconcileWatcher(ctx context.Context, instance *corev1beta1.OpenStackContro
 	}
 
 	if watcher.Status.ObservedGeneration == watcher.Generation && watcher.IsReady() {
+		helper.GetLogger().Info("Watcher ready condition is true")
 		instance.Status.ContainerImages.WatcherAPIImage = version.Status.ContainerImages.WatcherAPIImage
 		instance.Status.ContainerImages.WatcherApplierImage = version.Status.ContainerImages.WatcherApplierImage
 		instance.Status.ContainerImages.WatcherDecisionEngineImage = version.Status.ContainerImages.WatcherApplierImage
 		instance.Status.Conditions.MarkTrue(corev1beta1.OpenStackControlPlaneWatcherReadyCondition, corev1beta1.OpenStackControlPlaneWatcherReadyMessage)
 	} else {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			corev1beta1.OpenStackControlPlaneWatcherReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			corev1beta1.OpenStackControlPlaneWatcherReadyRunningMessage))
+		// We want to mirror the condition of the highest priority from the Watcher resource into the instance
+		// under the condition of type OpenStackControlPlaneWatcherReadyCondition, but only if the sub-resource
+		// currently has any conditions (which won't be true for the initial creation of the sub-resource, since
+		// it has not gone through a reconcile loop yet to have any conditions).  If this condition ends up being
+		// the highest priority condition in the OpenStackControlPlane, it will appear in the OpenStackControlPlane's
+		// "Ready" condition at the end of the reconciliation loop, clearly surfacing the condition to the user in
+		// the "oc get oscontrolplane -n <namespace>" output.
+		if len(watcher.Status.Conditions) > 0 {
+			MirrorSubResourceCondition(watcher.Status.Conditions, corev1beta1.OpenStackControlPlaneWatcherReadyCondition, instance, watcher.Kind)
+		} else {
+			// Default to the associated "running" condition message for the sub-resource if it currently lacks any conditions for mirroring
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlaneWatcherReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				corev1beta1.OpenStackControlPlaneWatcherReadyRunningMessage))
+		}
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Add MirrorSubResourceCondition calls across all OpenStack service reconcilers to enable proper condition hierarchy and severity-based prioritization in the OpenStackControlPlane's "Ready" condition.

Key changes:
- Add MirrorSubResourceCondition calls for better condition propagation from sub-resources to OpenStackControlPlane instance
- Ensure higher severity conditions (warn/error) are properly surfaced in 'oc get osctlplane' output instead of being overwritten by later info-level events

This addresses the core issue where the last-processed sub-resource condition would overwrite higher-severity conditions from earlier in the reconcile loop, ensuring critical conditions are properly prioritized and visible.

Files modified: pkg/openstack/common.go and all 20 OpenStack service reconcilers (keystone.go, barbican.go, cinder.go, glance.go, nova.go, neutron.go, etc.)

Related to: https://issues.redhat.com/browse/OSPRH-19707

Co-authored-by: Claude <claude@anthropic.com>