### PR TITLE
Set ImagePullPolicy to IfNotPresent on OpenStackClient pod

### DIFF
--- a/internal/openstackclient/funcs.go
+++ b/internal/openstackclient/funcs.go
@@ -77,10 +77,11 @@ func ClientPodSpec(
 		Volumes:                       volumes,
 		Containers: []corev1.Container{
 			{
-				Name:    "openstackclient",
-				Image:   instance.Spec.ContainerImage,
-				Command: []string{"/bin/sleep"},
-				Args:    []string{"infinity"},
+				Name:            "openstackclient",
+				Image:           instance.Spec.ContainerImage,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         []string{"/bin/sleep"},
+				Args:            []string{"infinity"},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsUser:                ptr.To[int64](42401),
 					RunAsGroup:               ptr.To[int64](42401),


### PR DESCRIPTION
The OpenStackClient pod is created as a raw corev1.Pod directly, bypassing lib-common workload helpers where SetPullPolicyDefaults is applied. When ImagePullPolicy is not explicitly set and the image tag is "latest" or unset, Kubernetes defaults the policy to Always. Explicitly set PullIfNotPresent to avoid unnecessary image pulls.