### PR TITLE
Pin RabbitMQ image to 3.9 on 18.0-fr5

### DIFF
--- a/config/operator/default_images.yaml
+++ b/config/operator/default_images.yaml
@@ -174,7 +174,7 @@ spec:
         - name: RELATED_IMAGE_PLACEMENT_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-placement-api:current-podified
         - name: RELATED_IMAGE_RABBITMQ_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-rabbitmq:current-podified
+          value: quay.io/openstack-k8s-operators/rabbitmq:3.9
         - name: RELATED_IMAGE_SWIFT_ACCOUNT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-swift-account:current-podified
         - name: RELATED_IMAGE_SWIFT_CONTAINER_IMAGE_URL_DEFAULT

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -2,7 +2,7 @@
 
 export OPENSTACK_RELEASE_VERSION=0.0.1-$(date +%s)
 export RELATED_IMAGE_OPENSTACK_CLIENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
-export RELATED_IMAGE_RABBITMQ_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-rabbitmq:current-podified
+export RELATED_IMAGE_RABBITMQ_IMAGE_URL_DEFAULT=quay.io/openstack-k8s-operators/rabbitmq:3.9
 export RELATED_IMAGE_KEYSTONE_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-keystone:current-podified
 export RELATED_IMAGE_MARIADB_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 export RELATED_IMAGE_INFRA_MEMCACHED_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-memcached:current-podified


### PR DESCRIPTION
The current-podified tag now resolves to RabbitMQ 4.2, which
requires the classic_mirrored_queue_version feature flag to be
enabled before upgrading. This breaks the minor update path from
fr2 to fr5 because the old mnesia data is incompatible with the
new RabbitMQ version.
    
Pin the image to quay.io/openstack-k8s-operators/rabbitmq:3.9
to keep the same RabbitMQ version across the update.