### PR TITLE
Revert "Bump Makefile version to 0.7.0"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.7.0
+VERSION ?= 0.6.0
 
 OPENSTACK_RELEASE_VERSION ?= $(VERSION)-$(shell date +%s)
 


### PR DESCRIPTION
Reverts openstack-k8s-operators/openstack-operator#1951 the version needs to be bumped on main and pr https://github.com/openstack-k8s-operators/openstack-operator/pull/1950 was created by branching automation for this