### PR TITLE
Remove rabbitmq/cluster-operator/v2 dependency

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -119,12 +119,6 @@ require (
 // must consistent within modules and service operators
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20250711200046-c86d80652a9e //allow-merging
 
-// custom RabbitmqClusterSpecCore for OpenStackControlplane (v2.16.0_patches)
-replace github.com/rabbitmq/cluster-operator/v2 => github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20250929174222-a0d328fa4dec //allow-merging
-
-// pin to support rabbitmq 2.16.0 rebase
-//replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20250627150254-e9823e99808e //allow-merging
-
 replace k8s.io/apimachinery => k8s.io/apimachinery v0.31.14 //allow-merging
 
 replace k8s.io/api => k8s.io/api v0.31.14 //allow-merging

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,7 +84,6 @@ import (
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 	_ "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
 	watcherv1 "github.com/openstack-k8s-operators/watcher-operator/api/v1beta1"
-	rabbitmqclusterv2 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -107,7 +106,6 @@ func init() {
 	utilruntime.Must(keystonev1.AddToScheme(scheme))
 	utilruntime.Must(mariadbv1.AddToScheme(scheme))
 	utilruntime.Must(memcachedv1.AddToScheme(scheme))
-	utilruntime.Must(rabbitmqclusterv2.AddToScheme(scheme))
 	utilruntime.Must(placementv1.AddToScheme(scheme))
 	utilruntime.Must(glancev1.AddToScheme(scheme))
 	utilruntime.Must(cinderv1.AddToScheme(scheme))

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/openstack-k8s-operators/test-operator/api v0.6.1-0.20260416110435-a3f78e737417
 	github.com/openstack-k8s-operators/watcher-operator/api v0.6.1-0.20260414124111-458e17672b3c
 	github.com/pkg/errors v0.9.1
-	github.com/rabbitmq/cluster-operator/v2 v2.16.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -158,10 +157,6 @@ replace github.com/openstack-k8s-operators/openstack-operator/api => ./api //all
 // must consistent within modules and service operators
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20250711200046-c86d80652a9e //allow-merging
 
-// custom RabbitmqClusterSpecCore for OpenStackControlplane (v2.16.0_patches)
-replace github.com/rabbitmq/cluster-operator/v2 => github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20250929174222-a0d328fa4dec //allow-merging
-
-// pin to support rabbitmq 2.16.0 rebase
 replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20250627150254-e9823e99808e //allow-merging
 
 replace k8s.io/apimachinery => k8s.io/apimachinery v0.31.14 //allow-merging

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,6 @@ github.com/openstack-k8s-operators/ovn-operator/api v0.6.1-0.20260420053123-cf09
 github.com/openstack-k8s-operators/ovn-operator/api v0.6.1-0.20260420053123-cf0908d8cf39/go.mod h1:ODYNTFMUlzvjlqXAh9AGXrzpBNQBAOkWiNQ6UldsqFw=
 github.com/openstack-k8s-operators/placement-operator/api v0.6.1-0.20260413090520-f18a11875c1d h1:ZvVIq5E/F82tqQckheo3WnL6XywTPc+PiJWyrllkyVo=
 github.com/openstack-k8s-operators/placement-operator/api v0.6.1-0.20260413090520-f18a11875c1d/go.mod h1:34ka8QoEZ2LFmJv6wO5l9U29f9Kd1vizVzbkzRQnwVA=
-github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20250929174222-a0d328fa4dec h1:saovr368HPAKHN0aRPh8h8n9s9dn3d8Frmfua0UYRlc=
-github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20250929174222-a0d328fa4dec/go.mod h1:Nh2NEePLjovUQof2krTAg4JaAoLacqtPTZQXK6izNfg=
 github.com/openstack-k8s-operators/swift-operator/api v0.6.1-0.20260418085220-949c802081aa h1:pnzRdcdTy91mxcU93e7xp9gn+pNyWyOdB8w/WlRynvo=
 github.com/openstack-k8s-operators/swift-operator/api v0.6.1-0.20260418085220-949c802081aa/go.mod h1:REDdMRGrY7JhGOsrKXt4hNZJAq0f6b3ykVh/Wyy4UXs=
 github.com/openstack-k8s-operators/telemetry-operator/api v0.6.1-0.20260420053123-02a691a5b4d4 h1:82WLFtF/6P1VwcVoyfO9vjEdMnkQFpHkVq4I3YY7L28=

--- a/internal/openstack/rabbitmq.go
+++ b/internal/openstack/rabbitmq.go
@@ -31,8 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	rabbitmqv2 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type mqStatus int
@@ -316,7 +317,12 @@ func removeRabbitmqClusterControllerReference(
 	instance *corev1beta1.OpenStackControlPlane,
 	name string,
 ) error {
-	rabbitmqCluster := &rabbitmqv2.RabbitmqCluster{}
+	rabbitmqCluster := &unstructured.Unstructured{}
+	rabbitmqCluster.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "rabbitmq.com",
+		Version: "v1beta1",
+		Kind:    "RabbitmqCluster",
+	})
 	namespacedName := types.NamespacedName{
 		Name:      name,
 		Namespace: instance.Namespace,

--- a/test/functional/ctlplane/suite_test.go
+++ b/test/functional/ctlplane/suite_test.go
@@ -32,8 +32,6 @@ import (
 	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	k8s_networkingv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	rabbitmqv2 "github.com/rabbitmq/cluster-operator/v2/api/v1beta1"
-
 	barbicanv1 "github.com/openstack-k8s-operators/barbican-operator/api/v1beta1"
 	cinderv1 "github.com/openstack-k8s-operators/cinder-operator/api/v1beta1"
 	designatev1 "github.com/openstack-k8s-operators/designate-operator/api/v1beta1"
@@ -182,9 +180,6 @@ var _ = BeforeSuite(func() {
 	barbicanv1CRDs, err := test.GetCRDDirFromModule(
 		"github.com/openstack-k8s-operators/barbican-operator/api", gomod, "bases")
 	Expect(err).ShouldNot(HaveOccurred())
-	rabbitmqv2CRDs, err := test.GetCRDDirFromModule(
-		"github.com/rabbitmq/cluster-operator/v2", gomod, "config/crd/bases")
-	Expect(err).ShouldNot(HaveOccurred())
 	certmgrv1CRDs, err := test.GetOpenShiftCRDDir("cert-manager/v1", gomod)
 	Expect(err).ShouldNot(HaveOccurred())
 	ocpconfigv1CRDs, err := test.GetOpenShiftCRDDir("config/v1", gomod)
@@ -219,7 +214,6 @@ var _ = BeforeSuite(func() {
 			telemetryv1CRDs,
 			designatev1CRDs,
 			barbicanv1CRDs,
-			rabbitmqv2CRDs,
 			certmgrv1CRDs,
 			ocpconfigv1CRDs,
 			watcherCRDs,
@@ -308,8 +302,6 @@ var _ = BeforeSuite(func() {
 	err = designatev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = barbicanv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = rabbitmqv2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = certmgrv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Replace the typed rabbitmqv2.RabbitmqCluster usage in removeRabbitmqClusterControllerReference with unstructured client. This was the only code importing the rabbitmq cluster-operator types.

Remove the scheme registration from cmd/main.go and the CRD loading from the envtest suite. The unstructured client does not need the types registered in the scheme.

This eliminates a dependency that required a pinned replace directive and complicated OCP version bumps.