### PR TITLE
Remove omitempty for baremetalSetTemplate

### DIFF
--- a/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/apis/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -40,6 +40,7 @@ spec:
           spec:
             properties:
               baremetalSetTemplate:
+                default: {}
                 properties:
                   agentImageUrl:
                     type: string

--- a/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/apis/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -36,8 +36,9 @@ import (
 // OpenStackDataPlaneNodeSetSpec defines the desired state of OpenStackDataPlaneNodeSet
 type OpenStackDataPlaneNodeSetSpec struct {
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
 	// BaremetalSetTemplate Template for BaremetalSet for the NodeSet
-	BaremetalSetTemplate baremetalv1.OpenStackBaremetalSetTemplateSpec `json:"baremetalSetTemplate,omitempty"`
+	BaremetalSetTemplate baremetalv1.OpenStackBaremetalSetTemplateSpec `json:"baremetalSetTemplate"`
 
 	// +kubebuilder:validation:Required
 	// NodeTemplate - node attributes specific to nodes defined by this resource. These

--- a/bindata/crds/crds.yaml
+++ b/bindata/crds/crds.yaml
@@ -16537,6 +16537,7 @@ spec:
           spec:
             properties:
               baremetalSetTemplate:
+                default: {}
                 properties:
                   agentImageUrl:
                     type: string

--- a/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
+++ b/config/crd/bases/dataplane.openstack.org_openstackdataplanenodesets.yaml
@@ -40,6 +40,7 @@ spec:
           spec:
             properties:
               baremetalSetTemplate:
+                default: {}
                 properties:
                   agentImageUrl:
                     type: string


### PR DESCRIPTION
This seems to break after we removed omitempty where there are defaults in https://github.com/openstack-k8s-operators/openstack-baremetal-operator/pull/324.