### PR TITLE
Add TLS certificate for InstanceHA metrics endpoint

### DIFF
--- a/api/core/v1beta1/conditions.go
+++ b/api/core/v1beta1/conditions.go
@@ -150,6 +150,9 @@ const (
 	// OpenStackControlPlaneInstanceHaCMReadyCondition Status=True condition which indicates if InstanceHa CM is ready
 	OpenStackControlPlaneInstanceHaCMReadyCondition condition.Type = "OpenStackControlPlaneInstanceHaCMReadyCondition"
 
+	// OpenStackControlPlaneInstanceHaTLSReadyCondition Status=True condition which indicates if InstanceHa TLS certificate is ready
+	OpenStackControlPlaneInstanceHaTLSReadyCondition condition.Type = "OpenStackControlPlaneInstanceHaTLSReadyCondition"
+
 	// OpenStackControlPlaneCertCleanupReadyCondition Status=True condition which indicates global certification cleanup is Ready
 	OpenStackControlPlaneCertCleanupReadyCondition condition.Type = "OpenStackControlPlaneCertCleanupReadyCondition"
 
@@ -491,6 +494,12 @@ const (
 
 	// OpenStackControlPlaneInstanceHaCMReadyMessage
 	OpenStackControlPlaneInstanceHaCMReadyMessage = "OpenStackControlPlane InstanceHa CM is available"
+
+	// OpenStackControlPlaneInstanceHaTLSReadyErrorMessage
+	OpenStackControlPlaneInstanceHaTLSReadyErrorMessage = "OpenStackControlPlane InstanceHa TLS cert error occured %s"
+
+	// OpenStackControlPlaneInstanceHaTLSReadyMessage
+	OpenStackControlPlaneInstanceHaTLSReadyMessage = "OpenStackControlPlane InstanceHa TLS cert is available"
 
 	// OpenStackControlPlaneOpenStackVersionInitializationReadyInitMessage
 	OpenStackControlPlaneOpenStackVersionInitializationReadyInitMessage = "OpenStackControlPlane OpenStackVersion initialization not started"

--- a/internal/openstack/instanceha.go
+++ b/internal/openstack/instanceha.go
@@ -2,7 +2,11 @@ package openstack
 
 import (
 	"context"
+	"fmt"
 
+	certmgrv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/openstack-k8s-operators/lib-common/modules/certmanager"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -21,6 +25,26 @@ const (
 
 // ReconcileInstanceHa reconciles the instance HA configuration for the OpenStack control plane
 func ReconcileInstanceHa(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, version *corev1beta1.OpenStackVersion, helper *helper.Helper) (ctrl.Result, error) {
+	Log := GetLogger(ctx)
+
+	if instance.Spec.TLS.PodLevel.Enabled {
+		_, err := EnsureInstanceHAMetricsCert(ctx, instance, helper)
+		if err != nil {
+			Log.Error(err, "Failed to ensure InstanceHA metrics certificate")
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				corev1beta1.OpenStackControlPlaneInstanceHaTLSReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				corev1beta1.OpenStackControlPlaneInstanceHaTLSReadyErrorMessage,
+				err.Error()))
+			return ctrl.Result{}, err
+		}
+		instance.Status.Conditions.Set(condition.TrueCondition(
+			corev1beta1.OpenStackControlPlaneInstanceHaTLSReadyCondition,
+			corev1beta1.OpenStackControlPlaneInstanceHaTLSReadyMessage,
+		))
+	}
+
 	customData := map[string]string{
 		InstanceHaImageKey: *getImg(version.Status.ContainerImages.OpenstackClientImage, &missingImageDefault),
 	}
@@ -53,4 +77,49 @@ func ReconcileInstanceHa(ctx context.Context, instance *corev1beta1.OpenStackCon
 	))
 
 	return ctrl.Result{}, nil
+}
+
+// EnsureInstanceHAMetricsCert creates a TLS certificate for InstanceHA metrics services
+func EnsureInstanceHAMetricsCert(ctx context.Context, instance *corev1beta1.OpenStackControlPlane, helper *helper.Helper) (string, error) {
+	Log := GetLogger(ctx)
+
+	dnsSuffix := clusterdns.GetDNSClusterDomain()
+
+	certRequest := certmanager.CertificateRequest{
+		IssuerName: instance.GetInternalIssuer(),
+		CertName:   "instanceha-metrics",
+		Hostnames: []string{
+			fmt.Sprintf("*.%s.svc", instance.Namespace),
+			fmt.Sprintf("*.%s.svc.%s", instance.Namespace, dnsSuffix),
+		},
+		Ips: nil,
+		Usages: []certmgrv1.KeyUsage{
+			certmgrv1.UsageKeyEncipherment,
+			certmgrv1.UsageDigitalSignature,
+			certmgrv1.UsageServerAuth,
+		},
+		Labels: map[string]string{ServiceCertSelector: ""},
+	}
+
+	if instance.Spec.TLS.PodLevel.Internal.Cert.Duration != nil {
+		certRequest.Duration = &instance.Spec.TLS.PodLevel.Internal.Cert.Duration.Duration
+	}
+	if instance.Spec.TLS.PodLevel.Internal.Cert.RenewBefore != nil {
+		certRequest.RenewBefore = &instance.Spec.TLS.PodLevel.Internal.Cert.RenewBefore.Duration
+	}
+
+	certSecret, ctrlResult, err := certmanager.EnsureCert(
+		ctx,
+		helper,
+		certRequest,
+		nil)
+	if err != nil {
+		return "", err
+	} else if (ctrlResult != ctrl.Result{}) {
+		Log.Info("InstanceHA metrics certificate creation in progress", "certificate", certRequest.CertName)
+		return "", fmt.Errorf("InstanceHA metrics certificate creation in progress")
+	}
+
+	Log.Info("InstanceHA metrics certificate ensured", "secret", certSecret.Name, "certificate", certRequest.CertName)
+	return certSecret.Name, nil
 }

--- a/test/functional/ctlplane/base_test.go
+++ b/test/functional/ctlplane/base_test.go
@@ -99,6 +99,7 @@ type Names struct {
 	OVNDbServerNBName                    types.NamespacedName
 	OVNDbServerSBName                    types.NamespacedName
 	OVNMetricsCertName                   types.NamespacedName
+	InstanceHAMetricsCertName            types.NamespacedName
 	NeutronOVNCertName                   types.NamespacedName
 	OpenStackTopology                    []types.NamespacedName
 	WatcherCertPublicRouteName           types.NamespacedName
@@ -290,6 +291,10 @@ func CreateNames(openstackControlplaneName types.NamespacedName) Names {
 		OVNMetricsCertName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,
 			Name:      "cert-ovn-metrics",
+		},
+		InstanceHAMetricsCertName: types.NamespacedName{
+			Namespace: openstackControlplaneName.Namespace,
+			Name:      "cert-instanceha-metrics",
 		},
 		NeutronOVNCertName: types.NamespacedName{
 			Namespace: openstackControlplaneName.Namespace,

--- a/test/functional/ctlplane/openstackoperator_controller_test.go
+++ b/test/functional/ctlplane/openstackoperator_controller_test.go
@@ -937,6 +937,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNNorthdCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNControllerCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNMetricsCertName))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.InstanceHAMetricsCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.NeutronOVNCertName))
 			DeferCleanup(
 				th.DeleteInstance,
@@ -1259,6 +1260,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNNorthdCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNControllerCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNMetricsCertName))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.InstanceHAMetricsCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.NeutronOVNCertName))
 			spec := GetDefaultOpenStackControlPlaneSpec()
 			spec["tls"] = GetTLSeCustomIssuerSpec()
@@ -1388,6 +1390,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNNorthdCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNControllerCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNMetricsCertName))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.InstanceHAMetricsCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.NeutronOVNCertName))
 
 			DeferCleanup(k8sClient.Delete, ctx,
@@ -2083,6 +2086,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNNorthdCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNControllerCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNMetricsCertName))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.InstanceHAMetricsCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.NeutronOVNCertName))
 
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.WatcherCertPublicRouteName))
@@ -2273,6 +2277,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNNorthdCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNControllerCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNMetricsCertName))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.InstanceHAMetricsCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.NeutronOVNCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.WatcherCertPublicRouteName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.WatcherCertPublicSvcName))
@@ -2750,6 +2755,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNNorthdCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNControllerCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNMetricsCertName))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.InstanceHAMetricsCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.NeutronOVNCertName))
 
 			DeferCleanup(
@@ -2991,6 +2997,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNNorthdCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNControllerCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNMetricsCertName))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.InstanceHAMetricsCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.NeutronOVNCertName))
 			// create cert secret for octavia ovn client
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(types.NamespacedName{Name: "cert-octavia-ovndbs", Namespace: names.Namespace}))
@@ -4049,6 +4056,7 @@ var _ = Describe("OpenStackOperator controller nova cell deletion", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNNorthdCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNControllerCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.OVNMetricsCertName))
+			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.InstanceHAMetricsCertName))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(names.NeutronOVNCertName))
 
 			// create cert secrets for memcached instance

--- a/test/kuttl/common/assert-sample-deployment.yaml
+++ b/test/kuttl/common/assert-sample-deployment.yaml
@@ -266,6 +266,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane InstanceHa TLS cert is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaTLSReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/ctlplane-basic-deployment/03-assert-deploy-custom-cacert.yaml
+++ b/test/kuttl/tests/ctlplane-basic-deployment/03-assert-deploy-custom-cacert.yaml
@@ -75,6 +75,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane InstanceHa TLS cert is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaTLSReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
+++ b/test/kuttl/tests/ctlplane-collapsed/01-assert-collapsed-cell.yaml
@@ -244,6 +244,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane InstanceHa TLS cert is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaTLSReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
+++ b/test/kuttl/tests/ctlplane-galera-3replicas/01-assert-galera-3replicas.yaml
@@ -231,6 +231,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane InstanceHa TLS cert is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaTLSReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/ctlplane-tls-cert-rotation/03-assert-new-certs.yaml
+++ b/test/kuttl/tests/ctlplane-tls-cert-rotation/03-assert-new-certs.yaml
@@ -287,6 +287,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane InstanceHa TLS cert is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaTLSReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/ctlplane-tls-custom-issuers/01-assert-deploy-openstack.yaml
+++ b/test/kuttl/tests/ctlplane-tls-custom-issuers/01-assert-deploy-openstack.yaml
@@ -252,6 +252,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane InstanceHa TLS cert is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaTLSReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/ctlplane-tls-custom-issuers/09-assert-deploy-openstack.yaml
+++ b/test/kuttl/tests/ctlplane-tls-custom-issuers/09-assert-deploy-openstack.yaml
@@ -252,6 +252,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane InstanceHa TLS cert is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaTLSReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/ctlplane-tls-custom-route/03-assert-deploy-openstack.yaml
+++ b/test/kuttl/tests/ctlplane-tls-custom-route/03-assert-deploy-openstack.yaml
@@ -278,6 +278,10 @@ status:
     reason: Ready
     status: "True"
     type: OpenStackControlPlaneInstanceHaCMReadyCondition
+  - message: OpenStackControlPlane InstanceHa TLS cert is available
+    reason: Ready
+    status: "True"
+    type: OpenStackControlPlaneInstanceHaTLSReadyCondition
   - message: OpenStackControlPlane KeystoneAPI completed
     reason: Ready
     status: "True"


### PR DESCRIPTION
Create a cert-manager Certificate for the InstanceHA metrics service when pod-level TLS is enabled. The certificate uses the internal issuer with wildcard hostnames for the namespace, following the same pattern as EnsureOVNMetricsCert. The resulting secret (cert-instanceha-metrics) is consumed by the infra-operator InstanceHA controller.