### PR TITLE
Set operator_version for git builds

### DIFF
--- a/.github/workflows/build-openstack-operator.yaml
+++ b/.github/workflows/build-openstack-operator.yaml
@@ -18,6 +18,7 @@ jobs:
       go_version: 1.24.x
       operator_sdk_version: 1.31.0
       bundle_dockerfile: ./bundle.Dockerfile
+      operator_version: 0.4.0
     secrets:
       IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
The shared workflow now supports this parameter and it is recommended to use it for openstack-operator which we version to provide "update" capable OLM catalogs