### PR TITLE
Remove deprecated cifmw_tempest_tempestconf_config

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -34,7 +34,7 @@
     vars:
       cifmw_operator_build_golang_ct: "docker.io/library/golang:1.24"
       cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.24"
-      cifmw_tempest_tempestconf_config:
+      cifmw_test_operator_tempest_tempestconf_config:
           # NOTE(alee) these tests will fail with barbican in the mix
           # while cinder/nova is not configured to talk to barbican
           # re-enable this when that support is added


### PR DESCRIPTION
The cifmw_tempest_tempestconf_config has been deprecated for a while, so it would be the best to start using the new alternative cifmw_test_operator_tempest_tempestconf_config. There should be no impact on the jobs, it should just let us cleanup the deprecated parameter.