### PR TITLE
Fix pin-bundle-images list element seperator on ERROR

### DIFF
--- a/hack/pin-bundle-images.sh
+++ b/hack/pin-bundle-images.sh
@@ -75,14 +75,16 @@ for MOD_PATH in ${MOD_PATHS}; do
     fi
 
     if [ -z "$SHA" ]; then
-        echo "ERROR: Failed to find bundle image SHA for:"
-        echo "  MOD_PATH: $MOD_PATH"
-        echo "  BASE: $BASE"
-        echo "  REF: $REF"
-        echo "  REPO_URL: $REPO_URL"
-        echo "  REPO_CURL_URL: $REPO_CURL_URL"
-        echo "  Bundle: ${REPO_URL}/${BASE}-operator-bundle:$REF"
-        echo ",EMPTY_SHA:$REF:$REPO_CURL_URL"
+        # Send diagnostics to stderr; stdout is consumed as bundle list tokens.
+        echo "" >&2
+        echo "ERROR: Failed to find bundle image SHA for:" >&2
+        echo "  MOD_PATH: $MOD_PATH" >&2
+        echo "  BASE: $BASE" >&2
+        echo "  REF: $REF" >&2
+        echo "  REPO_URL: $REPO_URL" >&2
+        echo "  REPO_CURL_URL: $REPO_CURL_URL" >&2
+        echo "  Bundle: ${REPO_URL}/${BASE}-operator-bundle:$REF" >&2
+        echo "EMPTY_SHA:$BASE:$REF:$REPO_CURL_URL" >&2
         exit 1
     fi
 

--- a/hack/sync-bindata.sh
+++ b/hack/sync-bindata.sh
@@ -126,7 +126,11 @@ EOF_CAT
 
 }
 
-for BUNDLE in $(hack/pin-bundle-images.sh | tr "," " "); do
+if ! BUNDLES="$(hack/pin-bundle-images.sh)"; then
+    exit 1
+fi
+
+for BUNDLE in $(echo "$BUNDLES" | tr "," " "); do
     (
         set +e
         n=0


### PR DESCRIPTION
When a bundle lookup failed, the error token was getting concatenated to the previous bundle reference, which made CI logs misleading during debugging. For example, a nova bundle failure appeared as if neutron failed because "ERROR" was appended to the neutron bundle ref.

Misleading CI log blaming neutron:
```
+ skopeo copy docker://quay.io/openstack-k8s-operators/neutron-operator-bundle:26247a82c50be671c34c3646900aeefd795e2748ERROR: dir:tmp/bindata/tmp
FATA[0000] Invalid source name docker://quay.io/openstack-k8s-operators/neutron-operator-bundle:26247a82c50be671c34c3646900aeefd795e2748ERROR:: invalid reference format
+ RC=1
+ '[' 1 -eq 0 -o 5 -ge 5 ']'
+ exit 1
make: *** [Makefile:174: bindata] Error 1
```

Actual failure on nova, but not getting caught in CI due to missing `,`:
```
./hack/pin-bundle-images.sh
,quay.io/openstack-k8s-operators/barbican-operator-bundle:4ba81106621be23697cbf660e73222bf727cbf86,quay.io/openstack-k8s-operators/cinder-operator-bundle:7d895a78aba4c0dc473ad70f5cda3ddb23ce2328,quay.io/openstack-k8s-operators/designate-operator-bundle:a4d9e9923a7c2e4d7df37d0c93e447d3cf8b3c50,quay.io/openstack-k8s-operators/glance-operator-bundle:5d3b9a38d41fc907da8294224cf73addc56325f3,quay.io/openstack-k8s-operators/heat-operator-bundle:bc6ef34fe170e7e48b40cdafb9fdbb93e594c198,quay.io/openstack-k8s-operators/horizon-operator-bundle:e2ac360661926baa6f4a7057a93db1d23c53bce5,quay.io/openstack-k8s-operators/infra-operator-bundle:5476763a36b6baebc82b0fe38e966e15a7881270,quay.io/openstack-k8s-operators/ironic-operator-bundle:b8fc3a4b05217d5b450a69e6f2064e1e471f3f3c,quay.io/openstack-k8s-operators/keystone-operator-bundle:c146da0da0d63e73760b568f63e125dac80ccfcc,quay.io/openstack-k8s-operators/manila-operator-bundle:523bbc8113634169b0dbe573511c8e49b993cead,quay.io/openstack-k8s-operators/mariadb-operator-bundle:564a51226a2a01ce3b5501d2b8a8fba133a02787,quay.io/openstack-k8s-operators/neutron-operator-bundle:26247a82c50be671c34c3646900aeefd795e2748ERROR: Failed to find bundle image SHA for:
  MOD_PATH: github.com/auniyal61/nova-operator/api
  BASE: nova
  REF: b54a701efcaf
  REPO_URL: quay.io/auniyal61
  REPO_CURL_URL: https://quay.io/api/v1/repository/auniyal61
  Bundle: quay.io/auniyal61/nova-operator-bundle:b54a701efcaf
,EMPTY_SHA:b54a701efcaf:https://quay.io/api/v1/repository/auniyal61
```