### PR TITLE
Add OpenStackDataPlaneService for instanceha-monitoring

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_instanceha_monitoring.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_instanceha_monitoring.yaml
@@ -1,0 +1,10 @@
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: instanceha-monitoring
+spec:
+  dataSources:
+    - secretRef:
+        name: instanceha-heartbeat-hmac
+  playbook: osp.edpm.instanceha_monitoring
+  edpmServiceType: instanceha-monitoring


### PR DESCRIPTION
Defines the EDPM service that mounts the instanceha-heartbeat-hmac secret into the ansible-runner pod, enabling automatic HMAC key distribution to compute nodes for heartbeat authentication.

Since there could be multiple instanceha crs in the same namespace, users should create copies of this service and reference the respective secrets named "<instanceha_cr_name>-heartbeat-hmac".