### PR TITLE
Add containerImageFields to swift OpenStackDataPlaneService

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_swift.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_swift.yaml
@@ -11,4 +11,9 @@ spec:
         name: swift-storage-config-data
     - configMapRef:
         name: swift-ring-files
+  containerImageFields:
+  - SwiftAccountImage
+  - SwiftContainerImage
+  - SwiftObjectImage
+  - SwiftProxyImage
   edpmServiceType: swift


### PR DESCRIPTION
The swift container images were added to the EDPM ansible vars in 8c3b225 but the OpenStackDataPlaneService was not updated to declare its containerImageFields.

Jira: [OSPCIX-1268](https://redhat.atlassian.net/browse/OSPCIX-1268)