### PR TITLE
Prune certain services from three KUTTL tests

### DIFF
--- a/test/kuttl/common/toggle_services.sh
+++ b/test/kuttl/common/toggle_services.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -x
+
+OSCTLPLANE=${1:-}
+SERVICE_LIST=${2:-}
+SERVICE_ENABLED=${3:-true}
+
+if [ -z "$OSCTLPLANE" ]; then
+    echo "ERROR: OpenStackControlPlane name (arg 1) is required"
+    exit 1
+fi
+
+SERVICE_PATCH='['
+
+IFS=',' read -ra array <<< "$SERVICE_LIST"
+for i in "${!array[@]}"; do
+    if [ "$i" -gt 0 ]; then
+        SERVICE_PATCH+=','
+    fi
+    SERVICE_PATCH+='{"op":"replace","path":"/spec/'"${array[$i]}"'/enabled",'
+    SERVICE_PATCH+='"value":'"${SERVICE_ENABLED}"'}'
+done
+
+SERVICE_PATCH+=']'
+
+if [ "$SERVICE_PATCH" != '[]' ]; then
+    oc patch openstackcontrolplane "${OSCTLPLANE}" -n "${NAMESPACE}" --type=json -p="${SERVICE_PATCH}"
+fi

--- a/test/kuttl/tests/ctlplane-basic-deployment-with-nicMappings/02-assert-deploy-openstack.yaml
+++ b/test/kuttl/tests/ctlplane-basic-deployment-with-nicMappings/02-assert-deploy-openstack.yaml
@@ -1,1 +1,235 @@
-../../common/assert-sample-deployment.yaml
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  keystone:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  galera:
+    enabled: true
+    templates:
+      openstack:
+        storageRequest: 500M
+        secret: osp-secret
+        replicas: 1
+      openstack-cell1:
+        storageRequest: 500M
+        secret: osp-secret
+        replicas: 1
+  rabbitmq:
+    templates:
+      rabbitmq:
+        replicas: 1
+      rabbitmq-cell1:
+        replicas: 1
+  memcached:
+    templates:
+      memcached:
+        replicas: 1
+  placement:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  glance:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+      glanceAPIs:
+        default:
+          replicas: 1
+      storage:
+        storageRequest: 10G
+  manila:
+    template:
+      manilaAPI:
+        replicas: 1
+      manilaScheduler:
+        replicas: 1
+      manilaShares:
+        share1:
+          replicas: 1
+  ovn:
+    template:
+      ovnDBCluster:
+        ovndbcluster-nb:
+          replicas: 1
+          dbType: NB
+          storageRequest: 10G
+        ovndbcluster-sb:
+          replicas: 1
+          dbType: SB
+          storageRequest: 10G
+      ovnNorthd:
+        replicas: 1
+      ovnController:
+        external-ids:
+          system-id: "random"
+          ovn-bridge: "br-int"
+          ovn-encap-type: "geneve"
+  neutron:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  horizon:
+    template:
+      replicas: 1
+      secret: osp-secret
+  nova:
+    template:
+      secret: osp-secret
+  heat:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      heatAPI:
+        replicas: 1
+      heatEngine:
+        replicas: 1
+      secret: osp-secret
+  octavia:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      octaviaAPI:
+        replicas: 1
+      secret: osp-secret
+  ironic:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      ironicAPI:
+        replicas: 1
+      ironicConductors:
+      - replicas: 1
+        storageRequest: 10G
+      ironicInspector:
+        replicas: 1
+      ironicNeutronAgent:
+        replicas: 1
+      secret: osp-secret
+  designate:
+    enabled: false
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+      designateAPI:
+        replicas: 1
+      designateCentral:
+        replicas: 1
+      designateMdns:
+        replicas: 1
+      designateWorker:
+        replicas: 1
+      designateProducer:
+        replicas: 1
+      designateBackendbind9:
+        replicas: 1
+  tls:
+    ingress:
+      ca:
+        duration: 87600h0m0s
+      cert:
+        duration: 43800h0m0s
+      enabled: true
+    podLevel:
+      enabled: true
+      internal:
+        ca:
+          duration: 87600h0m0s
+        cert:
+          duration: 43800h0m0s
+      libvirt:
+        ca:
+          duration: 87600h0m0s
+        cert:
+          duration: 43800h0m0s
+      ovn:
+        ca:
+          duration: 87600h0m0s
+        cert:
+          duration: 43800h0m0s
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: OpenStackControlPlane CAs completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneCAReadyCondition
+  - message: OpenStackControlPlane Client completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneClientReady
+  - message: OpenStackControlPlane glance service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeGlanceReady
+  - message: OpenStackControlPlane keystone service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeKeystoneAPIReady
+  - message: OpenStackControlPlane neutron service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeNeutronReady
+  - message: OpenStackControlPlane nova service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposeNovaReady
+  - message: OpenStackControlPlane placement service exposed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneExposePlacementAPIReady
+  - message: OpenStackControlPlane Glance completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneGlanceReady
+  - message: OpenStackControlPlane InstanceHa CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane KeystoneAPI completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneKeystoneAPIReady
+  - message: OpenStackControlPlane MariaDB completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneMariaDBReady
+  - message: OpenStackControlPlane Memcached completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneMemcachedReady
+  - message: OpenStackControlPlane Neutron completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneNeutronReady
+  - message: OpenStackControlPlane Nova completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneNovaReady
+  - message: OpenStackControlPlane OVN completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneOVNReady
+  - message: OpenStackControlPlane OpenStackVersion initialized
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneOpenStackVersionInitializationReadyCondition
+  - message: OpenStackControlPlane PlacementAPI completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlanePlacementAPIReady
+  - message: OpenStackControlPlane RabbitMQ completed
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneRabbitMQReady
+  - message: OpenStackControlPlane Test Operator CM is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneTestCMReadyCondition

--- a/test/kuttl/tests/ctlplane-basic-deployment-with-nicMappings/02-deploy-openstack.yaml
+++ b/test/kuttl/tests/ctlplane-basic-deployment-with-nicMappings/02-deploy-openstack.yaml
@@ -3,3 +3,6 @@ kind: TestStep
 commands:
   - script: |
       oc kustomize ../../../../config/samples/base/openstackcontrolplane | oc apply -n $NAMESPACE -f -
+  - script: |
+      # Disable the services that are not needed for the test (these are also already covered in the ctlplane-basic-deployment test)
+      NAMESPACE=$NAMESPACE ../../common/toggle_services.sh openstack "barbican,cinder,swift,telemetry" false

--- a/test/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
+++ b/test/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
@@ -32,19 +32,6 @@ spec:
           replicas: 1
       storage:
         storageRequest: 10G
-  cinder:
-    template:
-      databaseInstance: openstack
-      secret: osp-secret
-      cinderAPI:
-        replicas: 1
-      cinderScheduler:
-        replicas: 1
-      cinderBackup:
-        replicas: 0 # backend needs to be configured
-      cinderVolumes:
-        volume1:
-          replicas: 0 # backend needs to be configured
   ovn:
     template:
       ovnDBCluster:
@@ -114,26 +101,6 @@ spec:
           ceilometerService: CeilometerPassword
         secret: osp-secret
         serviceUser: ceilometer
-  barbican:
-    enabled: true
-    template:
-      databaseInstance: openstack
-      secret: osp-secret
-      barbicanAPI:
-        replicas: 1
-      barbicanWorker:
-        replicas: 1
-      barbicanKeystoneListener:
-        replicas: 1
-  swift:
-    enabled: true
-    template:
-      swiftRing:
-        ringReplicas: 1
-      swiftStorage:
-        replicas: 1
-      swiftProxy:
-        replicas: 1
   tls:
     ingress:
       ca:
@@ -175,30 +142,14 @@ status:
     reason: Ready
     status: "True"
     type: Ready
-  - message: OpenStackControlPlane Barbican completed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneBarbicanReady
   - message: OpenStackControlPlane CAs completed
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneCAReadyCondition
-  - message: OpenStackControlPlane Cinder completed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneCinderReady
   - message: OpenStackControlPlane Client completed
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneClientReady
-  - message: OpenStackControlPlane barbican service exposed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneExposeBarbicanReady
-  - message: OpenStackControlPlane cinder service exposed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneExposeCinderReady
   - message: OpenStackControlPlane glance service exposed
     reason: Ready
     status: "True"
@@ -219,10 +170,6 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneExposePlacementAPIReady
-  - message: OpenStackControlPlane swift service exposed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneExposeSwiftReady
   - message: OpenStackControlPlane watcher service exposed
     reason: Ready
     status: "True"
@@ -271,10 +218,6 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneRabbitMQReady
-  - message: OpenStackControlPlane Swift completed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneSwiftReady
   - message: OpenStackControlPlane Telemetry completed
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/ctlplane-collapsed/01-deploy-openstack-collapsed-cell.yaml
+++ b/test/kuttl/tests/ctlplane-collapsed/01-deploy-openstack-collapsed-cell.yaml
@@ -3,3 +3,6 @@ kind: TestStep
 commands:
   - script: |
       oc apply -n $NAMESPACE -f ../../../../config/samples/core_v1beta1_openstackcontrolplane_collapsed_cell.yaml
+  - script: |
+      # Disable the services that are not needed for the test (these are also already covered in the ctlplane-basic-deployment test)
+      NAMESPACE=$NAMESPACE ../../common/toggle_services.sh openstack-collapsed-cell "barbican,cinder,swift" false

--- a/test/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
+++ b/test/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
@@ -41,30 +41,6 @@ spec:
           replicas: 1
       storage:
         storageRequest: 10G
-  cinder:
-    template:
-      databaseInstance: openstack
-      secret: osp-secret
-      cinderAPI:
-        replicas: 1
-      cinderScheduler:
-        replicas: 1
-      cinderBackup:
-        replicas: 0 # backend needs to be configured
-      cinderVolumes:
-        volume1:
-          replicas: 0 # backend needs to be configured
-  barbican:
-    enabled: true
-    template:
-      databaseInstance: openstack
-      secret: osp-secret
-      barbicanAPI:
-        replicas: 1
-      barbicanWorker:
-        replicas: 1
-      barbicanKeystoneListener:
-        replicas: 1
   manila:
     template:
       manilaAPI:
@@ -116,18 +92,23 @@ spec:
       ironicNeutronAgent:
         replicas: 1
       secret: osp-secret
-  telemetry:
-    enabled: true
+  designate:
+    enabled: false
     template:
-      autoscaling:
-        aodh:
-          secret: osp-secret
-          serviceUser: aodh
-      ceilometer:
-        passwordSelector:
-          ceilometerService: CeilometerPassword
-        secret: osp-secret
-        serviceUser: ceilometer
+      databaseInstance: openstack
+      secret: osp-secret
+      designateAPI:
+        replicas: 1
+      designateCentral:
+        replicas: 1
+      designateMdns:
+        replicas: 1
+      designateWorker:
+        replicas: 1
+      designateProducer:
+        replicas: 1
+      designateBackendbind9:
+        replicas: 1
   tls:
     ingress:
       ca:
@@ -152,45 +133,20 @@ spec:
           duration: 87600h0m0s
         cert:
           duration: 43800h0m0s
-  swift:
-    enabled: true
-    template:
-      swiftRing:
-        ringReplicas: 1
-      swiftStorage:
-        replicas: 1
-      swiftProxy:
-        replicas: 1
 status:
   conditions:
   - message: Setup complete
     reason: Ready
     status: "True"
     type: Ready
-  - message: OpenStackControlPlane Barbican completed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneBarbicanReady
   - message: OpenStackControlPlane CAs completed
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneCAReadyCondition
-  - message: OpenStackControlPlane Cinder completed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneCinderReady
   - message: OpenStackControlPlane Client completed
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneClientReady
-  - message: OpenStackControlPlane barbican service exposed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneExposeBarbicanReady
-  - message: OpenStackControlPlane cinder service exposed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneExposeCinderReady
   - message: OpenStackControlPlane glance service exposed
     reason: Ready
     status: "True"
@@ -211,10 +167,6 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneExposePlacementAPIReady
-  - message: OpenStackControlPlane swift service exposed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneExposeSwiftReady
   - message: OpenStackControlPlane Glance completed
     reason: Ready
     status: "True"
@@ -259,14 +211,6 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneRabbitMQReady
-  - message: OpenStackControlPlane Swift completed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneSwiftReady
-  - message: OpenStackControlPlane Telemetry completed
-    reason: Ready
-    status: "True"
-    type: OpenStackControlPlaneTelemetryReady
   - message: OpenStackControlPlane Test Operator CM is available
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/ctlplane-galera-3replicas/01-deploy-galera-3replicas.yaml
+++ b/test/kuttl/tests/ctlplane-galera-3replicas/01-deploy-galera-3replicas.yaml
@@ -3,3 +3,6 @@ kind: TestStep
 commands:
   - script: |
       oc apply -n $NAMESPACE -f ../../../../config/samples/core_v1beta1_openstackcontrolplane_galera_3replicas.yaml
+  - script: |
+      # Disable the services that are not needed for the test (these are also already covered in the ctlplane-basic-deployment test)
+      NAMESPACE=$NAMESPACE ../../common/toggle_services.sh openstack-galera-3replicas "barbican,cinder,swift,telemetry" false


### PR DESCRIPTION
First pass at trying to prune some potentially unneeded services from the `OpenStackControlPlane` during KUTTL tests.  The approach taken here showed a 10-15% performance boost.