### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/dataplane/openstackdataplanenodeset_controller.go
+++ b/controllers/dataplane/openstackdataplanenodeset_controller.go
@@ -19,6 +19,7 @@ package dataplane
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -555,15 +556,9 @@ func checkDeployment(ctx context.Context, helper *helper.Helper,
 				continue
 			}
 			isDeploymentReady = true
-			for k, v := range deployment.Status.ConfigMapHashes {
-				instance.Status.ConfigMapHashes[k] = v
-			}
-			for k, v := range deployment.Status.SecretHashes {
-				instance.Status.SecretHashes[k] = v
-			}
-			for k, v := range deployment.Status.ContainerImages {
-				instance.Status.ContainerImages[k] = v
-			}
+			maps.Copy(instance.Status.ConfigMapHashes, deployment.Status.ConfigMapHashes)
+			maps.Copy(instance.Status.SecretHashes, deployment.Status.SecretHashes)
+			maps.Copy(instance.Status.ContainerImages, deployment.Status.ContainerImages)
 			instance.Status.DeployedConfigHash = deployment.Status.NodeSetHashes[instance.Name]
 
 			// Get list of services by name, either from ServicesOverride or

--- a/controllers/operator/openstack_controller.go
+++ b/controllers/operator/openstack_controller.go
@@ -866,7 +866,7 @@ func (r *OpenStackReconciler) postCleanupObsoleteResources(ctx context.Context, 
 				// The horizon-operator.openstack-operators has references to old roles/bindings
 				// the code below will delete those references before continuing
 				for _, ref := range refs {
-					refData := ref.(map[string]interface{})
+					refData := ref.(map[string]any)
 					Log.Info("Deleting operator reference", "Reference", ref)
 					obj := uns.Unstructured{}
 					obj.SetName(refData["name"].(string))

--- a/pkg/dataplane/deployment.go
+++ b/pkg/dataplane/deployment.go
@@ -322,7 +322,7 @@ func (d *Deployer) addCertMounts(
 				projectedVolumeSource := corev1.ProjectedVolumeSource{
 					Sources: []corev1.VolumeProjection{},
 				}
-				for i := 0; i < numberOfSecrets; i++ {
+				for i := range numberOfSecrets {
 					secretName := GetServiceCertsSecretName(d.NodeSet, service.Name, certKey, i)
 					certSecret := &corev1.Secret{}
 					err := client.Get(d.Ctx, types.NamespacedName{Name: secretName, Namespace: service.Namespace}, certSecret)

--- a/pkg/dataplane/inventory_test.go
+++ b/pkg/dataplane/inventory_test.go
@@ -12,7 +12,7 @@ func TestProcessConfigMapData_NumbersAsInts(t *testing.T) {
 		name         string
 		data         map[string]string
 		prefix       string
-		expected     map[string]interface{}
+		expected     map[string]any
 		expectedType any
 	}{
 		{
@@ -21,7 +21,7 @@ func TestProcessConfigMapData_NumbersAsInts(t *testing.T) {
 				"foo": "bar",
 			},
 			prefix: "",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
 			},
 			expectedType: "",
@@ -32,7 +32,7 @@ func TestProcessConfigMapData_NumbersAsInts(t *testing.T) {
 				"intVal": "123",
 			},
 			prefix: "",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"intVal": json.Number("123"),
 			},
 			expectedType: json.Number("1"),
@@ -43,7 +43,7 @@ func TestProcessConfigMapData_NumbersAsInts(t *testing.T) {
 				"floatVal": "123.45",
 			},
 			prefix: "",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"floatVal": json.Number("123.45"),
 			},
 			expectedType: json.Number("1"),
@@ -54,7 +54,7 @@ func TestProcessConfigMapData_NumbersAsInts(t *testing.T) {
 				"somekey": "42",
 			},
 			prefix: "myprefix-",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"myprefix-somekey": json.Number("42"),
 			},
 			expectedType: json.Number("1"),
@@ -91,7 +91,7 @@ func TestProcessSecretData_NumbersAsInts(t *testing.T) {
 		name         string
 		data         map[string][]byte
 		prefix       string
-		expected     map[string]interface{}
+		expected     map[string]any
 		expectedType any
 	}{
 		{
@@ -100,7 +100,7 @@ func TestProcessSecretData_NumbersAsInts(t *testing.T) {
 				"foo": []byte("bar"),
 			},
 			prefix: "",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
 			},
 			expectedType: "",
@@ -111,7 +111,7 @@ func TestProcessSecretData_NumbersAsInts(t *testing.T) {
 				"intVal": []byte("123"),
 			},
 			prefix: "",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"intVal": json.Number("123"),
 			},
 			expectedType: json.Number("1"),
@@ -122,7 +122,7 @@ func TestProcessSecretData_NumbersAsInts(t *testing.T) {
 				"floatVal": []byte("123.45"),
 			},
 			prefix: "",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"floatVal": json.Number("123.45"),
 			},
 			expectedType: json.Number("1"),
@@ -133,7 +133,7 @@ func TestProcessSecretData_NumbersAsInts(t *testing.T) {
 				"somekey": []byte("42"),
 			},
 			prefix: "myprefix-",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"myprefix-somekey": json.Number("42"),
 			},
 			expectedType: json.Number("1"),

--- a/pkg/dataplane/util/ansible_execution.go
+++ b/pkg/dataplane/util/ansible_execution.go
@@ -269,16 +269,16 @@ func (a *EEJob) FormatAEEExtraVars(
 	if service.Spec.DeployOnAllNodeSets {
 		a.ExtraVars["edpm_override_hosts"] = json.RawMessage([]byte("\"all\""))
 	} else {
-		a.ExtraVars["edpm_override_hosts"] = json.RawMessage([]byte(fmt.Sprintf("\"%s\"", nodeSet.GetName())))
+		a.ExtraVars["edpm_override_hosts"] = json.RawMessage(fmt.Appendf(nil, "\"%s\"", nodeSet.GetName()))
 	}
 	if service.Spec.EDPMServiceType != "" {
-		a.ExtraVars["edpm_service_type"] = json.RawMessage([]byte(fmt.Sprintf("\"%s\"", service.Spec.EDPMServiceType)))
+		a.ExtraVars["edpm_service_type"] = json.RawMessage(fmt.Appendf(nil, "\"%s\"", service.Spec.EDPMServiceType))
 	} else {
-		a.ExtraVars["edpm_service_type"] = json.RawMessage([]byte(fmt.Sprintf("\"%s\"", service.Name)))
+		a.ExtraVars["edpm_service_type"] = json.RawMessage(fmt.Appendf(nil, "\"%s\"", service.Name))
 	}
 
 	if len(deployment.Spec.ServicesOverride) > 0 {
-		a.ExtraVars["edpm_services_override"] = json.RawMessage([]byte(fmt.Sprintf("\"%s\"", deployment.Spec.ServicesOverride)))
+		a.ExtraVars["edpm_services_override"] = json.RawMessage(fmt.Appendf(nil, "\"%s\"", deployment.Spec.ServicesOverride))
 	}
 }
 

--- a/pkg/dataplane/util/ansibleee.go
+++ b/pkg/dataplane/util/ansibleee.go
@@ -3,6 +3,7 @@ package util //nolint:revive // util is an acceptable package name in this conte
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sort"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/storage"
@@ -183,7 +184,7 @@ func (a *EEJob) JobForOpenStackAnsibleEE(h *helper.Helper) (*batchv1.Job, error)
 		parsedExtraVars := ""
 		// unmarshal nested data structures
 		for _, variable := range keys {
-			var tmp interface{}
+			var tmp any
 			err := yaml.Unmarshal(a.ExtraVars[variable], &tmp)
 			if err != nil {
 				return nil, err
@@ -203,9 +204,7 @@ func labelsForOpenStackAnsibleEE(labels map[string]string) map[string]string {
 	ls := map[string]string{
 		"app": "openstackansibleee",
 	}
-	for key, val := range labels {
-		ls[key] = val
-	}
+	maps.Copy(ls, labels)
 	return ls
 }
 

--- a/pkg/lightspeed/funcs.go
+++ b/pkg/lightspeed/funcs.go
@@ -120,15 +120,15 @@ func PatchOLSConfig(
 	indexID string,
 ) error {
 	// 1. Patch the Providers section
-	providersPatch := []interface{}{
-		map[string]interface{}{
-			"credentialsSecretRef": map[string]interface{}{
+	providersPatch := []any{
+		map[string]any{
+			"credentialsSecretRef": map[string]any{
 				"name": instance.Spec.LLMCredentials,
 			},
-			"models": []interface{}{
-				map[string]interface{}{
+			"models": []any{
+				map[string]any{
 					"name":       instance.Spec.ModelName,
-					"parameters": map[string]interface{}{},
+					"parameters": map[string]any{},
 				},
 			},
 			"name": OpenStackLightspeedDefaultProvider,
@@ -141,8 +141,8 @@ func PatchOLSConfig(
 	}
 
 	// 2. Patch the RAG section
-	openstackRAG := []interface{}{
-		map[string]interface{}{
+	openstackRAG := []any{
+		map[string]any{
 			"image":     instance.Spec.RAGImage,
 			"indexID":   indexID,
 			"indexPath": OpenStackLightspeedVectorDBPath,
@@ -174,7 +174,7 @@ func PatchOLSConfig(
 
 	// 3. Add info which OpenStackLightspeed instance owns the OLSConfig
 	labels := olsConfig.GetLabels()
-	updatedLabels := map[string]interface{}{
+	updatedLabels := map[string]any{
 		OpenStackLightspeedOwnerIDLabel: string(instance.GetUID()),
 	}
 	for k, v := range labels {
@@ -299,7 +299,7 @@ func extractEnvFromPodLogs(ctx context.Context, pod *corev1.Pod, envVarName stri
 	}
 
 	logs := buf.String()
-	for _, envLine := range strings.Split(logs, "\n") {
+	for envLine := range strings.SplitSeq(logs, "\n") {
 		parts := strings.Split(envLine, "=")
 		if len(parts) != 2 {
 			continue

--- a/pkg/openstack/ca.go
+++ b/pkg/openstack/ca.go
@@ -937,7 +937,7 @@ func patchIssuer(
 		return err
 	}
 	// Unmarshal patch data into a local map for logging
-	patchDiff := map[string]interface{}{}
+	patchDiff := map[string]any{}
 	if err := json.Unmarshal(diff, &patchDiff); err != nil {
 		return err
 	}

--- a/pkg/operator/bindata/merge.go
+++ b/pkg/operator/bindata/merge.go
@@ -3,6 +3,7 @@ package bindata
 import (
 	"github.com/pkg/errors"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"maps"
 )
 
 const (
@@ -61,11 +62,11 @@ func MergeWebhookConfigurationForUpdate(current, updated *uns.Unstructured) erro
 
 	if gvk.Group == "admissionregistration.k8s.io" && (gvk.Kind == "MutatingWebhookConfiguration" || gvk.Kind == "ValidatingWebhookConfiguration") {
 
-		for i, webhook := range updated.Object["webhooks"].([]interface{}) {
+		for i, webhook := range updated.Object["webhooks"].([]any) {
 
-			currentClientConfig := current.Object["webhooks"].([]interface{})[i].(map[string]interface{})["clientConfig"].(map[string]interface{})
+			currentClientConfig := current.Object["webhooks"].([]any)[i].(map[string]any)["clientConfig"].(map[string]any)
 			if currentClientConfig != nil {
-				webhook.(map[string]interface{})["clientConfig"] = currentClientConfig
+				webhook.(map[string]any)["clientConfig"] = currentClientConfig
 			}
 
 		}
@@ -172,9 +173,7 @@ func mergeAnnotations(current, updated *uns.Unstructured) {
 		curAnnotations = map[string]string{}
 	}
 
-	for k, v := range updatedAnnotations {
-		curAnnotations[k] = v
-	}
+	maps.Copy(curAnnotations, updatedAnnotations)
 
 	updated.SetAnnotations(curAnnotations)
 }
@@ -189,9 +188,7 @@ func mergeLabels(current, updated *uns.Unstructured) {
 		curLabels = map[string]string{}
 	}
 
-	for k, v := range updatedLabels {
-		curLabels[k] = v
-	}
+	maps.Copy(curLabels, updatedLabels)
 
 	// add a label for openstack.openstack.org/crd to identify CRDs we install
 	gvk := updated.GroupVersionKind()

--- a/pkg/operator/bindata/render.go
+++ b/pkg/operator/bindata/render.go
@@ -19,14 +19,14 @@ import (
 // RenderData -
 type RenderData struct {
 	Funcs template.FuncMap
-	Data  map[string]interface{}
+	Data  map[string]any
 }
 
 // MakeRenderData -
 func MakeRenderData() RenderData {
 	return RenderData{
 		Funcs: template.FuncMap{},
-		Data:  map[string]interface{}{},
+		Data:  map[string]any{},
 	}
 }
 

--- a/tests/functional/ctlplane/base_test.go
+++ b/tests/functional/ctlplane/base_test.go
@@ -296,16 +296,16 @@ func CreateNames(openstackControlplaneName types.NamespacedName) Names {
 	}
 }
 
-func GetDefaultOpenStackClientSpec() map[string]interface{} {
-	return map[string]interface{}{}
+func GetDefaultOpenStackClientSpec() map[string]any {
+	return map[string]any{}
 }
 
-func CreateOpenStackClient(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateOpenStackClient(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "client.openstack.org/v1beta1",
 		"kind":       "OpenStackClient",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -327,12 +327,12 @@ func OpenStackClientConditionGetter(name types.NamespacedName) condition.Conditi
 	return instance.Status.Conditions
 }
 
-func CreateOpenStackVersion(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateOpenStackVersion(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "core.openstack.org/v1beta1",
 		"kind":       "OpenStackVersion",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -341,8 +341,8 @@ func CreateOpenStackVersion(name types.NamespacedName, spec map[string]interface
 	return th.CreateUnstructured(raw)
 }
 
-func GetDefaultOpenStackVersionSpec() map[string]interface{} {
-	return map[string]interface{}{}
+func GetDefaultOpenStackVersionSpec() map[string]any {
+	return map[string]any{}
 }
 
 func GetOpenStackVersion(name types.NamespacedName) *corev1.OpenStackVersion {
@@ -366,12 +366,12 @@ func OpenStackVersionRemoveFinalizer(ctx context.Context, name types.NamespacedN
 	}, timeout, interval).Should(Succeed())
 }
 
-func CreateOpenStackControlPlane(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateOpenStackControlPlane(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "core.openstack.org/v1beta1",
 		"kind":       "OpenStackControlPlane",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -381,16 +381,16 @@ func CreateOpenStackControlPlane(name types.NamespacedName, spec map[string]inte
 }
 
 // Build OpenStackDataPlaneNodeSetSpec struct with empty `Nodes` list
-func DefaultDataPlaneNoNodeSetSpec(tlsEnabled bool) map[string]interface{} {
-	spec := map[string]interface{}{
+func DefaultDataPlaneNoNodeSetSpec(tlsEnabled bool) map[string]any {
+	spec := map[string]any{
 		"preProvisioned": true,
-		"nodeTemplate": map[string]interface{}{
+		"nodeTemplate": map[string]any{
 			"networks": []infrav1.IPSetNetwork{
 				{Name: "ctlplane", SubnetName: "subnet1"},
 			},
 			"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
 		},
-		"nodes":            map[string]interface{}{},
+		"nodes":            map[string]any{},
 		"servicesOverride": []string{},
 	}
 	if tlsEnabled {
@@ -409,12 +409,12 @@ func GetDataplaneNodeset(name types.NamespacedName) *dataplanev1.OpenStackDataPl
 }
 
 // Build OpenStackDataPlaneNodeSet struct and fill it with preset values
-func DefaultDataplaneNodeSetTemplate(name types.NamespacedName, spec map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
+func DefaultDataplaneNodeSetTemplate(name types.NamespacedName, spec map[string]any) map[string]any {
+	return map[string]any{
 
 		"apiVersion": "dataplane.openstack.org/v1beta1",
 		"kind":       "OpenStackDataPlaneNodeSet",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -424,47 +424,47 @@ func DefaultDataplaneNodeSetTemplate(name types.NamespacedName, spec map[string]
 
 // Create OpenstackDataPlaneNodeSet in k8s and test that no errors occur
 // func CreateDataplaneNodeSet(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
-func CreateDataplaneNodeSet(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateDataplaneNodeSet(name types.NamespacedName, spec map[string]any) client.Object {
 	instance := DefaultDataplaneNodeSetTemplate(name, spec)
 	return th.CreateUnstructured(instance)
 }
 
-func GetTLSPublicSpec() map[string]interface{} {
-	return map[string]interface{}{
-		"podLevel": map[string]interface{}{
+func GetTLSPublicSpec() map[string]any {
+	return map[string]any{
+		"podLevel": map[string]any{
 			"enabled": false,
 		},
 	}
 }
 
-func GetTLSeCustomIssuerSpec() map[string]interface{} {
-	return map[string]interface{}{
-		"ingress": map[string]interface{}{
+func GetTLSeCustomIssuerSpec() map[string]any {
+	return map[string]any{
+		"ingress": map[string]any{
 			"enabled": true,
 
-			"ca": map[string]interface{}{
+			"ca": map[string]any{
 				"customIssuer": names.CustomIssuerName.Name,
 				"duration":     "100h",
 			},
-			"cert": map[string]interface{}{
+			"cert": map[string]any{
 				"duration": "10h",
 			},
 		},
-		"podLevel": map[string]interface{}{
+		"podLevel": map[string]any{
 			"enabled": true,
-			"internal": map[string]interface{}{
-				"ca": map[string]interface{}{
+			"internal": map[string]any{
+				"ca": map[string]any{
 					"duration": "100h",
 				},
-				"cert": map[string]interface{}{
+				"cert": map[string]any{
 					"duration": "10h",
 				},
 			},
-			"ovn": map[string]interface{}{
-				"ca": map[string]interface{}{
+			"ovn": map[string]any{
+				"ca": map[string]any{
 					"duration": "100h",
 				},
-				"cert": map[string]interface{}{
+				"cert": map[string]any{
 					"duration": "10h",
 				},
 			},
@@ -472,8 +472,8 @@ func GetTLSeCustomIssuerSpec() map[string]interface{} {
 	}
 }
 
-func GetDefaultGaleraSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultGaleraSpec() map[string]any {
+	return map[string]any{
 		"replicas":       1,
 		"logToDisk":      false,
 		"secret":         "osp-secret",
@@ -483,13 +483,13 @@ func GetDefaultGaleraSpec() map[string]interface{} {
 	}
 }
 
-func CreateGaleraConfig(namespace string, spec map[string]interface{}) client.Object {
+func CreateGaleraConfig(namespace string, spec map[string]any) client.Object {
 	name := uuid.New().String()
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "mariadb.openstack.org/v1beta1",
 		"kind":       "Galera",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -499,20 +499,20 @@ func CreateGaleraConfig(namespace string, spec map[string]interface{}) client.Ob
 	return th.CreateUnstructured(raw)
 }
 
-func GetDefaultRabbitMQSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultRabbitMQSpec() map[string]any {
+	return map[string]any{
 		"replicas":       1,
 		"containerImage": "",
 	}
 }
 
-func CreateRabbitMQConfig(namespace string, spec map[string]interface{}) client.Object {
+func CreateRabbitMQConfig(namespace string, spec map[string]any) client.Object {
 	name := uuid.New().String()
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "rabbitmq.openstack.org/v1beta1",
 		"kind":       "RabbitMq",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -522,144 +522,144 @@ func CreateRabbitMQConfig(namespace string, spec map[string]interface{}) client.
 	return th.CreateUnstructured(raw)
 }
 
-func GetDefaultOpenStackControlPlaneSpec() map[string]interface{} {
-	memcachedTemplate := map[string]interface{}{
-		"memcached": map[string]interface{}{
+func GetDefaultOpenStackControlPlaneSpec() map[string]any {
+	memcachedTemplate := map[string]any{
+		"memcached": map[string]any{
 			"replicas": 1,
 		},
 	}
-	rabbitTemplate := map[string]interface{}{
-		names.RabbitMQName.Name: map[string]interface{}{
+	rabbitTemplate := map[string]any{
+		names.RabbitMQName.Name: map[string]any{
 			"replicas": 1,
 		},
-		names.RabbitMQCell1Name.Name: map[string]interface{}{
+		names.RabbitMQCell1Name.Name: map[string]any{
 			"replicas": 1,
 		},
 	}
-	galeraTemplate := map[string]interface{}{
-		names.DBName.Name: map[string]interface{}{
+	galeraTemplate := map[string]any{
+		names.DBName.Name: map[string]any{
 			"storageRequest": "500M",
 		},
-		names.DBCell1Name.Name: map[string]interface{}{
+		names.DBCell1Name.Name: map[string]any{
 			"storageRequest": "500M",
 		},
 	}
-	keystoneTemplate := map[string]interface{}{
+	keystoneTemplate := map[string]any{
 		"databaseInstance": names.KeystoneAPIName.Name,
 		"secret":           "osp-secret",
 	}
-	ironicTemplate := map[string]interface{}{
-		"ironicConductors": []interface{}{},
+	ironicTemplate := map[string]any{
+		"ironicConductors": []any{},
 	}
-	heatTemplate := map[string]interface{}{
+	heatTemplate := map[string]any{
 		"databaseInstance": "openstack",
 		"secret":           "osp-secret",
-		"passwordSelectors": map[string]interface{}{
+		"passwordSelectors": map[string]any{
 			"authEncryptionKey": "HeatAuthEncryptionKey",
 		},
 	}
-	telemetryTemplate := map[string]interface{}{
-		"ceilometer": map[string]interface{}{
+	telemetryTemplate := map[string]any{
+		"ceilometer": map[string]any{
 			"enabled": false,
 		},
-		"metricStorage": map[string]interface{}{
+		"metricStorage": map[string]any{
 			"enabled": false,
 		},
-		"logging": map[string]interface{}{
+		"logging": map[string]any{
 			"enabled": false,
 		},
-		"autoscaling": map[string]interface{}{
+		"autoscaling": map[string]any{
 			"enabled": false,
 		},
 	}
-	manilaTemplate := map[string]interface{}{
+	manilaTemplate := map[string]any{
 		"databaseInstance":    "openstack",
 		"rabbitMqClusterName": "rabbitmq",
 		"memcachedInstance":   "memcached",
 		"databaseAccount":     "account",
-		"manilaAPI": map[string]interface{}{
+		"manilaAPI": map[string]any{
 			"replicas": 1,
 		},
-		"manilaScheduler": map[string]interface{}{
+		"manilaScheduler": map[string]any{
 			"replicas": 1,
 		},
-		"manilaShares": map[string]interface{}{
-			"share1": map[string]interface{}{
+		"manilaShares": map[string]any{
+			"share1": map[string]any{
 				"replicas": 1,
 			},
 		},
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"secret":       "osp-secret",
 		"storageClass": "local-storage",
-		"galera": map[string]interface{}{
+		"galera": map[string]any{
 			"enabled":   true,
 			"templates": galeraTemplate,
 		},
-		"rabbitmq": map[string]interface{}{
+		"rabbitmq": map[string]any{
 			"enabled":   true,
 			"templates": rabbitTemplate,
 		},
-		"memcached": map[string]interface{}{
+		"memcached": map[string]any{
 			"enabled":   true,
 			"templates": memcachedTemplate,
 		},
-		"keystone": map[string]interface{}{
+		"keystone": map[string]any{
 			"enabled":  true,
 			"template": keystoneTemplate,
 		},
-		"placement": map[string]interface{}{
+		"placement": map[string]any{
 			"enabled": false,
 		},
-		"glance": map[string]interface{}{
+		"glance": map[string]any{
 			"enabled": true,
 		},
-		"horizon": map[string]interface{}{
+		"horizon": map[string]any{
 			"enabled": true,
 		},
-		"cinder": map[string]interface{}{
+		"cinder": map[string]any{
 			"enabled": true,
 		},
-		"ovn": map[string]interface{}{
+		"ovn": map[string]any{
 			"enabled": false,
 		},
-		"neutron": map[string]interface{}{
+		"neutron": map[string]any{
 			"enabled": true,
 		},
-		"swift": map[string]interface{}{
+		"swift": map[string]any{
 			"enabled": false,
 		},
-		"nova": map[string]interface{}{
+		"nova": map[string]any{
 			"enabled": false,
 		},
-		"redis": map[string]interface{}{
+		"redis": map[string]any{
 			"enabled": false,
 		},
-		"ironic": map[string]interface{}{
+		"ironic": map[string]any{
 			"enabled":  false,
 			"template": ironicTemplate,
 		},
-		"designate": map[string]interface{}{
+		"designate": map[string]any{
 			"enabled": false,
 		},
-		"barbican": map[string]interface{}{
+		"barbican": map[string]any{
 			"enabled": false,
 		},
-		"openstackclient": map[string]interface{}{},
-		"manila": map[string]interface{}{
+		"openstackclient": map[string]any{},
+		"manila": map[string]any{
 			"enabled":  true,
 			"template": manilaTemplate,
 		},
-		"heat": map[string]interface{}{
+		"heat": map[string]any{
 			"enabled":  true,
 			"template": heatTemplate,
 		},
-		"telemetry": map[string]interface{}{
+		"telemetry": map[string]any{
 			"enabled":  true,
 			"template": telemetryTemplate,
 		},
-		"watcher": map[string]interface{}{
+		"watcher": map[string]any{
 			"enabled": false,
 		},
 	}
@@ -708,7 +708,7 @@ func CreateClusterConfigCM() client.Object {
 				Name:      "cluster-config-v1",
 				Namespace: "kube-system",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"install-config": "",
 			})
 	}, timeout, interval).Should(Succeed())
@@ -821,10 +821,10 @@ func SimulateControlplaneReady() {
 }
 
 // GetSampleTopologySpec - A sample (and opinionated) Topology Spec
-func GetSampleTopologySpec() map[string]interface{} {
+func GetSampleTopologySpec() map[string]any {
 	// Build the topology Spec
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       k8s_corev1.LabelHostname,
@@ -836,11 +836,11 @@ func GetSampleTopologySpec() map[string]interface{} {
 }
 
 // CreateTopology - Creates a Topology CR based on the spec passed as input
-func CreateTopology(topology types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateTopology(topology types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "topology.openstack.org/v1beta1",
 		"kind":       "Topology",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      topology.Name,
 			"namespace": topology.Namespace,
 		},

--- a/tests/functional/ctlplane/openstackoperator_controller_test.go
+++ b/tests/functional/ctlplane/openstackoperator_controller_test.go
@@ -181,8 +181,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			tlsSpec := GetTLSPublicSpec()
-			tlsSpec["ingress"] = map[string]interface{}{
-				"ca": map[string]interface{}{
+			tlsSpec["ingress"] = map[string]any{
+				"ca": map[string]any{
 					"duration": "100h",
 				},
 			}
@@ -211,8 +211,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			tlsSpec := GetTLSPublicSpec()
-			tlsSpec["ingress"] = map[string]interface{}{
-				"cert": map[string]interface{}{
+			tlsSpec["ingress"] = map[string]any{
+				"cert": map[string]any{
 					"duration": "10h",
 				},
 			}
@@ -241,11 +241,11 @@ var _ = Describe("OpenStackOperator controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			tlsSpec := GetTLSPublicSpec()
-			tlsSpec["ingress"] = map[string]interface{}{
-				"ca": map[string]interface{}{
+			tlsSpec["ingress"] = map[string]any{
+				"ca": map[string]any{
 					"duration": "100h",
 				},
-				"cert": map[string]interface{}{
+				"cert": map[string]any{
 					"duration": "10h",
 				},
 			}
@@ -274,11 +274,11 @@ var _ = Describe("OpenStackOperator controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			tlsSpec := GetTLSPublicSpec()
-			tlsSpec["ingress"] = map[string]interface{}{
-				"ca": map[string]interface{}{
+			tlsSpec["ingress"] = map[string]any{
+				"ca": map[string]any{
 					"renewBefore": "100h",
 				},
-				"cert": map[string]interface{}{
+				"cert": map[string]any{
 					"renewBefore": "10h",
 				},
 			}
@@ -309,8 +309,8 @@ var _ = Describe("OpenStackOperator controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			tlsSpec := GetTLSPublicSpec()
-			tlsSpec["ingress"] = map[string]interface{}{
-				"ca": map[string]interface{}{
+			tlsSpec["ingress"] = map[string]any{
+				"ca": map[string]any{
 					"customIssuer": "myissuer",
 				},
 			}
@@ -380,10 +380,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 	When("TLS - A TLSe OpenStackControlplane instance is created with customized internal ca duration", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
-			spec["tls"] = map[string]interface{}{
-				"podLevel": map[string]interface{}{
-					"internal": map[string]interface{}{
-						"ca": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"podLevel": map[string]any{
+					"internal": map[string]any{
+						"ca": map[string]any{
 							"duration": "100h",
 						},
 					},
@@ -435,10 +435,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 	When("TLS - A TLSe OpenStackControlplane instance is created with customized internal cert duration", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
-			spec["tls"] = map[string]interface{}{
-				"podLevel": map[string]interface{}{
-					"internal": map[string]interface{}{
-						"cert": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"podLevel": map[string]any{
+					"internal": map[string]any{
+						"cert": map[string]any{
 							"duration": "10h",
 						},
 					},
@@ -490,10 +490,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 	When("TLS - A TLSe OpenStackControlplane instance is created with an internal custom issuer", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
-			spec["tls"] = map[string]interface{}{
-				"podLevel": map[string]interface{}{
-					"internal": map[string]interface{}{
-						"ca": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"podLevel": map[string]any{
+					"internal": map[string]any{
+						"ca": map[string]any{
 							"customIssuer": "myissuer",
 						},
 					},
@@ -523,13 +523,13 @@ var _ = Describe("OpenStackOperator controller", func() {
 	When("TLS - A TLSe OpenStackControlplane instance is created with an libvirt custom issuer", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
-			spec["tls"] = map[string]interface{}{
-				"podLevel": map[string]interface{}{
-					"libvirt": map[string]interface{}{
-						"ca": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"podLevel": map[string]any{
+					"libvirt": map[string]any{
+						"ca": map[string]any{
 							"customIssuer": "myissuer",
 						},
-						"cert": map[string]interface{}{
+						"cert": map[string]any{
 							"duration": "43800h", // can we come up with a single default duration for certs?
 						},
 					},
@@ -559,10 +559,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 	When("TLS - A TLSe OpenStackControlplane instance is created with an ovn custom issuer", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
-			spec["tls"] = map[string]interface{}{
-				"podLevel": map[string]interface{}{
-					"ovn": map[string]interface{}{
-						"ca": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"podLevel": map[string]any{
+					"ovn": map[string]any{
+						"ca": map[string]any{
 							"customIssuer": "myissuer",
 						},
 					},
@@ -799,7 +799,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			th.CreateSecret(types.NamespacedName{Name: "openstack-config-secret", Namespace: namespace}, map[string][]byte{"secure.yaml": []byte("foo")})
-			th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]interface{}{"clouds.yaml": string("foo"), "OS_CLOUD": "default"})
+			th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]any{"clouds.yaml": string("foo"), "OS_CLOUD": "default"})
 
 			// client pod exists
 			Eventually(func(g Gomega) {
@@ -1055,7 +1055,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			th.CreateSecret(types.NamespacedName{Name: "openstack-config-secret", Namespace: namespace}, map[string][]byte{"secure.yaml": []byte("foo")})
-			th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]interface{}{"clouds.yaml": string("foo"), "OS_CLOUD": "default"})
+			th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]any{"clouds.yaml": string("foo"), "OS_CLOUD": "default"})
 
 			// client pod exists
 			Eventually(func(g Gomega) {
@@ -1303,17 +1303,17 @@ var _ = Describe("OpenStackOperator controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx,
 				th.CreateSecret(types.NamespacedName{Name: "openstack-config-secret", Namespace: namespace}, map[string][]byte{"secure.yaml": []byte("foo")}))
 			DeferCleanup(k8sClient.Delete, ctx,
-				th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]interface{}{"clouds.yaml": string("foo"), "OS_CLOUD": "default"}))
+				th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]any{"clouds.yaml": string("foo"), "OS_CLOUD": "default"}))
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			spec["tls"] = GetTLSPublicSpec()
-			spec["keystone"] = map[string]interface{}{
+			spec["keystone"] = map[string]any{
 				"enabled": true,
-				"apiOverride": map[string]interface{}{
-					"tls": map[string]interface{}{
+				"apiOverride": map[string]any{
+					"tls": map[string]any{
 						"secretName": names.CustomServiceCertSecretName.Name,
 					},
 				},
-				"template": map[string]interface{}{
+				"template": map[string]any{
 					"databaseInstance": names.KeystoneAPIName.Name,
 					"secret":           "osp-secret",
 				},
@@ -1571,20 +1571,20 @@ var _ = Describe("OpenStackOperator controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			spec["tls"] = GetTLSPublicSpec()
-			spec["cinder"] = map[string]interface{}{
+			spec["cinder"] = map[string]any{
 				"enabled": true,
-				"template": map[string]interface{}{
-					"cinderAPI": map[string]interface{}{
+				"template": map[string]any{
+					"cinderAPI": map[string]any{
 						"replicas": 1,
 					},
-					"cinderBackup": map[string]interface{}{
+					"cinderBackup": map[string]any{
 						"replicas": 1,
 					},
-					"cinderScheduler": map[string]interface{}{
+					"cinderScheduler": map[string]any{
 						"replicas": 1,
 					},
-					"cinderVolumes": map[string]interface{}{
-						"volume1": map[string]interface{}{
+					"cinderVolumes": map[string]any{
+						"volume1": map[string]any{
 							"replicas": 1,
 						},
 					},
@@ -1678,19 +1678,19 @@ var _ = Describe("OpenStackOperator controller", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			spec["tls"] = GetTLSPublicSpec()
-			spec["ovn"] = map[string]interface{}{
+			spec["ovn"] = map[string]any{
 				"enabled": true,
-				"template": map[string]interface{}{
-					"ovnDBCluster": map[string]interface{}{
-						"ovndbcluster-nb": map[string]interface{}{
+				"template": map[string]any{
+					"ovnDBCluster": map[string]any{
+						"ovndbcluster-nb": map[string]any{
 							"dbType": "NB",
 						},
-						"ovndbcluster-sb": map[string]interface{}{
+						"ovndbcluster-sb": map[string]any{
 							"dbType": "SB",
 						},
 					},
-					"ovnController": map[string]interface{}{
-						"nicMappings": map[string]interface{}{
+					"ovnController": map[string]any{
+						"nicMappings": map[string]any{
 							"datacentre": "ospbr",
 						},
 					},
@@ -1829,82 +1829,82 @@ var _ = Describe("OpenStackOperator controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx,
 				th.CreateSecret(types.NamespacedName{Name: "openstack-config-secret", Namespace: namespace}, map[string][]byte{"secure.yaml": []byte("foo")}))
 			DeferCleanup(k8sClient.Delete, ctx,
-				th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]interface{}{"clouds.yaml": string("foo"), "OS_CLOUD": "default"}))
+				th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]any{"clouds.yaml": string("foo"), "OS_CLOUD": "default"}))
 
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			// enable dependencies
-			spec["nova"] = map[string]interface{}{
+			spec["nova"] = map[string]any{
 				"enabled": true,
-				"template": map[string]interface{}{
+				"template": map[string]any{
 					"apiTimeout": 60,
-					"cellTemplates": map[string]interface{}{
-						"cell0": map[string]interface{}{},
+					"cellTemplates": map[string]any{
+						"cell0": map[string]any{},
 					},
 				},
 			}
-			spec["galera"] = map[string]interface{}{
+			spec["galera"] = map[string]any{
 				"enabled": true,
 			}
-			spec["memcached"] = map[string]interface{}{
+			spec["memcached"] = map[string]any{
 				"enabled": true,
-				"templates": map[string]interface{}{
-					"memcached": map[string]interface{}{
+				"templates": map[string]any{
+					"memcached": map[string]any{
 						"replicas": 1,
 					},
 				},
 			}
-			spec["rabbitmq"] = map[string]interface{}{
+			spec["rabbitmq"] = map[string]any{
 				"enabled": true,
-				"templates": map[string]interface{}{
-					"rabbitmq": map[string]interface{}{
+				"templates": map[string]any{
+					"rabbitmq": map[string]any{
 						"replicas": 1,
 					},
 				},
 			}
-			spec["keystone"] = map[string]interface{}{
+			spec["keystone"] = map[string]any{
 				"enabled": true,
 			}
-			spec["glance"] = map[string]interface{}{
+			spec["glance"] = map[string]any{
 				"enabled": true,
 			}
-			spec["neutron"] = map[string]interface{}{
+			spec["neutron"] = map[string]any{
 				"enabled": true,
 			}
-			spec["placement"] = map[string]interface{}{
+			spec["placement"] = map[string]any{
 				"enabled": true,
-				"template": map[string]interface{}{
+				"template": map[string]any{
 					"apiTimeout": 60,
 				},
 			}
 			// turn off unrelated to this test case services
-			spec["horizon"] = map[string]interface{}{
+			spec["horizon"] = map[string]any{
 				"enabled": false,
 			}
-			spec["cinder"] = map[string]interface{}{
+			spec["cinder"] = map[string]any{
 				"enabled": false,
 			}
-			spec["swift"] = map[string]interface{}{
+			spec["swift"] = map[string]any{
 				"enabled": false,
 			}
-			spec["redis"] = map[string]interface{}{
+			spec["redis"] = map[string]any{
 				"enabled": false,
 			}
-			spec["ironic"] = map[string]interface{}{
+			spec["ironic"] = map[string]any{
 				"enabled": false,
 			}
-			spec["designate"] = map[string]interface{}{
+			spec["designate"] = map[string]any{
 				"enabled": false,
 			}
-			spec["barbican"] = map[string]interface{}{
+			spec["barbican"] = map[string]any{
 				"enabled": false,
 			}
-			spec["manila"] = map[string]interface{}{
+			spec["manila"] = map[string]any{
 				"enabled": false,
 			}
-			spec["heat"] = map[string]interface{}{
+			spec["heat"] = map[string]any{
 				"enabled": false,
 			}
-			spec["telemetry"] = map[string]interface{}{
+			spec["telemetry"] = map[string]any{
 				"enabled": false,
 			}
 
@@ -1967,16 +1967,16 @@ var _ = Describe("OpenStackOperator controller", func() {
 	When("A watcher OpenStackControlplane instance is created with telemetry and default values", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
-			spec["watcher"] = map[string]interface{}{
+			spec["watcher"] = map[string]any{
 				"enabled": true,
 			}
-			spec["telemetry"] = map[string]interface{}{
+			spec["telemetry"] = map[string]any{
 				"enabled": true,
-				"template": map[string]interface{}{
-					"ceilometer": map[string]interface{}{
+				"template": map[string]any{
+					"ceilometer": map[string]any{
 						"enabled": true,
 					},
-					"metricStorage": map[string]interface{}{
+					"metricStorage": map[string]any{
 						"enabled": true,
 					},
 				},
@@ -2139,13 +2139,13 @@ var _ = Describe("OpenStackOperator controller", func() {
 	When("A watcher OpenStackControlplane instance is created with custom parameters", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
-			spec["watcher"] = map[string]interface{}{
+			spec["watcher"] = map[string]any{
 				"enabled": true,
-				"template": map[string]interface{}{
-					"decisionengineServiceTemplate": map[string]interface{}{
+				"template": map[string]any{
+					"decisionengineServiceTemplate": map[string]any{
 						"customServiceConfig": "#testcustom",
 					},
-					"apiServiceTemplate": map[string]interface{}{
+					"apiServiceTemplate": map[string]any{
 						"replicas": int32(2),
 					},
 					"databaseInstance": "custom-db",
@@ -2153,13 +2153,13 @@ var _ = Describe("OpenStackOperator controller", func() {
 					"apiTimeout":       120,
 				},
 			}
-			spec["telemetry"] = map[string]interface{}{
+			spec["telemetry"] = map[string]any{
 				"enabled": true,
-				"template": map[string]interface{}{
-					"ceilometer": map[string]interface{}{
+				"template": map[string]any{
+					"ceilometer": map[string]any{
 						"enabled": true,
 					},
-					"metricStorage": map[string]interface{}{
+					"metricStorage": map[string]any{
 						"enabled": true,
 					},
 				},
@@ -2322,10 +2322,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 		})
 
 		It("rejects the OpenStackControlPlane if its name is not that same as the OpenStackVersion's name", func() {
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "core.openstack.org/v1beta1",
 				"kind":       "OpenStackControlPlane",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      names.OpenStackControlplaneName.Name,
 					"namespace": names.Namespace,
 				},
@@ -2354,10 +2354,10 @@ var _ = Describe("OpenStackOperator controller", func() {
 		})
 
 		It("accepts the OpenStackControlPlane if its name is the same as the OpenStackVersion's name", func() {
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "core.openstack.org/v1beta1",
 				"kind":       "OpenStackControlPlane",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      names.OpenStackVersionName2.Name,
 					"namespace": names.Namespace,
 				},
@@ -2417,7 +2417,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			th.CreateSecret(types.NamespacedName{Name: "openstack-config-secret", Namespace: namespace}, map[string][]byte{"secure.yaml": []byte("foo")})
-			th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]interface{}{"clouds.yaml": string("foo"), "OS_CLOUD": "default"})
+			th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]any{"clouds.yaml": string("foo"), "OS_CLOUD": "default"})
 		})
 
 		It("sets nodeSelector in resource specs", func() {
@@ -2585,7 +2585,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 	When("An OpenStackControlplane instance references a wrong topology", func() {
 		BeforeEach(func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": "foo",
 			}
 			DeferCleanup(
@@ -2619,18 +2619,18 @@ var _ = Describe("OpenStackOperator controller", func() {
 			spec["topologyRef"] = map[string]string{
 				"name": names.OpenStackTopology[0].Name,
 			}
-			spec["telemetry"] = map[string]interface{}{
+			spec["telemetry"] = map[string]any{
 				"enabled": true,
-				"template": map[string]interface{}{
-					"ceilometer": map[string]interface{}{
+				"template": map[string]any{
+					"ceilometer": map[string]any{
 						"enabled": true,
 					},
-					"metricStorage": map[string]interface{}{
+					"metricStorage": map[string]any{
 						"enabled": true,
 					},
 				},
 			}
-			spec["watcher"] = map[string]interface{}{
+			spec["watcher"] = map[string]any{
 				"enabled": true,
 			}
 			// Build the topology Spec
@@ -2679,7 +2679,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			th.CreateConfigMap(types.NamespacedName{
 				Name:      "openstack-config",
 				Namespace: namespace,
-			}, map[string]interface{}{
+			}, map[string]any{
 				"clouds.yaml": string("foo"),
 				"OS_CLOUD":    "default",
 			})
@@ -2847,10 +2847,10 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 		Expect(OSCtlplane.Labels).Should(Not(BeNil()))
 		Expect(OSCtlplane.Labels).Should(HaveKeyWithValue("core.openstack.org/openstackcontrolplane", ""))
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": OSCtlplane.GetNamespace(),
 			},
@@ -2886,13 +2886,13 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Does not override default label via defaulting webhook when provided", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 		spec["tls"] = GetTLSPublicSpec()
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "openstack",
 				"namespace": namespace,
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					"core.openstack.org/openstackcontrolplane": "foo",
 				},
 			},
@@ -2912,17 +2912,17 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("calls placement validation webhook", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 		spec["tls"] = GetTLSPublicSpec()
-		spec["placement"] = map[string]interface{}{
-			"template": map[string]interface{}{
-				"defaultConfigOverwrite": map[string]interface{}{
+		spec["placement"] = map[string]any{
+			"template": map[string]any{
+				"defaultConfigOverwrite": map[string]any{
 					"api-paste.ini": "not supported",
 				},
 			},
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "openstack",
 				"namespace": namespace,
 			},
@@ -2948,21 +2948,21 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with to long memcached keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		memcachedTemplate := map[string]interface{}{
-			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{
+		memcachedTemplate := map[string]any{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]any{
 				"replicas": 1,
 			},
 		}
 
-		spec["memcached"] = map[string]interface{}{
+		spec["memcached"] = map[string]any{
 			"enabled":   true,
 			"templates": memcachedTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -2985,21 +2985,21 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with wrong memcached keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		memcachedTemplate := map[string]interface{}{
-			"foo_bar": map[string]interface{}{
+		memcachedTemplate := map[string]any{
+			"foo_bar": map[string]any{
 				"replicas": 1,
 			},
 		}
 
-		spec["memcached"] = map[string]interface{}{
+		spec["memcached"] = map[string]any{
 			"enabled":   true,
 			"templates": memcachedTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3022,21 +3022,21 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with to long rabbitmq keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		rabbitmqTemplate := map[string]interface{}{
-			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{
+		rabbitmqTemplate := map[string]any{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]any{
 				"replicas": 1,
 			},
 		}
 
-		spec["rabbitmq"] = map[string]interface{}{
+		spec["rabbitmq"] = map[string]any{
 			"enabled":   true,
 			"templates": rabbitmqTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3059,21 +3059,21 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with wrong rabbitmq keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		rabbitmqTemplate := map[string]interface{}{
-			"foo_bar": map[string]interface{}{
+		rabbitmqTemplate := map[string]any{
+			"foo_bar": map[string]any{
 				"replicas": 1,
 			},
 		}
 
-		spec["rabbitmq"] = map[string]interface{}{
+		spec["rabbitmq"] = map[string]any{
 			"enabled":   true,
 			"templates": rabbitmqTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3096,21 +3096,21 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with to long galera keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		galeraTemplate := map[string]interface{}{
-			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{
+		galeraTemplate := map[string]any{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]any{
 				"storageRequest": "500M",
 			},
 		}
 
-		spec["galera"] = map[string]interface{}{
+		spec["galera"] = map[string]any{
 			"enabled":   true,
 			"templates": galeraTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3133,21 +3133,21 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with wrong galera keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		galeraTemplate := map[string]interface{}{
-			"foo_bar": map[string]interface{}{
+		galeraTemplate := map[string]any{
+			"foo_bar": map[string]any{
 				"storageRequest": "500M",
 			},
 		}
 
-		spec["galera"] = map[string]interface{}{
+		spec["galera"] = map[string]any{
 			"enabled":   true,
 			"templates": galeraTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3170,29 +3170,29 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with to long glanceapi keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		apiList := map[string]interface{}{
-			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{
+		apiList := map[string]any{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]any{
 				"replicas": 1,
 			},
 		}
 
-		glanceTemplate := map[string]interface{}{
+		glanceTemplate := map[string]any{
 			"databaseInstance": "openstack",
 			"secret":           "secret",
 			"databaseAccount":  "account",
 			"glanceAPIs":       apiList,
 		}
 
-		spec["glance"] = map[string]interface{}{
+		spec["glance"] = map[string]any{
 			"enabled":        true,
 			"uniquePodNames": false,
 			"template":       glanceTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3215,29 +3215,29 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with to long glanceapi keys/names (uniquePodNames)", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		apiList := map[string]interface{}{
-			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{
+		apiList := map[string]any{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]any{
 				"replicas": 1,
 			},
 		}
 
-		glanceTemplate := map[string]interface{}{
+		glanceTemplate := map[string]any{
 			"databaseInstance": "openstack",
 			"secret":           "secret",
 			"databaseAccount":  "account",
 			"glanceAPIs":       apiList,
 		}
 
-		spec["glance"] = map[string]interface{}{
+		spec["glance"] = map[string]any{
 			"enabled":        true,
 			"uniquePodNames": true,
 			"template":       glanceTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3260,28 +3260,28 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with wrong glanceapi keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		apiList := map[string]interface{}{
-			"foo_bar": map[string]interface{}{
+		apiList := map[string]any{
+			"foo_bar": map[string]any{
 				"replicas": 1,
 			},
 		}
 
-		glanceTemplate := map[string]interface{}{
+		glanceTemplate := map[string]any{
 			"databaseInstance": "openstack",
 			"secret":           "secret",
 			"databaseAccount":  "account",
 			"glanceAPIs":       apiList,
 		}
 
-		spec["glance"] = map[string]interface{}{
+		spec["glance"] = map[string]any{
 			"enabled":  true,
 			"template": glanceTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3304,26 +3304,26 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with to long cinderVolume keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		volumeList := map[string]interface{}{
-			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{},
+		volumeList := map[string]any{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]any{},
 		}
-		cinderTemplate := map[string]interface{}{
+		cinderTemplate := map[string]any{
 			"databaseInstance": "openstack",
 			"secret":           "secret",
 			"databaseAccount":  "account",
 			"cinderVolumes":    volumeList,
 		}
 
-		spec["cinder"] = map[string]interface{}{
+		spec["cinder"] = map[string]any{
 			"enabled":        true,
 			"uniquePodNames": false,
 			"template":       cinderTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3346,26 +3346,26 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with to long cinderVolume keys/names (uniquePodNames)", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		volumeList := map[string]interface{}{
-			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]interface{}{},
+		volumeList := map[string]any{
+			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": map[string]any{},
 		}
-		cinderTemplate := map[string]interface{}{
+		cinderTemplate := map[string]any{
 			"databaseInstance": "openstack",
 			"secret":           "secret",
 			"databaseAccount":  "account",
 			"cinderVolumes":    volumeList,
 		}
 
-		spec["cinder"] = map[string]interface{}{
+		spec["cinder"] = map[string]any{
 			"enabled":        true,
 			"uniquePodNames": true,
 			"template":       cinderTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3388,26 +3388,26 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	It("Blocks creating ctlplane CRs with wrong cinderVolume keys/names", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
 
-		volumeList := map[string]interface{}{
-			"foo_bar": map[string]interface{}{},
+		volumeList := map[string]any{
+			"foo_bar": map[string]any{},
 		}
-		cinderTemplate := map[string]interface{}{
+		cinderTemplate := map[string]any{
 			"databaseInstance": "openstack",
 			"secret":           "secret",
 			"databaseAccount":  "account",
 			"cinderVolumes":    volumeList,
 		}
 
-		spec["cinder"] = map[string]interface{}{
+		spec["cinder"] = map[string]any{
 			"enabled":        true,
 			"uniquePodNames": true,
 			"template":       cinderTemplate,
 		}
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3428,14 +3428,14 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	})
 	It("Blocks creating ctlplane CRs with wrong topology namespace", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
-		spec["topologyRef"] = map[string]interface{}{
+		spec["topologyRef"] = map[string]any{
 			"name":      "foo",
 			"namespace": "bar",
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},
@@ -3455,13 +3455,13 @@ var _ = Describe("OpenStackOperator Webhook", func() {
 	})
 	It("Blocks creating ctlplane CRs with watcher enabled without telemetry services", func() {
 		spec := GetDefaultOpenStackControlPlaneSpec()
-		spec["watcher"] = map[string]interface{}{
+		spec["watcher"] = map[string]any{
 			"enabled": true,
 		}
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "core.openstack.org/v1beta1",
 			"kind":       "OpenStackControlPlane",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "foo",
 				"namespace": namespace,
 			},

--- a/tests/functional/ctlplane/openstackversion_controller_test.go
+++ b/tests/functional/ctlplane/openstackversion_controller_test.go
@@ -221,52 +221,52 @@ var _ = Describe("OpenStackOperator controller", func() {
 			spec := GetDefaultOpenStackControlPlaneSpec()
 
 			// a single galera database
-			galeraTemplate := map[string]interface{}{
-				names.DBName.Name: map[string]interface{}{
+			galeraTemplate := map[string]any{
+				names.DBName.Name: map[string]any{
 					"storageRequest": "500M",
 				},
 			}
-			spec["galera"] = map[string]interface{}{
+			spec["galera"] = map[string]any{
 				"enabled":   true,
 				"templates": galeraTemplate,
 			}
 
-			spec["horizon"] = map[string]interface{}{
+			spec["horizon"] = map[string]any{
 				"enabled": false,
 			}
 
-			spec["glance"] = map[string]interface{}{
+			spec["glance"] = map[string]any{
 				"enabled": false,
 			}
-			spec["cinder"] = map[string]interface{}{
+			spec["cinder"] = map[string]any{
 				"enabled": false,
 			}
-			spec["neutron"] = map[string]interface{}{
+			spec["neutron"] = map[string]any{
 				"enabled": false,
 			}
-			spec["manila"] = map[string]interface{}{
+			spec["manila"] = map[string]any{
 				"enabled": false,
 			}
-			spec["heat"] = map[string]interface{}{
+			spec["heat"] = map[string]any{
 				"enabled": false,
 			}
-			spec["telemetry"] = map[string]interface{}{
+			spec["telemetry"] = map[string]any{
 				"enabled": false,
 			}
 			spec["tls"] = GetTLSPublicSpec()
-			spec["ovn"] = map[string]interface{}{
+			spec["ovn"] = map[string]any{
 				"enabled": true,
-				"template": map[string]interface{}{
-					"ovnDBCluster": map[string]interface{}{
-						"ovndbcluster-nb": map[string]interface{}{
+				"template": map[string]any{
+					"ovnDBCluster": map[string]any{
+						"ovndbcluster-nb": map[string]any{
 							"dbType": "NB",
 						},
-						"ovndbcluster-sb": map[string]interface{}{
+						"ovndbcluster-sb": map[string]any{
 							"dbType": "SB",
 						},
 					},
-					"ovnController": map[string]interface{}{
-						"nicMappings": map[string]interface{}{
+					"ovnController": map[string]any{
+						"nicMappings": map[string]any{
 							"datacentre": "ospbr",
 						},
 					},
@@ -380,7 +380,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			Expect(th.K8sClient.Status().Update(th.Ctx, dataplanenodeset)).To(Succeed())
 
 			th.CreateSecret(types.NamespacedName{Name: "openstack-config-secret", Namespace: namespace}, map[string][]byte{"secure.yaml": []byte("foo")})
-			th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]interface{}{"clouds.yaml": string("foo"), "OS_CLOUD": "default"})
+			th.CreateConfigMap(types.NamespacedName{Name: "openstack-config", Namespace: namespace}, map[string]any{"clouds.yaml": string("foo"), "OS_CLOUD": "default"})
 
 			// verify that the controlplane deploys the old OVN controller image
 			OSCtlplane := GetOpenStackControlPlane(names.OpenStackControlplaneName)

--- a/tests/functional/dataplane/base_test.go
+++ b/tests/functional/dataplane/base_test.go
@@ -30,11 +30,11 @@ var DefaultEdpmServiceAnsibleVarList = []string{
 var CustomEdpmServiceDomainTag = "test-image:latest"
 var DefaultBackoffLimit = int32(6)
 
-func CreateICSP(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateICSP(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "operator.openshift.io/v1alpha1",
 		"kind":       "ImageContentSourcePolicy",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -44,18 +44,18 @@ func CreateICSP(name types.NamespacedName, spec map[string]interface{}) client.O
 }
 
 func CreateMachineConfig() client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "machineconfiguration.openshift.io/v1",
 		"kind":       "MachineConfig",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": "99-master-generated-registries",
 		},
-		"spec": map[string]interface{}{
-			"config": map[string]interface{}{
-				"storage": map[string]interface{}{
-					"files": []interface{}{
-						map[string]interface{}{
-							"contents": map[string]interface{}{
+		"spec": map[string]any{
+			"config": map[string]any{
+				"storage": map[string]any{
+					"files": []any{
+						map[string]any{
+							"contents": map[string]any{
 								"source":      "data:text/plain;charset=utf-8;base64,dW5xdWFsaWZpZWQtc2VhcmNoLXJlZ2lzdHJpZXMgPSBbInJlZ2lzdHJ5LmFjY2Vzcy5yZWRoYXQuY29tIiwgImRvY2tlci5pbyJdCnNob3J0LW5hbWUtbW9kZSA9ICIiCgpbW3JlZ2lzdHJ5XV0KICBwcmVmaXggPSAiIgogIGxvY2F0aW9uID0gInJlZ2lzdHJ5LmNpLm9wZW5zaGlmdC5vcmcvb3JpZ2luLzQuMTMtMjAyMy0wMi0yNi0xNjMwMzAiCgogIFtbcmVnaXN0cnkubWlycm9yXV0KICAgIGxvY2F0aW9uID0gInJlZ2lzdHJ5Lm9rZC5ibmUtc2hpZnQubmV0Ojg0NDMvb2tkIgogICAgcHVsbC1mcm9tLW1pcnJvciA9ICJkaWdlc3Qtb25seSIKCltbcmVnaXN0cnldXQogIHByZWZpeCA9ICIiCiAgbG9jYXRpb24gPSAicmVnaXN0cnkuY2kub3BlbnNoaWZ0Lm9yZy9vcmlnaW4vNC4xMy0yMDIzLTAzLTA3LTA5NDQwNiIKCiAgW1tyZWdpc3RyeS5taXJyb3JdXQogICAgbG9jYXRpb24gPSAicmVnaXN0cnkub2tkLmJuZS1zaGlmdC5uZXQ6ODQ0My9va2QiCiAgICBwdWxsLWZyb20tbWlycm9yID0gImRpZ2VzdC1vbmx5IgoKW1tyZWdpc3RyeV1dCiAgcHJlZml4ID0gIiIKICBsb2NhdGlvbiA9ICJyZWdpc3RyeS5jaS5vcGVuc2hpZnQub3JnL29yaWdpbi9yZWxlYXNlIgoKICBbW3JlZ2lzdHJ5Lm1pcnJvcl1dCiAgICBsb2NhdGlvbiA9ICJyZWdpc3RyeS5va2QuYm5lLXNoaWZ0Lm5ldDo4NDQzL29rZCIKICAgIHB1bGwtZnJvbS1taXJyb3IgPSAiZGlnZXN0LW9ubHkiCg==",
 								"compression": "",
 							},
@@ -73,20 +73,20 @@ func CreateMachineConfig() client.Object {
 }
 
 // Create OpenstackDataPlaneNodeSet in k8s and test that no errors occur
-func CreateDataplaneNodeSet(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
+func CreateDataplaneNodeSet(name types.NamespacedName, spec map[string]any) *unstructured.Unstructured {
 	instance := DefaultDataplaneNodeSetTemplate(name, spec)
 	return th.CreateUnstructured(instance)
 }
 
 // Create OpenStackDataPlaneDeployment in k8s and test that no errors occur
-func CreateDataplaneDeployment(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
+func CreateDataplaneDeployment(name types.NamespacedName, spec map[string]any) *unstructured.Unstructured {
 	instance := DefaultDataplaneDeploymentTemplate(name, spec)
 	return th.CreateUnstructured(instance)
 }
 
 // Create an OpenStackDataPlaneService with a given NamespacedName, assert on success
 func CreateDataplaneService(name types.NamespacedName, globalService bool) *unstructured.Unstructured {
-	var raw map[string]interface{}
+	var raw map[string]any
 	if globalService {
 		raw = DefaultDataplaneGlobalService(name)
 	} else {
@@ -96,23 +96,23 @@ func CreateDataplaneService(name types.NamespacedName, globalService bool) *unst
 }
 
 func CreateDataplaneServicesWithSameServiceType(name types.NamespacedName) {
-	CreateDataPlaneServiceFromSpec(name, map[string]interface{}{
+	CreateDataPlaneServiceFromSpec(name, map[string]any{
 		"edpmServiceType": "nova"})
 	CreateDataPlaneServiceFromSpec(types.NamespacedName{
-		Name: "duplicate-service", Namespace: name.Namespace}, map[string]interface{}{
+		Name: "duplicate-service", Namespace: name.Namespace}, map[string]any{
 		"edpmServiceType": "nova"})
 }
 
 // Create an OpenStackDataPlaneService with a given NamespacedName, and a given unstructured spec
-func CreateDataPlaneServiceFromSpec(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
+func CreateDataPlaneServiceFromSpec(name types.NamespacedName, spec map[string]any) *unstructured.Unstructured {
 	if spec["playbook"] == nil && spec["playbookContents"] == nil && spec["role"] == nil {
 		spec["playbook"] = "test"
 	}
-	raw := map[string]interface{}{
+	raw := map[string]any{
 
 		"apiVersion": "dataplane.openstack.org/v1beta1",
 		"kind":       "OpenStackDataPlaneService",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -122,22 +122,22 @@ func CreateDataPlaneServiceFromSpec(name types.NamespacedName, spec map[string]i
 }
 
 // Build CustomServiceImageSpec struct with empty `Nodes` list
-func CustomServiceImageSpec() map[string]interface{} {
+func CustomServiceImageSpec() map[string]any {
 
-	var ansibleServiceVars = make(map[string]interface{})
+	var ansibleServiceVars = make(map[string]any)
 	for _, svcName := range DefaultEdpmServiceAnsibleVarList {
 		imageAddress := fmt.Sprintf(`"%s.%s"`, svcName, CustomEdpmServiceDomainTag)
 		ansibleServiceVars[svcName] = imageAddress
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"preProvisioned": true,
-		"nodeTemplate": map[string]interface{}{
+		"nodeTemplate": map[string]any{
 			"networks": []infrav1.IPSetNetwork{
 				{Name: "ctlplane", SubnetName: "subnet1"},
 			},
 			"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-			"ansible": map[string]interface{}{
+			"ansible": map[string]any{
 				"ansibleVars": ansibleServiceVars,
 			},
 		},
@@ -145,12 +145,12 @@ func CustomServiceImageSpec() map[string]interface{} {
 	}
 }
 
-func CreateNetConfig(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
+func CreateNetConfig(name types.NamespacedName, spec map[string]any) *unstructured.Unstructured {
 	raw := DefaultNetConfig(name, spec)
 	return th.CreateUnstructured(raw)
 }
 
-func CreateDNSMasq(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
+func CreateDNSMasq(name types.NamespacedName, spec map[string]any) *unstructured.Unstructured {
 	raw := DefaultDNSMasq(name, spec)
 	return th.CreateUnstructured(raw)
 }
@@ -183,28 +183,28 @@ func CreateOpenStackVersion(name types.NamespacedName) *unstructured.Unstructure
 }
 
 // Struct initialization
-func DefaultOpenStackVersion(name types.NamespacedName) map[string]interface{} {
-	return map[string]interface{}{
+func DefaultOpenStackVersion(name types.NamespacedName) map[string]any {
+	return map[string]any{
 		"apiVersion": "core.openstack.org/v1beta1",
 		"kind":       "OpenStackVersion",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"targetVersion": "0.0.1",
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"availableVersion": "0.0.1",
 		},
 	}
 }
 
-func DefaultICSPSpec() map[string]interface{} {
-	return map[string]interface{}{
-		"repositoryDigestMirrors": []interface{}{
-			map[string]interface{}{
-				"mirrors": []interface{}{
+func DefaultICSPSpec() map[string]any {
+	return map[string]any{
+		"repositoryDigestMirrors": []any{
+			map[string]any{
+				"mirrors": []any{
 					"registry.okd.bne-shift.net:8443/okd", // Change to a string
 				},
 				"source": "registry.ci.openshift.org/origin/release", // Move "source" here
@@ -214,22 +214,22 @@ func DefaultICSPSpec() map[string]interface{} {
 }
 
 // Build OpenStackDataPlaneNodeSetSpec struct and fill it with preset values
-func DefaultDataPlaneNodeSetSpec(nodeSetName string) map[string]interface{} {
+func DefaultDataPlaneNodeSetSpec(nodeSetName string) map[string]any {
 
-	return map[string]interface{}{
+	return map[string]any{
 		"services": []string{
 			"foo-service",
 			"foo-update-service",
 			"global-service",
 		},
-		"nodeTemplate": map[string]interface{}{
+		"nodeTemplate": map[string]any{
 			"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-			"ansible": map[string]interface{}{
+			"ansible": map[string]any{
 				"ansibleUser": "cloud-user",
 			},
 		},
-		"nodes": map[string]interface{}{
-			fmt.Sprintf("%s-node-1", nodeSetName): map[string]interface{}{
+		"nodes": map[string]any{
+			fmt.Sprintf("%s-node-1", nodeSetName): map[string]any{
 				"hostName": "edpm-compute-node-1",
 				"networks": []infrav1.IPSetNetwork{
 					{Name: "networkinternal", SubnetName: "subnet1"},
@@ -237,9 +237,9 @@ func DefaultDataPlaneNodeSetSpec(nodeSetName string) map[string]interface{} {
 				},
 			},
 		},
-		"baremetalSetTemplate": map[string]interface{}{
-			"baremetalHosts": map[string]interface{}{
-				"ctlPlaneIP": map[string]interface{}{},
+		"baremetalSetTemplate": map[string]any{
+			"baremetalHosts": map[string]any{
+				"ctlPlaneIP": map[string]any{},
 			},
 			"deploymentSSHSecret": "dataplane-ansible-ssh-private-key-secret",
 			"ctlplaneInterface":   "172.20.12.1",
@@ -249,20 +249,20 @@ func DefaultDataPlaneNodeSetSpec(nodeSetName string) map[string]interface{} {
 	}
 }
 
-func DuplicateServiceNodeSetSpec(nodeSetName string) map[string]interface{} {
-	return map[string]interface{}{
+func DuplicateServiceNodeSetSpec(nodeSetName string) map[string]any {
+	return map[string]any{
 		"services": []string{
 			"foo-service",
 			"duplicate-service",
 		},
-		"nodeTemplate": map[string]interface{}{
+		"nodeTemplate": map[string]any{
 			"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-			"ansible": map[string]interface{}{
+			"ansible": map[string]any{
 				"ansibleUser": "cloud-user",
 			},
 		},
-		"nodes": map[string]interface{}{
-			fmt.Sprintf("%s-node-1", nodeSetName): map[string]interface{}{
+		"nodes": map[string]any{
+			fmt.Sprintf("%s-node-1", nodeSetName): map[string]any{
 				"hostName": "edpm-compute-node-1",
 				"networks": []infrav1.IPSetNetwork{
 					{Name: "networkinternal", SubnetName: "subnet1"},
@@ -277,17 +277,17 @@ func DuplicateServiceNodeSetSpec(nodeSetName string) map[string]interface{} {
 }
 
 // Build OpenStackDataPlaneNodeSetSpec struct with empty `Nodes` list
-func DefaultDataPlaneNoNodeSetSpec(tlsEnabled bool) map[string]interface{} {
-	spec := map[string]interface{}{
+func DefaultDataPlaneNoNodeSetSpec(tlsEnabled bool) map[string]any {
+	spec := map[string]any{
 		"preProvisioned": true,
-		"nodeTemplate": map[string]interface{}{
+		"nodeTemplate": map[string]any{
 			"networks": []infrav1.IPSetNetwork{
 				{Name: "networkinternal", SubnetName: "subnet1"},
 				{Name: "ctlplane", SubnetName: "subnet1"},
 			},
 			"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
 		},
-		"nodes": map[string]interface{}{},
+		"nodes": map[string]any{},
 	}
 	if tlsEnabled {
 		spec["tlsEnabled"] = true
@@ -297,9 +297,9 @@ func DefaultDataPlaneNoNodeSetSpec(tlsEnabled bool) map[string]interface{} {
 }
 
 // Build OpenStackDataPlnaeDeploymentSpec and fill it with preset values
-func DefaultDataPlaneDeploymentSpec() map[string]interface{} {
+func DefaultDataPlaneDeploymentSpec() map[string]any {
 
-	return map[string]interface{}{
+	return map[string]any{
 		"nodeSets": []string{
 			"edpm-compute-nodeset",
 		},
@@ -307,8 +307,8 @@ func DefaultDataPlaneDeploymentSpec() map[string]interface{} {
 	}
 }
 
-func MinorUpdateDataPlaneDeploymentSpec() map[string]interface{} {
-	return map[string]interface{}{
+func MinorUpdateDataPlaneDeploymentSpec() map[string]any {
+	return map[string]any{
 		"nodeSets": []string{
 			"edpm-compute-nodeset",
 		},
@@ -316,8 +316,8 @@ func MinorUpdateDataPlaneDeploymentSpec() map[string]interface{} {
 	}
 }
 
-func MinorUpdateServicesDataPlaneDeploymentSpec() map[string]interface{} {
-	return map[string]interface{}{
+func MinorUpdateServicesDataPlaneDeploymentSpec() map[string]any {
+	return map[string]any{
 		"nodeSets": []string{
 			"edpm-compute-nodeset",
 		},
@@ -326,8 +326,8 @@ func MinorUpdateServicesDataPlaneDeploymentSpec() map[string]interface{} {
 }
 
 // Build OpenStackDataPlnaeDeploymentSpec with duplicate services
-func DuplicateServiceDeploymentSpec() map[string]interface{} {
-	return map[string]interface{}{
+func DuplicateServiceDeploymentSpec() map[string]any {
+	return map[string]any{
 		"nodeSets": []string{
 			"edpm-compute-nodeset",
 		},
@@ -339,8 +339,8 @@ func DuplicateServiceDeploymentSpec() map[string]interface{} {
 }
 
 // Build OpenStackDataPlnaeDeploymentSpec with global service
-func GlobalServiceDeploymentSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GlobalServiceDeploymentSpec() map[string]any {
+	return map[string]any{
 		"nodeSets": []string{
 			"alpha-nodeset",
 			"beta-nodeset",
@@ -354,8 +354,8 @@ func GlobalServiceDeploymentSpec() map[string]interface{} {
 }
 
 // Build OpenStackDataPlnaeDeploymentSpec with single global service
-func SingleGlobalServiceDeploymentSpec() map[string]interface{} {
-	return map[string]interface{}{
+func SingleGlobalServiceDeploymentSpec() map[string]any {
+	return map[string]any{
 		"nodeSets": []string{
 			"alpha-nodeset",
 			"beta-nodeset",
@@ -366,15 +366,15 @@ func SingleGlobalServiceDeploymentSpec() map[string]interface{} {
 	}
 }
 
-func DefaultNetConfigSpec() map[string]interface{} {
-	return map[string]interface{}{
-		"networks": []map[string]interface{}{{
+func DefaultNetConfigSpec() map[string]any {
+	return map[string]any{
+		"networks": []map[string]any{{
 			"dnsDomain":  "test-domain.test",
 			"mtu":        1500,
 			"name":       "CtlPlane",
 			"serviceNet": "ctlplane",
-			"subnets": []map[string]interface{}{{
-				"allocationRanges": []map[string]interface{}{{
+			"subnets": []map[string]any{{
+				"allocationRanges": []map[string]any{{
 					"end":   "172.20.12.120",
 					"start": "172.20.12.0",
 				},
@@ -389,8 +389,8 @@ func DefaultNetConfigSpec() map[string]interface{} {
 			"mtu":        1500,
 			"name":       "networkinternal",
 			"serviceNet": "internalapi",
-			"subnets": []map[string]interface{}{{
-				"allocationRanges": []map[string]interface{}{{
+			"subnets": []map[string]any{{
+				"allocationRanges": []map[string]any{{
 					"end":   "172.20.13.120",
 					"start": "172.20.13.0",
 				},
@@ -405,8 +405,8 @@ func DefaultNetConfigSpec() map[string]interface{} {
 	}
 }
 
-func DefaultDNSMasqSpec() map[string]interface{} {
-	return map[string]interface{}{
+func DefaultDNSMasqSpec() map[string]any {
+	return map[string]any{
 		"replicas": 1,
 	}
 }
@@ -473,12 +473,12 @@ func SimulateIPSetComplete(name types.NamespacedName) {
 }
 
 // Build OpenStackDataPlaneNodeSet struct and fill it with preset values
-func DefaultDataplaneNodeSetTemplate(name types.NamespacedName, spec map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
+func DefaultDataplaneNodeSetTemplate(name types.NamespacedName, spec map[string]any) map[string]any {
+	return map[string]any{
 
 		"apiVersion": "dataplane.openstack.org/v1beta1",
 		"kind":       "OpenStackDataPlaneNodeSet",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -487,13 +487,13 @@ func DefaultDataplaneNodeSetTemplate(name types.NamespacedName, spec map[string]
 }
 
 // Build OpenStackDataPlaneDeployment struct and fill it with preset values
-func DefaultDataplaneDeploymentTemplate(name types.NamespacedName, spec map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
+func DefaultDataplaneDeploymentTemplate(name types.NamespacedName, spec map[string]any) map[string]any {
+	return map[string]any{
 
 		"apiVersion": "dataplane.openstack.org/v1beta1",
 		"kind":       "OpenStackDataPlaneDeployment",
 
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -501,11 +501,11 @@ func DefaultDataplaneDeploymentTemplate(name types.NamespacedName, spec map[stri
 	}
 }
 
-func DefaultNetConfig(name types.NamespacedName, spec map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
+func DefaultNetConfig(name types.NamespacedName, spec map[string]any) map[string]any {
+	return map[string]any{
 		"apiVersion": "network.openstack.org/v1beta1",
 		"kind":       "NetConfig",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -513,11 +513,11 @@ func DefaultNetConfig(name types.NamespacedName, spec map[string]interface{}) ma
 	}
 }
 
-func DefaultDNSMasq(name types.NamespacedName, spec map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
+func DefaultDNSMasq(name types.NamespacedName, spec map[string]any) map[string]any {
+	return map[string]any{
 		"apiVersion": "network.openstack.org/v1beta1",
 		"kind":       "DNSMasq",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -527,46 +527,46 @@ func DefaultDNSMasq(name types.NamespacedName, spec map[string]interface{}) map[
 
 // Create an empty OpenStackDataPlaneService struct
 // containing only given NamespacedName as metadata
-func DefaultDataplaneService(name types.NamespacedName) map[string]interface{} {
+func DefaultDataplaneService(name types.NamespacedName) map[string]any {
 
-	return map[string]interface{}{
+	return map[string]any{
 
 		"apiVersion": "dataplane.openstack.org/v1beta1",
 		"kind":       "OpenStackDataPlaneService",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"playbook": "test",
 		}}
 }
 
 // Create an empty OpenStackDataPlaneService struct
 // containing only given NamespacedName as metadata
-func DefaultDataplaneGlobalService(name types.NamespacedName) map[string]interface{} {
+func DefaultDataplaneGlobalService(name types.NamespacedName) map[string]any {
 
-	return map[string]interface{}{
+	return map[string]any{
 
 		"apiVersion": "dataplane.openstack.org/v1beta1",
 		"kind":       "OpenStackDataPlaneService",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"deployOnAllNodeSets": true,
 			"playbook":            "test",
 		},
 	}
 }
 
-func CreateOpenStackControlPlane(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateOpenStackControlPlane(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "core.openstack.org/v1beta1",
 		"kind":       "OpenStackControlPlane",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -575,79 +575,79 @@ func CreateOpenStackControlPlane(name types.NamespacedName, spec map[string]inte
 	return th.CreateUnstructured(raw)
 }
 
-func GetDefaultOpenStackControlPlaneSpec(tlsIngress bool, tlsPodlevel bool) map[string]interface{} {
-	memcachedTemplate := map[string]interface{}{
-		"memcached": map[string]interface{}{
+func GetDefaultOpenStackControlPlaneSpec(tlsIngress bool, tlsPodlevel bool) map[string]any {
+	memcachedTemplate := map[string]any{
+		"memcached": map[string]any{
 			"replicas": 1,
 		},
 	}
-	rabbitTemplate := map[string]interface{}{
-		"rabbitmq": map[string]interface{}{
+	rabbitTemplate := map[string]any{
+		"rabbitmq": map[string]any{
 			"replicas": 1,
 		},
-		"rabbitmq-cell1": map[string]interface{}{
+		"rabbitmq-cell1": map[string]any{
 			"replicas": 1,
 		},
 	}
-	galeraTemplate := map[string]interface{}{
-		"openstack": map[string]interface{}{
+	galeraTemplate := map[string]any{
+		"openstack": map[string]any{
 			"storageRequest": "500M",
 		},
-		"openstack-cell1": map[string]interface{}{
+		"openstack-cell1": map[string]any{
 			"storageRequest": "500M",
 		},
 	}
-	keystoneTemplate := map[string]interface{}{
+	keystoneTemplate := map[string]any{
 		"databaseInstance": "keystone",
 		"secret":           "osp-secret",
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"secret":       "osp-secret",
 		"storageClass": "local-storage",
-		"galera": map[string]interface{}{
+		"galera": map[string]any{
 			"enabled":   true,
 			"templates": galeraTemplate,
 		},
-		"rabbitmq": map[string]interface{}{
+		"rabbitmq": map[string]any{
 			"enabled":   true,
 			"templates": rabbitTemplate,
 		},
-		"memcached": map[string]interface{}{
+		"memcached": map[string]any{
 			"enabled":   true,
 			"templates": memcachedTemplate,
 		},
-		"keystone": map[string]interface{}{
+		"keystone": map[string]any{
 			"enabled":  true,
 			"template": keystoneTemplate,
 		},
-		"tls": map[string]interface{}{
-			"ingress": map[string]interface{}{
+		"tls": map[string]any{
+			"ingress": map[string]any{
 				"enabled": tlsIngress,
 
-				"ca": map[string]interface{}{
+				"ca": map[string]any{
 					"customIssuer": "custom-issuer",
 					"duration":     "100h",
 				},
-				"cert": map[string]interface{}{
+				"cert": map[string]any{
 					"duration": "10h",
 				},
 			},
-			"podLevel": map[string]interface{}{
+			"podLevel": map[string]any{
 				"enabled": tlsPodlevel,
-				"internal": map[string]interface{}{
-					"ca": map[string]interface{}{
+				"internal": map[string]any{
+					"ca": map[string]any{
 						"duration": "100h",
 					},
-					"cert": map[string]interface{}{
+					"cert": map[string]any{
 						"duration": "10h",
 					},
 				},
-				"ovn": map[string]interface{}{
-					"ca": map[string]interface{}{
+				"ovn": map[string]any{
+					"ca": map[string]any{
 						"duration": "100h",
 					},
-					"cert": map[string]interface{}{
+					"cert": map[string]any{
 						"duration": "10h",
 					},
 				},

--- a/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanedeployment_controller_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			// marked for deployment on all nodesets
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
 			// with EDPMServiceType set
-			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
+			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]any{
 				"edpmServiceType":               "foo-update-service",
 				"openStackAnsibleEERunnerImage": "foo-image:latest"})
 
@@ -182,7 +182,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -285,7 +285,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			// Three services on both nodesets
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
-			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
+			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]any{
 				"edpmServiceType":               "foo-update-service",
 				"openStackAnsibleEERunnerImage": "foo-image:latest"})
 
@@ -298,30 +298,30 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			// Create both nodesets
 
 			betaNodeName := fmt.Sprintf("%s-node-1", betaNodeSetName.Name)
-			betaNodeSetSpec := map[string]interface{}{
+			betaNodeSetSpec := map[string]any{
 				"preProvisioned": false,
 				"services": []string{
 					"foo-service",
 				},
-				"nodeTemplate": map[string]interface{}{
+				"nodeTemplate": map[string]any{
 					"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-					"ansible": map[string]interface{}{
+					"ansible": map[string]any{
 						"ansibleUser": "cloud-user",
 					},
 				},
-				"nodes": map[string]interface{}{
-					betaNodeName: map[string]interface{}{
+				"nodes": map[string]any{
+					betaNodeName: map[string]any{
 						"hostname": betaNodeName,
-						"networks": []map[string]interface{}{{
+						"networks": []map[string]any{{
 							"name":       "CtlPlane",
 							"subnetName": "subnet1",
 						},
 						},
 					},
 				},
-				"baremetalSetTemplate": map[string]interface{}{
-					"baremetalHosts": map[string]interface{}{
-						"ctlPlaneIP": map[string]interface{}{},
+				"baremetalSetTemplate": map[string]any{
+					"baremetalHosts": map[string]any{
+						"ctlPlaneIP": map[string]any{},
 					},
 					"deploymentSSHSecret": "dataplane-ansible-ssh-private-key-secret",
 					"ctlplaneInterface":   "172.20.12.1",
@@ -335,7 +335,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			SimulateIPSetComplete(types.NamespacedName{Name: betaNodeName, Namespace: namespace})
 			SimulateDNSDataComplete(betaNodeSetName)
 
-			deploymentSpec := map[string]interface{}{
+			deploymentSpec := map[string]any{
 				"nodeSets": []string{
 					"alpha-nodeset",
 					"beta-nodeset",
@@ -393,7 +393,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -545,7 +545,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			SimulateIPSetComplete(dataplaneNodeName)
 			SimulateDNSDataComplete(alphaNodeSetName)
 
-			deploymentSpec := map[string]interface{}{
+			deploymentSpec := map[string]any{
 				"nodeSets": []string{
 					"alpha-nodeset",
 					"beta-nodeset",
@@ -603,7 +603,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -694,7 +694,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -759,7 +759,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			// Three services on both nodesets
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
-			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
+			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]any{
 				"EDPMServiceType": "foo-update-service"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
@@ -772,32 +772,32 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			// Create both nodesets
 
 			betaNodeName := fmt.Sprintf("%s-node-1", betaNodeSetName.Name)
-			betaNodeSetSpec := map[string]interface{}{
+			betaNodeSetSpec := map[string]any{
 				"preProvisioned": false,
 				"services": []string{
 					"foo-service",
 					"global-service",
 					"foo-update-service",
 				},
-				"nodeTemplate": map[string]interface{}{
+				"nodeTemplate": map[string]any{
 					"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-					"ansible": map[string]interface{}{
+					"ansible": map[string]any{
 						"ansibleUser": "cloud-user",
 					},
 				},
-				"nodes": map[string]interface{}{
-					betaNodeName: map[string]interface{}{
+				"nodes": map[string]any{
+					betaNodeName: map[string]any{
 						"hostname": betaNodeName,
-						"networks": []map[string]interface{}{{
+						"networks": []map[string]any{{
 							"name":       "CtlPlane",
 							"subnetName": "subnet1",
 						},
 						},
 					},
 				},
-				"baremetalSetTemplate": map[string]interface{}{
-					"baremetalHosts": map[string]interface{}{
-						"ctlPlaneIP": map[string]interface{}{},
+				"baremetalSetTemplate": map[string]any{
+					"baremetalHosts": map[string]any{
+						"ctlPlaneIP": map[string]any{},
 					},
 					"deploymentSSHSecret": "dataplane-ansible-ssh-private-key-secret",
 					"ctlplaneInterface":   "172.20.12.1",
@@ -811,7 +811,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			SimulateIPSetComplete(types.NamespacedName{Name: betaNodeName, Namespace: namespace})
 			SimulateDNSDataComplete(betaNodeSetName)
 
-			deploymentSpec := map[string]interface{}{
+			deploymentSpec := map[string]any{
 				"nodeSets": []string{
 					"alpha-nodeset",
 					"beta-nodeset",
@@ -869,7 +869,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -1027,7 +1027,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -1092,7 +1092,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			// Three services on both nodesets
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
-			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
+			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]any{
 				"EDPMServiceType": "foo-update-service"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
@@ -1105,30 +1105,30 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			// Create both nodesets
 
 			betaNodeName := fmt.Sprintf("%s-node-1", betaNodeSetName.Name)
-			betaNodeSetSpec := map[string]interface{}{
+			betaNodeSetSpec := map[string]any{
 				"preProvisioned": false,
 				"services": []string{
 					"foo-service",
 				},
-				"nodeTemplate": map[string]interface{}{
+				"nodeTemplate": map[string]any{
 					"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-					"ansible": map[string]interface{}{
+					"ansible": map[string]any{
 						"ansibleUser": "cloud-user",
 					},
 				},
-				"nodes": map[string]interface{}{
-					betaNodeName: map[string]interface{}{
+				"nodes": map[string]any{
+					betaNodeName: map[string]any{
 						"hostname": betaNodeName,
-						"networks": []map[string]interface{}{{
+						"networks": []map[string]any{{
 							"name":       "CtlPlane",
 							"subnetName": "subnet1",
 						},
 						},
 					},
 				},
-				"baremetalSetTemplate": map[string]interface{}{
-					"baremetalHosts": map[string]interface{}{
-						"ctlPlaneIP": map[string]interface{}{},
+				"baremetalSetTemplate": map[string]any{
+					"baremetalHosts": map[string]any{
+						"ctlPlaneIP": map[string]any{},
 					},
 					"deploymentSSHSecret": "dataplane-ansible-ssh-private-key-secret",
 					"ctlplaneInterface":   "172.20.12.1",
@@ -1194,7 +1194,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -1300,7 +1300,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			// Three services on both nodesets
 			CreateDataplaneService(dataplaneServiceName, false)
 			CreateDataplaneService(dataplaneGlobalServiceName, true)
-			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]interface{}{
+			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, map[string]any{
 				"EDPMServiceType": "foo-update-service"})
 
 			DeferCleanup(th.DeleteService, dataplaneServiceName)
@@ -1313,30 +1313,30 @@ var _ = Describe("Dataplane Deployment Test", func() {
 			// Create both nodesets
 
 			betaNodeName := fmt.Sprintf("%s-node-1", betaNodeSetName.Name)
-			betaNodeSetSpec := map[string]interface{}{
+			betaNodeSetSpec := map[string]any{
 				"preProvisioned": false,
 				"services": []string{
 					"foo-service",
 				},
-				"nodeTemplate": map[string]interface{}{
+				"nodeTemplate": map[string]any{
 					"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-					"ansible": map[string]interface{}{
+					"ansible": map[string]any{
 						"ansibleUser": "cloud-user",
 					},
 				},
-				"nodes": map[string]interface{}{
-					betaNodeName: map[string]interface{}{
+				"nodes": map[string]any{
+					betaNodeName: map[string]any{
 						"hostname": betaNodeName,
-						"networks": []map[string]interface{}{{
+						"networks": []map[string]any{{
 							"name":       "CtlPlane",
 							"subnetName": "subnet1",
 						},
 						},
 					},
 				},
-				"baremetalSetTemplate": map[string]interface{}{
-					"baremetalHosts": map[string]interface{}{
-						"ctlPlaneIP": map[string]interface{}{},
+				"baremetalSetTemplate": map[string]any{
+					"baremetalHosts": map[string]any{
+						"ctlPlaneIP": map[string]any{},
 					},
 					"deploymentSSHSecret": "dataplane-ansible-ssh-private-key-secret",
 					"ctlplaneInterface":   "172.20.12.1",
@@ -1402,7 +1402,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -1550,7 +1550,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -1652,7 +1652,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)
@@ -1753,7 +1753,7 @@ var _ = Describe("Dataplane Deployment Test", func() {
 				Namespace: namespace,
 				Name:      "ovncontroller-config",
 			}
-			mapData := map[string]interface{}{
+			mapData := map[string]any{
 				"ovsdb-config": "test-ovn-config",
 			}
 			th.CreateConfigMap(ovnConfigMapName, mapData)

--- a/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_controller_test.go
@@ -42,13 +42,13 @@ type AnsibleInventory struct {
 		} `yaml:"vars"`
 		Hosts struct {
 			Node struct {
-				AnsibleHost       string        `yaml:"ansible_host"`
-				AnsiblePort       string        `yaml:"ansible_port"`
-				AnsibleUser       string        `yaml:"ansible_user"`
-				CtlPlaneIP        string        `yaml:"ctlplane_ip"`
-				DNSSearchDomains  []interface{} `yaml:"dns_search_domains"`
-				ManagementNetwork string        `yaml:"management_network"`
-				Networks          []interface{} `yaml:"networks"`
+				AnsibleHost       string `yaml:"ansible_host"`
+				AnsiblePort       string `yaml:"ansible_port"`
+				AnsibleUser       string `yaml:"ansible_user"`
+				CtlPlaneIP        string `yaml:"ctlplane_ip"`
+				DNSSearchDomains  []any  `yaml:"dns_search_domains"`
+				ManagementNetwork string `yaml:"management_network"`
+				Networks          []any  `yaml:"networks"`
 			} `yaml:"edpm-compute-node-1"`
 		} `yaml:"hosts"`
 	} `yaml:"edpm-compute-nodeset"`
@@ -480,7 +480,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		When("A Dataplane resorce is created without PreProvisioned nodes and ordered deployment", func() {
 			BeforeEach(func() {
 				spec := DefaultDataPlaneNoNodeSetSpec(tlsEnabled)
-				spec["metadata"] = map[string]interface{}{"ansiblesshprivatekeysecret": ""}
+				spec["metadata"] = map[string]any{"ansiblesshprivatekeysecret": ""}
 				spec["preProvisioned"] = false
 				DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
@@ -529,7 +529,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		When("A Dataplane resorce is created without PreProvisioned nodes but is marked as PreProvisioned, with ordered deployment", func() {
 			BeforeEach(func() {
 				spec := DefaultDataPlaneNoNodeSetSpec(tlsEnabled)
-				spec["metadata"] = map[string]interface{}{"ansiblesshprivatekeysecret": ""}
+				spec["metadata"] = map[string]any{"ansiblesshprivatekeysecret": ""}
 				DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, spec))
@@ -712,9 +712,9 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		When("The individual node has a AnsibleUser override", func() {
 			BeforeEach(func() {
 				DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
-				nodeOverrideSpec := map[string]interface{}{
+				nodeOverrideSpec := map[string]any{
 					"hostName": dataplaneNodeName.Name,
-					"networks": []map[string]interface{}{
+					"networks": []map[string]any{
 						{
 							"name":       "networkinternal",
 							"subnetName": "subnet1",
@@ -724,20 +724,20 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 							"subnetName": "subnet1",
 						},
 					},
-					"ansible": map[string]interface{}{
+					"ansible": map[string]any{
 						"ansibleUser": "test-user",
 					},
 				}
 
-				nodeTemplateOverrideSpec := map[string]interface{}{
+				nodeTemplateOverrideSpec := map[string]any{
 					"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-					"ansible": map[string]interface{}{
+					"ansible": map[string]any{
 						"ansibleUser": "cloud-user",
 					},
 				}
 
 				nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(tlsEnabled)
-				nodeSetSpec["nodes"] = map[string]interface{}{dataplaneNodeName.Name: nodeOverrideSpec}
+				nodeSetSpec["nodes"] = map[string]any{dataplaneNodeName.Name: nodeOverrideSpec}
 				nodeSetSpec["nodeTemplate"] = nodeTemplateOverrideSpec
 
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
@@ -897,7 +897,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		When("A Dataplane resorce is created without PreProvisioned nodes and ordered deployment", func() {
 			BeforeEach(func() {
 				spec := DefaultDataPlaneNoNodeSetSpec(tlsEnabled)
-				spec["metadata"] = map[string]interface{}{"ansiblesshprivatekeysecret": ""}
+				spec["metadata"] = map[string]any{"ansiblesshprivatekeysecret": ""}
 				spec["preProvisioned"] = false
 				DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
@@ -946,7 +946,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		When("A Dataplane resorce is created without PreProvisioned nodes but is marked as PreProvisioned, with ordered deployment", func() {
 			BeforeEach(func() {
 				spec := DefaultDataPlaneNoNodeSetSpec(tlsEnabled)
-				spec["metadata"] = map[string]interface{}{"ansiblesshprivatekeysecret": ""}
+				spec["metadata"] = map[string]any{"ansiblesshprivatekeysecret": ""}
 				DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, spec))
@@ -1130,9 +1130,9 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			BeforeEach(func() {
 				DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
 				DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
-				nodeOverrideSpec := map[string]interface{}{
+				nodeOverrideSpec := map[string]any{
 					"hostName": dataplaneNodeName.Name,
-					"networks": []map[string]interface{}{
+					"networks": []map[string]any{
 						{
 							"name":       "networkinternal",
 							"subnetName": "subnet1",
@@ -1142,20 +1142,20 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 							"subnetName": "subnet1",
 						},
 					},
-					"ansible": map[string]interface{}{
+					"ansible": map[string]any{
 						"ansibleUser": "test-user",
 					},
 				}
 
-				nodeTemplateOverrideSpec := map[string]interface{}{
+				nodeTemplateOverrideSpec := map[string]any{
 					"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-					"ansible": map[string]interface{}{
+					"ansible": map[string]any{
 						"ansibleUser": "cloud-user",
 					},
 				}
 
 				nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(tlsEnabled)
-				nodeSetSpec["nodes"] = map[string]interface{}{dataplaneNodeName.Name: nodeOverrideSpec}
+				nodeSetSpec["nodes"] = map[string]any{dataplaneNodeName.Name: nodeOverrideSpec}
 				nodeSetSpec["nodeTemplate"] = nodeTemplateOverrideSpec
 
 				DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
@@ -1267,7 +1267,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		BeforeEach(func() {
 
 			dataplanev1.SetupDefaults()
-			updateServiceSpec := map[string]interface{}{
+			updateServiceSpec := map[string]any{
 				"playbook": "osp.edpm.update",
 			}
 			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, updateServiceSpec)
@@ -1315,7 +1315,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		BeforeEach(func() {
 
 			dataplanev1.SetupDefaults()
-			updateServiceSpec := map[string]interface{}{
+			updateServiceSpec := map[string]any{
 				"playbook": "osp.edpm.update_services",
 			}
 			CreateDataPlaneServiceFromSpec(newDataplaneUpdateServiceName, updateServiceSpec)
@@ -1407,7 +1407,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			nodeSetSpec := DefaultDataPlaneNodeSetSpec("edpm-compute")
 			nodeSetSpec["preProvisioned"] = true
 			nodeSetSpec["services"] = []string{"bootstrap"}
-			nodeSetSpec["nodeTemplate"] = map[string]interface{}{
+			nodeSetSpec["nodeTemplate"] = map[string]any{
 				"extraMounts": []storage.VolMounts{
 					{
 						Mounts: []corev1.VolumeMount{
@@ -1427,7 +1427,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 					},
 				},
 				"ansibleSSHPrivateKeySecret": "dataplane-ansible-ssh-private-key-secret",
-				"ansible": map[string]interface{}{
+				"ansible": map[string]any{
 					"ansibleUser": "cloud-user",
 				},
 			}

--- a/tests/functional/dataplane/openstackdataplanenodeset_webhook_test.go
+++ b/tests/functional/dataplane/openstackdataplanenodeset_webhook_test.go
@@ -36,11 +36,11 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 		BeforeEach(func() {
 			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(false)
 			nodeSetSpec["preProvisioned"] = false
-			nodeSetSpec["nodes"] = map[string]interface{}{
-				"compute-0": map[string]interface{}{
+			nodeSetSpec["nodes"] = map[string]any{
+				"compute-0": map[string]any{
 					"hostName": "compute-0"},
 			}
-			nodeSetSpec["baremetalSetTemplate"] = map[string]interface{}{
+			nodeSetSpec["baremetalSetTemplate"] = map[string]any{
 				"bmhLabelSelector": map[string]string{
 					"app": "test-openstack",
 				},
@@ -64,13 +64,13 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 		BeforeEach(func() {
 			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(false)
 			nodeSetSpec["preProvisioned"] = false
-			nodeSetSpec["baremetalSetTemplate"] = map[string]interface{}{
+			nodeSetSpec["baremetalSetTemplate"] = map[string]any{
 				"cloudUserName": "test-user",
 				"bmhLabelSelector": map[string]string{
 					"app": "test-openstack",
 				},
-				"baremetalHosts": map[string]interface{}{
-					"compute-0": map[string]interface{}{
+				"baremetalHosts": map[string]any{
+					"compute-0": map[string]any{
 						"ctlPlaneIP": "192.168.1.12/24",
 					},
 				},
@@ -94,17 +94,17 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 		BeforeEach(func() {
 			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(false)
 			nodeSetSpec["preProvisioned"] = false
-			nodeSetSpec["nodes"] = map[string]interface{}{
-				"compute-0": map[string]interface{}{
+			nodeSetSpec["nodes"] = map[string]any{
+				"compute-0": map[string]any{
 					"hostName": "compute-0"},
 			}
-			nodeSetSpec["baremetalSetTemplate"] = map[string]interface{}{
+			nodeSetSpec["baremetalSetTemplate"] = map[string]any{
 				"domainName": "example.com",
 				"bmhLabelSelector": map[string]string{
 					"app": "test-openstack",
 				},
-				"baremetalHosts": map[string]interface{}{
-					"compute-0": map[string]interface{}{
+				"baremetalHosts": map[string]any{
+					"compute-0": map[string]any{
 						"ctlPlaneIP": "192.168.1.12/24",
 					},
 				},
@@ -124,8 +124,8 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 		BeforeEach(func() {
 			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(false)
 			nodeSetSpec["preProvisioned"] = true
-			nodeSetSpec["nodes"] = map[string]interface{}{
-				"compute-0": map[string]interface{}{
+			nodeSetSpec["nodes"] = map[string]any{
+				"compute-0": map[string]any{
 					"hostName": "compute-0"},
 			}
 			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, nodeSetSpec))
@@ -135,8 +135,8 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 			Eventually(func(_ Gomega) string {
 				newNodeSetSpec := DefaultDataPlaneNoNodeSetSpec(false)
 				newNodeSetSpec["preProvisioned"] = true
-				newNodeSetSpec["nodes"] = map[string]interface{}{
-					"compute-0": map[string]interface{}{
+				newNodeSetSpec["nodes"] = map[string]any{
+					"compute-0": map[string]any{
 						"hostName": "compute-0"},
 				}
 				newInstance := DefaultDataplaneNodeSetTemplate(types.NamespacedName{Name: "test-duplicate-node", Namespace: namespace}, newNodeSetSpec)
@@ -151,19 +151,19 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 			Eventually(func(_ Gomega) string {
 				newNodeSetSpec := DefaultDataPlaneNoNodeSetSpec(false)
 				newNodeSetSpec["preProvisioned"] = true
-				newNodeSetSpec["nodes"] = map[string]interface{}{
-					"compute-3": map[string]interface{}{
+				newNodeSetSpec["nodes"] = map[string]any{
+					"compute-3": map[string]any{
 						"hostName": "compute-3",
-						"ansible": map[string]interface{}{
+						"ansible": map[string]any{
 							"ansibleHost": "compute-3",
 						},
 					},
-					"compute-2": map[string]interface{}{
+					"compute-2": map[string]any{
 						"hostName": "compute-2"},
-					"compute-8": map[string]interface{}{
+					"compute-8": map[string]any{
 						"hostName": "compute-8"},
-					"compute-0": map[string]interface{}{
-						"ansible": map[string]interface{}{
+					"compute-0": map[string]any{
+						"ansible": map[string]any{
 							"ansibleHost": "compute-0",
 						},
 					},
@@ -180,8 +180,8 @@ var _ = Describe("DataplaneNodeSet Webhook", func() {
 		BeforeEach(func() {
 			nodeSetSpec := DefaultDataPlaneNoNodeSetSpec(false)
 			nodeSetSpec["preProvisioned"] = true
-			nodeSetSpec["nodes"] = map[string]interface{}{
-				"compute-0": map[string]interface{}{
+			nodeSetSpec["nodes"] = map[string]any{
+				"compute-0": map[string]any{
 					"hostName": "compute-0"},
 			}
 


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>