### PR TITLE
fix: Add controller prefix to duplicate log messages

### DIFF
--- a/controllers/client/openstackclient_controller.go
+++ b/controllers/client/openstackclient_controller.go
@@ -542,7 +542,7 @@ func (r *OpenStackClientReconciler) findObjectsForSrc(ctx context.Context, src c
 		}
 
 		for _, item := range crList.Items {
-			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("[Client] input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{

--- a/controllers/core/openstackcontrolplane_controller.go
+++ b/controllers/core/openstackcontrolplane_controller.go
@@ -758,7 +758,7 @@ func (r *OpenStackControlPlaneReconciler) findObjectsForSrc(ctx context.Context,
 		}
 
 		for _, item := range crList.Items {
-			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("[ControlPlane] input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{


### PR DESCRIPTION
Two different controllers are watching the same Secret changes and both logging when they detect that a keystone-related resource has changed.

This commit add controller prefix to both controllers:
- Add [ControlPlane] prefix to OpenStackControlPlane controller log
- Add [Client] prefix to OpenStackClient controller log

Benefits:
- Immediate differentiation of log sources
- Low risk, minimal code changes
- Maintains all existing functionality
- Improved operator debugging experience

Before:
'input source keystone changed, reconcile: nova - openstack' 'input source keystone changed, reconcile: nova - openstack'

After:
'[ControlPlane] input source keystone changed, reconcile: nova - openstack'
'[Client] input source keystone changed, reconcile: nova - openstack'

Fixes: #duplicate-logs
Assisted by: claude-4-sonnet