### PR TITLE
Enable OVNDBCluster metrics collection

### DIFF
--- a/pkg/openstack/ovn.go
+++ b/pkg/openstack/ovn.go
@@ -137,6 +137,7 @@ func ReconcileOVNDbClusters(ctx context.Context, instance *corev1beta1.OpenStack
 		if !instance.Spec.Ovn.Enabled {
 			instance.Status.ContainerImages.OvnNbDbclusterImage = nil
 			instance.Status.ContainerImages.OvnSbDbclusterImage = nil
+			instance.Status.ContainerImages.OpenstackNetworkExporterImage = nil
 			if _, err := EnsureDeleted(ctx, helper, OVNDBCluster); err != nil {
 				return false, conditions, err
 			}
@@ -223,6 +224,8 @@ func ReconcileOVNDbClusters(ctx context.Context, instance *corev1beta1.OpenStack
 				OVNDBCluster.Spec.ContainerImage = *version.Status.ContainerImages.OvnSbDbclusterImage
 			}
 
+			OVNDBCluster.Spec.ExporterImage = *getImg(version.Status.ContainerImages.OpenstackNetworkExporterImage, &missingImageDefault)
+
 			if OVNDBCluster.Spec.StorageClass == "" {
 				OVNDBCluster.Spec.StorageClass = instance.Spec.StorageClass
 			}
@@ -248,6 +251,7 @@ func ReconcileOVNDbClusters(ctx context.Context, instance *corev1beta1.OpenStack
 	if OVNDBClustersReady {
 		instance.Status.ContainerImages.OvnNbDbclusterImage = version.Status.ContainerImages.OvnNbDbclusterImage
 		instance.Status.ContainerImages.OvnSbDbclusterImage = version.Status.ContainerImages.OvnSbDbclusterImage
+		instance.Status.ContainerImages.OpenstackNetworkExporterImage = version.Status.ContainerImages.OpenstackNetworkExporterImage
 	}
 
 	return OVNDBClustersReady, conditions, nil


### PR DESCRIPTION
Add Prometheus metrics support to OVNDBCluster by updating the ovn-operator dependency and configuring the openstack-network-exporter sidecar container. This enables monitoring of OVSDB server metrics through the same pattern used for OVNNorthd.

Changes include:
- Update ovn-operator/api dependency to include OVNDBCluster metrics support
- Add ExporterImage assignment for OVNDBCluster reconciliation
- Update container image status tracking for OpenstackNetworkExporter
- Regenerate CRDs with new metricsEnabled and exporterImage fields

Depends-On: https://github.com/openstack-k8s-operators/ovn-operator/pull/480
Resolves: https://issues.redhat.com/browse/OSPRH-12567
Assisted-by: Claude