### PR TITLE
Fix stale SecretHashes on nodeset status after node removal

### DIFF
--- a/internal/controller/dataplane/openstackdataplanenodeset_controller.go
+++ b/internal/controller/dataplane/openstackdataplanenodeset_controller.go
@@ -592,6 +592,9 @@ func checkDeployment(ctx context.Context, helper *helper.Helper,
 			for k, v := range deployment.Status.ConfigMapHashes {
 				instance.Status.ConfigMapHashes[k] = v
 			}
+			if len(deployment.Spec.ServicesOverride) == 0 {
+				instance.Status.SecretHashes = make(map[string]string, len(deployment.Status.SecretHashes))
+			}
 			for k, v := range deployment.Status.SecretHashes {
 				instance.Status.SecretHashes[k] = v
 			}


### PR DESCRIPTION
When a node is removed from a nodeset and a full deployment (no ServicesOverride) succeeds, overwrite the nodeset's SecretHashes with the deployment's hashes instead of merging. This drops stale TLS cert secret hash entries for the removed node. Partial deployments (with ServicesOverride) continue to merge additively to preserve hashes from other deployments.

jira: [OSPRH-27533](https://issues.redhat.com/browse/OSPRH-27533)
