### PR TITLE
Allow ACME-issued certificates for public endpoint routes

### DIFF
--- a/internal/openstack/common.go
+++ b/internal/openstack/common.go
@@ -616,13 +616,9 @@ func (ed *EndpointDetail) CreateRoute(
 				return ctrl.Result{}, err
 			}
 
-			// check if secret has the expected entries tls.crt, tls.key and ca.crt
-			if certSecret != nil {
-				for _, key := range []string{"tls.crt", "tls.key", "ca.crt"} {
-					if _, exist := certSecret.Data[key]; !exist {
-						return ctrl.Result{}, fmt.Errorf("certificate secret %s does not provide %s", *ed.Route.TLS.SecretName, key)
-					}
-				}
+			// check the secret has the required tls.crt and tls.key entries
+			if err := validateRouteCertSecret(certSecret, *ed.Route.TLS.SecretName); err != nil {
+				return ctrl.Result{}, err
 			}
 		}
 
@@ -659,8 +655,12 @@ func (ed *EndpointDetail) CreateRoute(
 			Termination:                   routev1.TLSTerminationEdge,
 			Certificate:                   string(certSecret.Data[tls.CertKey]),
 			Key:                           string(certSecret.Data[tls.PrivateKey]),
-			CACertificate:                 string(certSecret.Data[tls.CAKey]),
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		}
+		// ca.crt is optional (absent for ACME-issued certs); only set the
+		// route CACertificate when the secret actually provides it.
+		if caCert, ok := certSecret.Data[tls.CAKey]; ok {
+			tlsConfig.CACertificate = string(caCert)
 		}
 
 		// for internal TLS (TLSE) use routev1.TLSTerminationReencrypt
@@ -870,6 +870,23 @@ func hasCertInOverrideSpec(overrideSpec route.OverrideSpec) bool {
 	return overrideSpec.Spec.TLS.CACertificate != "" &&
 		overrideSpec.Spec.TLS.Certificate != "" &&
 		overrideSpec.Spec.TLS.Key != ""
+}
+
+// validateRouteCertSecret ensures a user-provided route TLS secret contains the
+// required tls.crt and tls.key entries. ca.crt is intentionally not required:
+// certificates issued by an ACME issuer (e.g. Let's Encrypt) do not populate
+// ca.crt, and the issuing chain is delivered via tls.crt instead. ca.crt is only
+// needed to advertise a custom CA on the route, which is optional.
+func validateRouteCertSecret(certSecret *k8s_corev1.Secret, secretName string) error {
+	if certSecret == nil {
+		return nil
+	}
+	for _, key := range []string{tls.CertKey, tls.PrivateKey} {
+		if _, exist := certSecret.Data[key]; !exist {
+			return fmt.Errorf("certificate secret %s does not provide %s", secretName, key)
+		}
+	}
+	return nil
 }
 
 func serviceExists(route string, services *k8s_corev1.ServiceList) bool {

--- a/internal/openstack/common.go
+++ b/internal/openstack/common.go
@@ -602,7 +602,7 @@ func (ed *EndpointDetail) CreateRoute(
 		certSecret := &k8s_corev1.Secret{}
 
 		// if a custom cert secret was provided, check if it exist
-		// and has the required cert, key and cacert
+		// and has the required cert and key (cacert optional)
 		// Right now there is no check if certificate is valid for
 		// the hostname of the route. If the referenced secret is
 		// there and has the required files it is just being used.
@@ -616,13 +616,9 @@ func (ed *EndpointDetail) CreateRoute(
 				return ctrl.Result{}, err
 			}
 
-			// check if secret has the expected entries tls.crt, tls.key and ca.crt
-			if certSecret != nil {
-				for _, key := range []string{"tls.crt", "tls.key", "ca.crt"} {
-					if _, exist := certSecret.Data[key]; !exist {
-						return ctrl.Result{}, fmt.Errorf("certificate secret %s does not provide %s", *ed.Route.TLS.SecretName, key)
-					}
-				}
+			// check the secret has the required tls.crt and tls.key entries
+			if err := validateRouteCertSecret(certSecret, *ed.Route.TLS.SecretName); err != nil {
+				return ctrl.Result{}, err
 			}
 		}
 
@@ -659,8 +655,12 @@ func (ed *EndpointDetail) CreateRoute(
 			Termination:                   routev1.TLSTerminationEdge,
 			Certificate:                   string(certSecret.Data[tls.CertKey]),
 			Key:                           string(certSecret.Data[tls.PrivateKey]),
-			CACertificate:                 string(certSecret.Data[tls.CAKey]),
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		}
+		// ca.crt is optional (absent for ACME-issued certs); only set the
+		// route CACertificate when the secret actually provides it.
+		if caCert, ok := certSecret.Data[tls.CAKey]; ok {
+			tlsConfig.CACertificate = string(caCert)
 		}
 
 		// for internal TLS (TLSE) use routev1.TLSTerminationReencrypt
@@ -870,6 +870,23 @@ func hasCertInOverrideSpec(overrideSpec route.OverrideSpec) bool {
 	return overrideSpec.Spec.TLS.CACertificate != "" &&
 		overrideSpec.Spec.TLS.Certificate != "" &&
 		overrideSpec.Spec.TLS.Key != ""
+}
+
+// validateRouteCertSecret ensures a user-provided route TLS secret contains the
+// required tls.crt and tls.key entries. ca.crt is intentionally not required:
+// certificates issued by an ACME issuer (e.g. Let's Encrypt) do not populate
+// ca.crt, and the issuing chain is delivered via tls.crt instead. ca.crt is only
+// needed to advertise a custom CA on the route, which is optional.
+func validateRouteCertSecret(certSecret *k8s_corev1.Secret, secretName string) error {
+	if certSecret == nil {
+		return nil
+	}
+	for _, key := range []string{tls.CertKey, tls.PrivateKey} {
+		if _, exist := certSecret.Data[key]; !exist {
+			return fmt.Errorf("certificate secret %s does not provide %s", secretName, key)
+		}
+	}
+	return nil
 }
 
 func serviceExists(route string, services *k8s_corev1.ServiceList) bool {

--- a/internal/openstack/common_test.go
+++ b/internal/openstack/common_test.go
@@ -572,3 +572,72 @@ func TestCheckRouteAdmissionStatus_UpdatedStatus(t *testing.T) {
 	err = checkRouteAdmissionStatus(ctx, h, "test-route", "test-namespace")
 	g.Expect(err).ToNot(HaveOccurred())
 }
+
+func TestValidateRouteCertSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      map[string][]byte
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "cert, key and ca.crt present",
+			data: map[string][]byte{
+				"tls.crt": []byte("cert"),
+				"tls.key": []byte("key"),
+				"ca.crt":  []byte("ca"),
+			},
+			wantErr: false,
+		},
+		{
+			// ACME issuers (e.g. Let's Encrypt) do not populate ca.crt; the
+			// secret must still be accepted.
+			name: "cert and key present, ca.crt absent (ACME)",
+			data: map[string][]byte{
+				"tls.crt": []byte("cert"),
+				"tls.key": []byte("key"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "tls.key missing",
+			data: map[string][]byte{
+				"tls.crt": []byte("cert"),
+			},
+			wantErr:   true,
+			errSubstr: "does not provide tls.key",
+		},
+		{
+			name: "tls.crt missing",
+			data: map[string][]byte{
+				"tls.key": []byte("key"),
+			},
+			wantErr:   true,
+			errSubstr: "does not provide tls.crt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			secret := &k8s_corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "custom-route-cert", Namespace: "test-namespace"},
+				Data:       tt.data,
+			}
+
+			err := validateRouteCertSecret(secret, secret.Name)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errSubstr))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestValidateRouteCertSecret_NilSecret(t *testing.T) {
+	g := NewWithT(t)
+	// A nil secret is tolerated (the caller may not have fetched one).
+	g.Expect(validateRouteCertSecret(nil, "custom-route-cert")).ToNot(HaveOccurred())
+}


### PR DESCRIPTION
When a user supplies a custom TLS secret for a public endpoint route
(via `apiOverride`), the operator required the secret to contain
`tls.crt`, `tls.key` **and** `ca.crt`. Certificates issued by an ACME
issuer (e.g. Let's Encrypt) do not populate `ca.crt`: the issuing chain
is delivered inline in `tls.crt`, and the signing root is publicly
trusted, so a separate `ca.crt` entry is neither produced nor needed.
This made it impossible to use ACME-issued certificates for public
endpoints without synthesising a `ca.crt` key.

This makes `ca.crt` optional on that path:

- The secret key check is extracted into `validateRouteCertSecret`,
  which now requires only `tls.crt` and `tls.key`.
- The route's `CACertificate` is set only when the secret actually
  provides `ca.crt`, instead of writing an empty value.

Certificate chains continue to be served correctly because cert-manager
packs the full issuing chain into `tls.crt`; `CACertificate` is only
used to advertise an additional custom CA, which remains supported when
present. Re-encrypt (TLSE) routes are unaffected — their
`DestinationCACertificate` is still sourced from the internal CA bundle.

This covers the "bring your own secret" flow. Having the operator
manage an ACME `Certificate` directly (which additionally requires
guarding the custom-issuer CA-extraction path and splitting public vs
internal SAN profiles) is intentionally out of scope here.

Jira: [RHOSRFE-109](https://redhat.atlassian.net/browse/RHOSRFE-109)



🤖 Generated with [Claude Code](https://claude.com/claude-code)
