### PR TITLE
[imagePullPolicy] Switch imagePullPolicy from Always to IfNotPresent

### DIFF
--- a/internal/dataplane/util/ansibleee.go
+++ b/internal/dataplane/util/ansibleee.go
@@ -102,7 +102,7 @@ func (a *EEJob) JobForOpenStackAnsibleEE(h *helper.Helper) (*batchv1.Job, error)
 	podSpec := corev1.PodSpec{
 		RestartPolicy: corev1.RestartPolicyNever,
 		Containers: []corev1.Container{{
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			Image:           a.Image,
 			Name:            a.Name,
 			Args:            args,

--- a/test/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -135,7 +135,7 @@ spec:
             edpm_service_type: custom-global-service
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: custom-global-service-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -237,7 +237,7 @@ spec:
             edpm_service_type: download-cache
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: download-cache-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -335,7 +335,7 @@ spec:
             edpm_service_type: bootstrap
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: bootstrap-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -439,7 +439,7 @@ spec:
             edpm_service_type: configure-network
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: configure-network-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -537,7 +537,7 @@ spec:
             edpm_service_type: validate-network
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: validate-network-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -635,7 +635,7 @@ spec:
             edpm_service_type: configure-os
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: configure-os-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -733,7 +733,7 @@ spec:
             edpm_service_type: install-certs
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: install-certs-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -880,7 +880,7 @@ spec:
             edpm_service_type: ovn
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: ovn-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -989,7 +989,7 @@ spec:
             edpm_service_type: neutron-metadata
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: neutron-metadata-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1128,7 +1128,7 @@ spec:
             edpm_service_type: neutron-ovn
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: neutron-ovn-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1267,7 +1267,7 @@ spec:
             edpm_service_type: neutron-sriov
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: neutron-sriov-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1376,7 +1376,7 @@ spec:
             edpm_service_type: neutron-dhcp
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: neutron-dhcp-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1485,7 +1485,7 @@ spec:
             edpm_service_type: libvirt
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: libvirt-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1594,7 +1594,7 @@ spec:
             edpm_service_type: nova
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: nova-edpm-compute-global-edpm-compute-global
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
@@ -130,7 +130,7 @@ spec:
             edpm_service_type: download-cache
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: download-cache-edpm-multinodeset-edpm-compute-beta-nodeset
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -227,7 +227,7 @@ spec:
             edpm_service_type: bootstrap
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: bootstrap-edpm-multinodeset-edpm-compute-beta-nodeset
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-multiple-secrets/02-assert.yaml
@@ -167,7 +167,7 @@ spec:
             edpm_service_type: install-certs-ovr
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: install-certs-ovr-openstack-edpm-tls-openstack-edpm-tls
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -292,7 +292,7 @@ spec:
             edpm_service_type: generic-service1
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: generic-service1-openstack-edpm-tls-openstack-edpm-tls
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -126,7 +126,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: download-cache-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -225,7 +225,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: bootstrap-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -331,7 +331,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: configure-network-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -431,7 +431,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: validate-network-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -531,7 +531,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: configure-os-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -631,7 +631,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: install-certs-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -773,7 +773,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: ovn-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -883,7 +883,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: neutron-metadata-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1023,7 +1023,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: neutron-ovn-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1163,7 +1163,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: neutron-sriov-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1273,7 +1273,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: neutron-dhcp-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1383,7 +1383,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: libvirt-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -1493,7 +1493,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: nova-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
@@ -68,7 +68,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: configure-os-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -128,7 +128,7 @@ spec:
                 - ovn
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: ovn-edpm-compute-no-nodes-updated-ovn-cm-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
@@ -129,7 +129,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: bootstrap-edpm-multinodeset-edpm-compute-beta-nodeset
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -236,7 +236,7 @@ spec:
             foo: bar
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: download-cache-edpm-multinodeset-edpm-compute-beta-nodeset
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/07-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/07-assert.yaml
@@ -62,7 +62,7 @@ spec:
                 - configure-os
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: configure-os-edpm-compute-node-selection-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -200,7 +200,7 @@ spec:
             edpm_service_type: install-certs-ovrd
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: install-certs-ovrd-openstack-edpm-tls-openstack-edpm-tls
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -334,7 +334,7 @@ spec:
             edpm_service_type: tls-dnsnames
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: tls-dnsnames-openstack-edpm-tls-openstack-edpm-tls
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -210,7 +210,7 @@ spec:
                 - custom-tls-dns
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: tls-dns-ips-openstack-edpm-tls-ovrd-openstack-edpm-tls
         resources: {}
         terminationMessagePath: /dev/termination-log
@@ -324,7 +324,7 @@ spec:
                 - custom-tls-dns
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: custom-tls-dns-openstack-edpm-tls-ovrd-openstack-edpm-tls
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-extramounts/00-assert.yaml
+++ b/test/kuttl/tests/dataplane-extramounts/00-assert.yaml
@@ -85,7 +85,7 @@ spec:
             edpm_service_type: test-service
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: test-service-edpm-extramounts-edpm-extramounts
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-service-config/00-assert.yaml
+++ b/test/kuttl/tests/dataplane-service-config/00-assert.yaml
@@ -74,7 +74,7 @@ spec:
             edpm_service_type: kuttl-service
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: kuttl-service-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/test/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -113,7 +113,7 @@ spec:
 
 
         image: example.com/repo/runner-image:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: custom-img-svc-edpm-compute-no-nodes-edpm-no-nodes-custom-svc
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/kuttl/tests/dataplane-service-failure/00-assert.yaml
+++ b/test/kuttl/tests/dataplane-service-failure/00-assert.yaml
@@ -74,7 +74,7 @@ spec:
             edpm_service_type: failed-service
 
 
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: failed-service-edpm-compute-no-nodes-edpm-compute-no-nodes
         resources: {}
         terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
Use `PullIfNotPresent` instead of `PullAlways` for container image pull policy to avoid unnecessary image pulls when the image already exists locally. Updates source code and kuttl test assertions.

Jira: https://redhat.atlassian.net/browse/OSPRH-28872