### PR TITLE
Add OLM upgrade support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 	BUNDLE_GEN_FLAGS += --use-image-digests
 endif
 
+# REPLACES is the previous version that this version replaces (for OLM upgrades)
+# Example: make bundle REPLACES=openstack-operator.v0.6.0 VERSION=0.6.1
+REPLACES ?=
+
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.41.1
@@ -397,10 +401,16 @@ endif
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
-	cd config/operator/deployment/ && $(KUSTOMIZE) edit set image controller=$(IMG) && \
+	cd config/operator/deployment/ && \
+	sed -i '/^patches:/,$$d' kustomization.yaml && \
+	$(KUSTOMIZE) edit set image controller=$(IMG) && \
 	$(KUSTOMIZE) edit add patch --kind Deployment --name openstack-operator-controller-init --namespace system --patch "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/0\", \"value\": {\"name\": \"OPENSTACK_RELEASE_VERSION\", \"value\": \"$(OPENSTACK_RELEASE_VERSION)\"}}]" && \
 	$(KUSTOMIZE) edit add patch --kind Deployment --name openstack-operator-controller-init --namespace system --patch "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/1\", \"value\": {\"name\": \"OPERATOR_IMAGE_URL\", \"value\": \"$(IMG)\"}}]"
 	$(KUSTOMIZE) build config/operator --load-restrictor='LoadRestrictionsNone' | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+ifneq ($(REPLACES),)
+	@echo "Adding replaces: $(REPLACES) to CSV"
+	sed -i "/^  name: openstack-operator.v$(VERSION)/a\  replaces: $(REPLACES)" bundle/manifests/openstack-operator.clusterserviceversion.yaml
+endif
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
@@ -445,14 +455,34 @@ MAKE_ENV := $(shell echo '$(.VARIABLES)' | awk -v RS=' ' '/^(IMAGE)|.*?(REGISTRY
 SHELL_EXPORT = $(foreach v,$(MAKE_ENV),$(v)='$($(v))')
 
 # These images MUST exist in a registry and be pull-able.
+# Sub-operator bundles are included for from-scratch catalog builds but are not functionally
+# required — sub-operators are deployed by operator-controller-init, not OLM.
 BUNDLE_IMGS = "$(BUNDLE_IMG)$(shell $(SHELL_EXPORT) /bin/bash hack/pin-bundle-images.sh || echo bundle-fail-tag)"
+
+# When REPLACES is set, include the previous version's bundle in the catalog for upgrade support
+# PREV_BUNDLE_IMG can be set to override the default (defaults to upstream :latest)
+# Example: make catalog-build REPLACES=openstack-operator.v0.6.0 PREV_BUNDLE_IMG=quay.io/openstack-k8s-operators/openstack-operator-bundle:latest
+ifneq ($(REPLACES),)
+PREV_BUNDLE_IMG ?= quay.io/openstack-k8s-operators/openstack-operator-bundle:latest
+endif
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-index:v$(VERSION)
 
-# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
+# Set CATALOG_BASE_IMG to an existing catalog image tag to add the new bundle to it.
+# Only adds the openstack-operator bundle — sub-operator bundles from the base catalog
+# are preserved but not functionally used (sub-operators are deployed by operator-controller-init).
 ifneq ($(origin CATALOG_BASE_IMG), undefined)
 FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
+CATALOG_BUNDLE_IMGS ?= $(BUNDLE_IMG)
+else
+# Building from scratch: include previous bundle if REPLACES is set, plus all dependency bundles
+# Can be overridden by setting CATALOG_BUNDLE_IMGS on command line
+ifneq ($(REPLACES),)
+CATALOG_BUNDLE_IMGS ?= $(PREV_BUNDLE_IMG),$(BUNDLE_IMGS)
+else
+CATALOG_BUNDLE_IMGS ?= $(BUNDLE_IMGS)
+endif
 endif
 
 # Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
@@ -461,7 +491,7 @@ endif
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
 	# FIXME: hardcoded bundle below should use go.mod pinned version for manila bundle
-	$(OPM) index add --container-tool podman --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool podman --mode semver --tag $(CATALOG_IMG) --bundles $(CATALOG_BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/hack/pin-bundle-images.sh
+++ b/hack/pin-bundle-images.sh
@@ -43,62 +43,33 @@ for MOD_PATH in ${MOD_PATHS}; do
     CURL_REGISTRY="quay.io"
     REPO_CURL_URL="https://${CURL_REGISTRY}/api/v1/repository/openstack-k8s-operators"
     REPO_URL="${CURL_REGISTRY}/openstack-k8s-operators"
-
-    # IMAGEBASE takes precedence - if this operator matches IMAGEBASE, use custom registry
-    if [[ "$BASE" == "$IMAGEBASE" ]]; then
-        REPO_URL="${IMAGEREGISTRY}/${IMAGENAMESPACE}"
-        CURL_REGISTRY="${IMAGEREGISTRY}"
-        if [[ ${LOCAL_REGISTRY} -eq 1 ]]; then
-            REPO_CURL_URL="http://${CURL_REGISTRY}/v2/${IMAGENAMESPACE}"
-        elif [[ "${CURL_REGISTRY}" == "docker.io" ]]; then
-            REPO_CURL_URL="https://hub.docker.com/v2/repositories/${IMAGENAMESPACE}"
+    if [[ "$GITHUB_USER" != "openstack-k8s-operators" || "$BASE" == "$IMAGEBASE" ]]; then
+        if [[ "$IMAGENAMESPACE" != "openstack-k8s-operators" || "${IMAGEREGISTRY}" != "quay.io" ]]; then
+            REPO_URL="${IMAGEREGISTRY}/${IMAGENAMESPACE}"
+            CURL_REGISTRY="${IMAGEREGISTRY}"
+            # Quay registry v2 api does not return all the tags that's why keeping v1 for quay and v2
+            # for local registry
+            if [[ ${LOCAL_REGISTRY} -eq 1 ]]; then
+                REPO_CURL_URL="http://${CURL_REGISTRY}/v2/${IMAGENAMESPACE}"
+            elif [[ "${CURL_REGISTRY}" == "docker.io" ]]; then
+                # replace docker.io by hub.docker.com to read tags
+                REPO_CURL_URL="https://hub.docker.com/v2/repositories/${IMAGENAMESPACE}"
+            else
+                REPO_CURL_URL="https://${CURL_REGISTRY}/api/v1/repository/${IMAGENAMESPACE}"
+            fi
         else
-            REPO_CURL_URL="https://${CURL_REGISTRY}/api/v1/repository/${IMAGENAMESPACE}"
-        fi
-    # For operators with replace directives (non-openstack-k8s-operators users),
-    # bundle images are only on quay.io, not mirrored to local registry
-    elif [[ "$GITHUB_USER" != "openstack-k8s-operators" ]]; then
-        # Force quay.io for replaced operators, use the GitHub user's namespace
-        CURL_REGISTRY="quay.io"
-        REPO_CURL_URL="https://${CURL_REGISTRY}/api/v1/repository/${GITHUB_USER}"
-        REPO_URL="${CURL_REGISTRY}/${GITHUB_USER}"
-    # For standard operators with custom registry settings
-    elif [[ "$IMAGENAMESPACE" != "openstack-k8s-operators" || "${IMAGEREGISTRY}" != "quay.io" ]]; then
-        REPO_URL="${IMAGEREGISTRY}/${IMAGENAMESPACE}"
-        CURL_REGISTRY="${IMAGEREGISTRY}"
-        # Quay registry v2 api does not return all the tags that's why keeping v1 for quay and v2
-        # for local registry
-        if [[ ${LOCAL_REGISTRY} -eq 1 ]]; then
-            REPO_CURL_URL="http://${CURL_REGISTRY}/v2/${IMAGENAMESPACE}"
-        elif [[ "${CURL_REGISTRY}" == "docker.io" ]]; then
-            # replace docker.io by hub.docker.com to read tags
-            REPO_CURL_URL="https://hub.docker.com/v2/repositories/${IMAGENAMESPACE}"
-        else
-            REPO_CURL_URL="https://${CURL_REGISTRY}/api/v1/repository/${IMAGENAMESPACE}"
+            REPO_CURL_URL="https://${CURL_REGISTRY}/api/v1/repository/${GITHUB_USER}"
+            REPO_URL="${CURL_REGISTRY}/${GITHUB_USER}"
         fi
     fi
 
-    # Query local registry only for standard operators (openstack-k8s-operators) or custom IMAGEBASE
-    # Replaced operators (e.g., lmiccini/*) always query quay.io since bundles aren't mirrored locally
-    if [[ ${LOCAL_REGISTRY} -eq 1 && ( "$GITHUB_USER" == "openstack-k8s-operators" || "$BASE" == "$IMAGEBASE" ) ]]; then
+    if [[ ${LOCAL_REGISTRY} -eq 1 && ( "$GITHUB_USER" != "openstack-k8s-operators" || "$BASE" == "$IMAGEBASE" ) ]]; then
         SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tags/list | jq -r '.tags // [] | .[]' | sort -u | { grep $REF || true; })
-        # If local registry doesn't have the bundle, fall back to quay.io
-        if [ -z "$SHA" ]; then
-            SHA=$(curl -s https://quay.io/api/v1/repository/openstack-k8s-operators/$BASE-operator-bundle/tag/?onlyActiveTags=true\&filter_tag_name=like:$REF | jq -r '.tags // [] | .[].name')
-            # Update REPO_URL to use quay.io since we're falling back
-            REPO_URL="quay.io/openstack-k8s-operators"
-        fi
     elif [[ "${CURL_REGISTRY}" == "docker.io" ]]; then
         SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tags/?page_size=100 | jq -r '.results // [] | .[].name' | sort -u | { grep $REF || true; })
     elif [[ "${CURL_REGISTRY}" != "quay.io" ]]; then
         # quay.rdoproject.io doesn't support filter_tag_name, so increase limit to 100
         SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/?onlyActiveTags=true\&limit=100 | jq -r '.tags // [] | .[].name' | sort -u | { grep $REF || true; })
-        # If non-quay.io registry doesn't have the bundle for openstack-k8s-operators, fall back to quay.io
-        if [[ -z "$SHA" && "$GITHUB_USER" == "openstack-k8s-operators" ]]; then
-            SHA=$(curl -s https://quay.io/api/v1/repository/openstack-k8s-operators/$BASE-operator-bundle/tag/?onlyActiveTags=true\&filter_tag_name=like:$REF | jq -r '.tags // [] | .[].name')
-            # Update REPO_URL to use quay.io since we're falling back
-            REPO_URL="quay.io/openstack-k8s-operators"
-        fi
     else
         SHA=$(curl -s ${REPO_CURL_URL}/$BASE-operator-bundle/tag/?onlyActiveTags=true\&filter_tag_name=like:$REF | jq -r '.tags // [] | .[].name')
     fi


### PR DESCRIPTION
Add REPLACES variable to inject `replaces` field into the CSV for OLM upgrade paths. Add PREV_BUNDLE_IMG and CATALOG_BUNDLE_IMGS variables to support incremental and from-scratch catalog builds with full upgrade chains. Fix kustomization.yaml patch accumulation by clearing old patches before regenerating.