### PR TITLE
Cleanup EdpmMultipathdImage container references

### DIFF
--- a/api/core/v1beta1/openstackversion_types.go
+++ b/api/core/v1beta1/openstackversion_types.go
@@ -107,7 +107,8 @@ type ContainerTemplate struct {
 	DesignateWorkerImage          *string `json:"designateWorkerImage,omitempty"`
 	EdpmFrrImage                  *string `json:"edpmFrrImage,omitempty"`
 	EdpmIscsidImage               *string `json:"edpmIscsidImage,omitempty"`
-	EdpmLogrotateCrondImage       *string `json:"edpmLogrotateCrondImage,omitempty"`
+	EdpmLogrotateCrondImage *string `json:"edpmLogrotateCrondImage,omitempty"`
+	// Deprecated: EdpmMultipathdImage is no longer used. multipathd now runs on the host instead of in a container.
 	EdpmMultipathdImage           *string `json:"edpmMultipathdImage,omitempty"`
 	EdpmNeutronDhcpAgentImage     *string `json:"edpmNeutronDhcpAgentImage,omitempty"`
 	EdpmNeutronMetadataAgentImage *string `json:"edpmNeutronMetadataAgentImage,omitempty"`

--- a/api/dataplane/v1beta1/openstackdataplanenodeset_types.go
+++ b/api/dataplane/v1beta1/openstackdataplanenodeset_types.go
@@ -233,9 +233,10 @@ var ContainerImageDefaults = openstackv1.ContainerImages{
 		EdpmNeutronDhcpAgentImage:     getStrPtr("quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent:current-podified"),
 		EdpmNeutronMetadataAgentImage: getStrPtr("quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified"),
 		EdpmNeutronOvnAgentImage:      getStrPtr("quay.io/podified-antelope-centos9/openstack-neutron-ovn-agent:current-podified"),
-		EdpmNeutronSriovAgentImage:    getStrPtr("quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent:current-podified"),
-		EdpmMultipathdImage:           getStrPtr("quay.io/podified-antelope-centos9/openstack-multipathd:current-podified"),
-		NovaComputeImage:              getStrPtr("quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"),
+		EdpmNeutronSriovAgentImage: getStrPtr("quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent:current-podified"),
+		// Deprecated: EdpmMultipathdImage is no longer used. multipathd now runs on the host instead of in a container.
+		EdpmMultipathdImage: getStrPtr("quay.io/podified-antelope-centos9/openstack-multipathd:current-podified"),
+		NovaComputeImage:    getStrPtr("quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"),
 		OvnControllerImage:            getStrPtr("quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified"),
 		EdpmOvnBgpAgentImage:          getStrPtr("quay.io/podified-antelope-centos9/openstack-ovn-bgp-agent:current-podified"),
 		CeilometerComputeImage:        getStrPtr("quay.io/podified-antelope-centos9/openstack-telemetry-ceilometer-compute:current-podified"),
@@ -265,7 +266,8 @@ func SetupDefaults() {
 			ApacheImage:                   getImageDefault("RELATED_IMAGE_APACHE_IMAGE_URL_DEFAULT", ContainerImageDefaults.ApacheImage),
 			EdpmFrrImage:                  getImageDefault("RELATED_IMAGE_EDPM_FRR_IMAGE_URL_DEFAULT", ContainerImageDefaults.EdpmFrrImage),
 			EdpmIscsidImage:               getImageDefault("RELATED_IMAGE_EDPM_ISCSID_IMAGE_URL_DEFAULT", ContainerImageDefaults.EdpmIscsidImage),
-			EdpmLogrotateCrondImage:       getImageDefault("RELATED_IMAGE_EDPM_LOGROTATE_CROND_IMAGE_URL_DEFAULT", ContainerImageDefaults.EdpmLogrotateCrondImage),
+			EdpmLogrotateCrondImage: getImageDefault("RELATED_IMAGE_EDPM_LOGROTATE_CROND_IMAGE_URL_DEFAULT", ContainerImageDefaults.EdpmLogrotateCrondImage),
+			// Deprecated: EdpmMultipathdImage is no longer used. multipathd now runs on the host instead of in a container.
 			EdpmMultipathdImage:           getImageDefault("RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT", ContainerImageDefaults.EdpmMultipathdImage),
 			EdpmNeutronDhcpAgentImage:     getImageDefault("RELATED_IMAGE_EDPM_NEUTRON_DHCP_AGENT_IMAGE_URL_DEFAULT", ContainerImageDefaults.EdpmNeutronDhcpAgentImage),
 			EdpmNeutronMetadataAgentImage: getImageDefault("RELATED_IMAGE_EDPM_NEUTRON_METADATA_AGENT_IMAGE_URL_DEFAULT", ContainerImageDefaults.EdpmNeutronMetadataAgentImage),

--- a/config/operator/default_images.yaml
+++ b/config/operator/default_images.yaml
@@ -77,8 +77,6 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
         - name: RELATED_IMAGE_EDPM_LOGROTATE_CROND_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-cron:current-podified
-        - name: RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-multipathd:current-podified
         - name: RELATED_IMAGE_EDPM_NEUTRON_DHCP_AGENT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent:current-podified
         - name: RELATED_IMAGE_EDPM_NEUTRON_METADATA_AGENT_IMAGE_URL_DEFAULT

--- a/config/operator/default_images.yaml
+++ b/config/operator/default_images.yaml
@@ -77,8 +77,9 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
         - name: RELATED_IMAGE_EDPM_LOGROTATE_CROND_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-cron:current-podified
-        - name: RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT
-          value: quay.io/podified-antelope-centos9/openstack-multipathd:current-podified
+        # Deprecated: EdpmMultipathdImage is no longer used. multipathd now runs on the host instead of in a container.
+        # - name: RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT
+        #   value: quay.io/podified-antelope-centos9/openstack-multipathd:current-podified
         - name: RELATED_IMAGE_EDPM_NEUTRON_DHCP_AGENT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent:current-podified
         - name: RELATED_IMAGE_EDPM_NEUTRON_METADATA_AGENT_IMAGE_URL_DEFAULT

--- a/docs/assemblies/common_configurations.adoc
+++ b/docs/assemblies/common_configurations.adoc
@@ -94,7 +94,6 @@ ifeval::["{build}" != "downstream"]
         edpm_telemetry_ceilometer_ipmi_image: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi
         edpm_nova_compute_image: "quay.io/podified-antelope-centos9/openstack-nova-compute
         edpm_neutron_sriov_image: "quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent
-        edpm_multipathd_image: "quay.io/podified-antelope-centos9/openstack-multipathd
         edpm_neutron_dhcp_image: "quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent
         edpm_neutron_metadata_agent_image: "quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn
         edpm_neutron_ovn_agent_image: "quay.io/podified-antelope-centos9/openstack-neutron-ovn-agent
@@ -119,7 +118,6 @@ ifeval::["{build}" == "downstream"]
         edpm_telemetry_ceilometer_ipmi_image: redhat.registry.io/rhoso-beta/openstack-ceilometer-ipmi-rhel9:18.0.0
         edpm_nova_compute_image: "redhat.registry.io/rhoso-beta/openstack-nova-compute-rhel9:18.0.0
         edpm_neutron_sriov_image: "redhat.registry.io/rhoso-beta/openstack-neutron-sriov-agent-rhel9:18.0.0
-        edpm_multipathd_image: "redhat.registry.io/rhoso-beta/openstack-multipathd-rhel9:18.0.0
         edpm_neutron_dhcp_image: "redhat.registry.io/rhoso-beta/openstack-neutron-dhcp-agent-rhel9:18.0.0
         edpm_neutron_metadata_agent_image: "redhat.registry.io/rhoso-beta/openstack-neutron-metadata-agent-ovn-rhel9:18.0.0
         edpm_neutron_ovn_agent_image: "redhat.registry.io/rhoso-beta/openstack-neutron-ovn-agent-rhel9:18.0.0

--- a/docs/assemblies/ctlplane_resources.adoc
+++ b/docs/assemblies/ctlplane_resources.adoc
@@ -2043,11 +2043,6 @@ ContainerTemplate - struct that contains container image URLs for each service i
 | *string
 | false
 
-| edpmMultipathdImage
-|
-| *string
-| false
-
 | edpmNeutronDhcpAgentImage
 |
 | *string

--- a/docs/assemblies/proc_creating-a-set-of-data-plane-nodes.adoc
+++ b/docs/assemblies/proc_creating-a-set-of-data-plane-nodes.adoc
@@ -291,7 +291,6 @@ ifeval::["{build}" != "downstream"]
         edpm_libvirt_image: "quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified"
         edpm_nova_compute_image: "quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified"
         edpm_neutron_sriov_image: "quay.io/podified-antelope-centos9/openstack-neutron-sriov-agent:current-podified"
-        edpm_multipathd_image: "quay.io/podified-antelope-centos9/openstack-multipathd:current-podified"
 endif::[]
 ifeval::["{build}" == "downstream"]
         edpm_iscsid_image: "registry.redhat.io/rhosp-dev-preview/openstack-iscsid:18.0"
@@ -305,7 +304,6 @@ ifeval::["{build}" == "downstream"]
         edpm_libvirt_image: "registry.redhat.io/rhosp-dev-preview/openstack-nova-libvirt:18.0"
         edpm_nova_compute_image: "registry.redhat.io/rhosp-dev-preview/openstack-nova-compute:18.0"
         edpm_neutron_sriov_image: "registry.redhat.io/rhosp-dev-preview/openstack-neutron-sriov-agent:18.0"
-        edpm_multipathd_image: "registry.redhat.io/rhosp-dev-preview/openstack-multipathd:18.0"
 endif::[]
 ----
 

--- a/docs/assemblies/proc_deploying-in-disconnected-environments.adoc
+++ b/docs/assemblies/proc_deploying-in-disconnected-environments.adoc
@@ -21,7 +21,7 @@ edpm_podman_registries_conf
 `edpm_podman_disconnected_ocp` is a boolean variable that is used to conditionally render `registries.conf` on the dataplane nodes during the deployment. While `edpm_podman_registries_conf` contains the contents of the `registries.conf` that were acquired from the `MachineConfig` in the cluster. The contents of this file will be written to  `/etc/containers/registries.conf` on each of the dataplane nodes. This ensures that our dataplane nodes are configured in a consistent manner with the OpenShift nodes.
 
 Since this configuration file is lifted directly from OpenShift, the dataplane nodes also have the same requirements as OpenShift for images - such as using image digests rather than image tags.
-This can be seen in the Ansible inventory secret for each of the `OpenStackDataPlaneNodeSet` objects in the cluster. Using `multipathd` as an example:
+This can be seen in the Ansible inventory secret for each of the `OpenStackDataPlaneNodeSet` objects in the cluster. Using `frr` as an example:
 
 [,yaml]
 ----
@@ -29,22 +29,22 @@ This can be seen in the Ansible inventory secret for each of the `OpenStackDataP
           [...]
             [[registry]]
               prefix = ""
-              location = "registry.redhat.io/rhoso/openstack-multipathd-rhel9"
+              location = "registry.redhat.io/rhoso/openstack-frr-rhel9"
 
               [[registry.mirror]]
-                location = "quay-mirror-registry.example.net:8443/olm/rhoso-openstack-multipathd-rhel9"
+                location = "quay-mirror-registry.example.net:8443/olm/rhoso-openstack-frr-rhel9"
                 pull-from-mirror = "digest-only"
           [...]
 ----
 
 Note that the `pull-from-mirror` parameter is set to `digest-only`. This means that any attempt by podman to pull an image by a digest will result in the image being pulled from the specified mirror.
 
-Accordingly, image references in the `OpenStackVersion` CR are provided in the digest format, for example the multipathd image:
+Accordingly, image references in the `OpenStackVersion` CR are provided in the digest format, for example the FRR image:
 
 [,bash]
 ----
-$ oc get openstackversion -o jsonpath='{.items[].status.containerImages.edpmMultipathdImage}'
-"registry.redhat.io/rhoso/openstack-multipathd-rhel9@sha256:7df2e1ebe4ec6815173e49157848a63d28a64ffb0db8de6562c4633c0fbcdf3f"
+$ oc get openstackversion -o jsonpath='{.items[].status.containerImages.edpmFrrImage}'
+"registry.redhat.io/rhoso/openstack-frr-rhel9@sha256:7df2e1ebe4ec6815173e49157848a63d28a64ffb0db8de6562c4633c0fbcdf3f"
 ----
 
 Since all images are in the digest format for the `OpenStackVersion` resource, there is no additional action required by users to work in a disconnected environment.

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -78,7 +78,8 @@ export RELATED_IMAGE_BARBICAN_KEYSTONE_LISTENER_IMAGE_URL_DEFAULT=quay.io/podifi
 export RELATED_IMAGE_EDPM_FRR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-frr:current-podified
 export RELATED_IMAGE_EDPM_ISCSID_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
 export RELATED_IMAGE_EDPM_LOGROTATE_CROND_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-cron:current-podified
-export RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-multipathd:current-podified
+# Deprecated: EdpmMultipathdImage is no longer used. multipathd now runs on the host instead of in a container.
+# export RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-multipathd:current-podified
 export RELATED_IMAGE_EDPM_NEUTRON_DHCP_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent:current-podified
 export RELATED_IMAGE_EDPM_NEUTRON_METADATA_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
 export RELATED_IMAGE_EDPM_NEUTRON_OVN_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-neutron-ovn-agent:current-podified

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -78,7 +78,6 @@ export RELATED_IMAGE_BARBICAN_KEYSTONE_LISTENER_IMAGE_URL_DEFAULT=quay.io/podifi
 export RELATED_IMAGE_EDPM_FRR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-frr:current-podified
 export RELATED_IMAGE_EDPM_ISCSID_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
 export RELATED_IMAGE_EDPM_LOGROTATE_CROND_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-cron:current-podified
-export RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-multipathd:current-podified
 export RELATED_IMAGE_EDPM_NEUTRON_DHCP_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-neutron-dhcp-agent:current-podified
 export RELATED_IMAGE_EDPM_NEUTRON_METADATA_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
 export RELATED_IMAGE_EDPM_NEUTRON_OVN_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-neutron-ovn-agent:current-podified

--- a/internal/dataplane/inventory.go
+++ b/internal/dataplane/inventory.go
@@ -335,9 +335,6 @@ func resolveGroupAnsibleVars(template *dataplanev1.NodeTemplate, group *ansible.
 	if template.Ansible.AnsibleVars["edpm_logrotate_crond_image"] == nil {
 		group.Vars["edpm_logrotate_crond_image"] = containerImages.EdpmLogrotateCrondImage
 	}
-	if template.Ansible.AnsibleVars["edpm_multipathd_image"] == nil {
-		group.Vars["edpm_multipathd_image"] = containerImages.EdpmMultipathdImage
-	}
 	if template.Ansible.AnsibleVars["edpm_neutron_dhcp_image"] == nil {
 		group.Vars["edpm_neutron_dhcp_image"] = containerImages.EdpmNeutronDhcpAgentImage
 	}

--- a/internal/dataplane/inventory.go
+++ b/internal/dataplane/inventory.go
@@ -335,9 +335,7 @@ func resolveGroupAnsibleVars(template *dataplanev1.NodeTemplate, group *ansible.
 	if template.Ansible.AnsibleVars["edpm_logrotate_crond_image"] == nil {
 		group.Vars["edpm_logrotate_crond_image"] = containerImages.EdpmLogrotateCrondImage
 	}
-	if template.Ansible.AnsibleVars["edpm_multipathd_image"] == nil {
-		group.Vars["edpm_multipathd_image"] = containerImages.EdpmMultipathdImage
-	}
+	// edpm_multipathd_image is no longer used - multipathd now runs on the host instead of in a container
 	if template.Ansible.AnsibleVars["edpm_neutron_dhcp_image"] == nil {
 		group.Vars["edpm_neutron_dhcp_image"] = containerImages.EdpmNeutronDhcpAgentImage
 	}

--- a/internal/dataplane/util/version.go
+++ b/internal/dataplane/util/version.go
@@ -66,6 +66,7 @@ func GetContainerImages(version *openstackv1.OpenStackVersion) openstackv1.Conta
 		containerImages.EdpmFrrImage = version.Status.ContainerImages.EdpmFrrImage
 		containerImages.EdpmIscsidImage = version.Status.ContainerImages.EdpmIscsidImage
 		containerImages.EdpmLogrotateCrondImage = version.Status.ContainerImages.EdpmLogrotateCrondImage
+		//nolint:staticcheck // SA1019: Intentionally using deprecated field for backward compatibility
 		containerImages.EdpmMultipathdImage = version.Status.ContainerImages.EdpmMultipathdImage
 		containerImages.EdpmNeutronDhcpAgentImage = version.Status.ContainerImages.EdpmNeutronDhcpAgentImage
 		containerImages.EdpmNeutronMetadataAgentImage = version.Status.ContainerImages.EdpmNeutronMetadataAgentImage
@@ -92,6 +93,7 @@ func GetContainerImages(version *openstackv1.OpenStackVersion) openstackv1.Conta
 		containerImages.EdpmFrrImage = dataplanev1.ContainerImages.EdpmFrrImage
 		containerImages.EdpmIscsidImage = dataplanev1.ContainerImages.EdpmIscsidImage
 		containerImages.EdpmLogrotateCrondImage = dataplanev1.ContainerImages.EdpmLogrotateCrondImage
+		//nolint:staticcheck // SA1019: Intentionally using deprecated field for backward compatibility
 		containerImages.EdpmMultipathdImage = dataplanev1.ContainerImages.EdpmMultipathdImage
 		containerImages.EdpmNeutronDhcpAgentImage = dataplanev1.ContainerImages.EdpmNeutronDhcpAgentImage
 		containerImages.EdpmNeutronMetadataAgentImage = dataplanev1.ContainerImages.EdpmNeutronMetadataAgentImage

--- a/internal/openstack/version.go
+++ b/internal/openstack/version.go
@@ -145,6 +145,7 @@ func GetContainerImages(defaults *corev1beta1.ContainerDefaults, instance corev1
 			EdpmFrrImage:                  getImg(instance.Spec.CustomContainerImages.EdpmFrrImage, defaults.EdpmFrrImage),
 			EdpmIscsidImage:               getImg(instance.Spec.CustomContainerImages.EdpmIscsidImage, defaults.EdpmIscsidImage),
 			EdpmLogrotateCrondImage:       getImg(instance.Spec.CustomContainerImages.EdpmLogrotateCrondImage, defaults.EdpmLogrotateCrondImage),
+			//nolint:staticcheck // SA1019: Intentionally using deprecated field for backward compatibility
 			EdpmMultipathdImage:           getImg(instance.Spec.CustomContainerImages.EdpmMultipathdImage, defaults.EdpmMultipathdImage),
 			EdpmNeutronDhcpAgentImage:     getImg(instance.Spec.CustomContainerImages.EdpmNeutronDhcpAgentImage, defaults.EdpmNeutronDhcpAgentImage),
 			EdpmNeutronMetadataAgentImage: getImg(instance.Spec.CustomContainerImages.EdpmNeutronMetadataAgentImage, defaults.EdpmNeutronMetadataAgentImage),

--- a/test/functional/ctlplane/openstackversion_controller_test.go
+++ b/test/functional/ctlplane/openstackversion_controller_test.go
@@ -132,7 +132,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 				g.Expect(version.Status.ContainerImages.EdpmFrrImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.EdpmIscsidImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.EdpmLogrotateCrondImage).ShouldNot(BeNil())
-				g.Expect(version.Status.ContainerImages.EdpmMultipathdImage).ShouldNot(BeNil())
+				// EdpmMultipathdImage is no longer used - multipathd now runs on the host instead of in a container
 				g.Expect(version.Status.ContainerImages.EdpmNeutronMetadataAgentImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.EdpmNeutronSriovAgentImage).ShouldNot(BeNil())
 				g.Expect(version.Status.ContainerImages.EdpmNodeExporterImage).ShouldNot(BeNil())


### PR DESCRIPTION
multipathd service has been moved from container to host in edpm-ansible (https://github.com/openstack-k8s-operators/edpm-ansible/pull/1060). Clean up the related EdpmMultipathdImage container references following the same pattern as EdpmIscsidImage cleanup:

- Mark EdpmMultipathdImage field as deprecated in API types with appropriate comments
- Remove edpm_multipathd_image from inventory variable assignments
- Comment out RELATED_IMAGE_EDPM_MULTIPATHD_IMAGE_URL_DEFAULT in build configuration
- Remove edpm_multipathd_image from documentation examples
- Remove EdpmMultipathdImage test assertions
- Remove edpmMultipathdImage field documentation

The API fields are preserved but marked as deprecated to maintain backward compatibility. All usage of the field has been removed from the codebase.

Closes: https://redhat.atlassian.net/browse/OSPRH-17429