### PR TITLE
Use ECDSA P-256 private keys for cert-manager certificates

### DIFF
--- a/bindata/operator/infra-operator-webhooks.yaml
+++ b/bindata/operator/infra-operator-webhooks.yaml
@@ -37,6 +37,9 @@ spec:
   issuerRef:
     kind: Issuer
     name: infra-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: infra-operator-webhook-server-cert
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/bindata/operator/openstack-baremetal-operator-webhooks.yaml
+++ b/bindata/operator/openstack-baremetal-operator-webhooks.yaml
@@ -37,6 +37,9 @@ spec:
   issuerRef:
     kind: Issuer
     name: openstack-baremetal-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: openstack-baremetal-operator-webhook-server-cert
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/bindata/services/barbican-operator-services.yaml
+++ b/bindata/services/barbican-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: barbican-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: barbican-operator-metrics-server-cert

--- a/bindata/services/cinder-operator-services.yaml
+++ b/bindata/services/cinder-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: cinder-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: cinder-operator-metrics-server-cert

--- a/bindata/services/designate-operator-services.yaml
+++ b/bindata/services/designate-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: designate-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: designate-operator-metrics-server-cert

--- a/bindata/services/glance-operator-services.yaml
+++ b/bindata/services/glance-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: glance-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: glance-operator-metrics-server-cert

--- a/bindata/services/heat-operator-services.yaml
+++ b/bindata/services/heat-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: heat-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: heat-operator-metrics-server-cert

--- a/bindata/services/horizon-operator-services.yaml
+++ b/bindata/services/horizon-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: horizon-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: horizon-operator-metrics-server-cert

--- a/bindata/services/infra-operator-services.yaml
+++ b/bindata/services/infra-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: infra-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: infra-operator-metrics-server-cert

--- a/bindata/services/ironic-operator-services.yaml
+++ b/bindata/services/ironic-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: ironic-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: ironic-operator-metrics-server-cert

--- a/bindata/services/keystone-operator-services.yaml
+++ b/bindata/services/keystone-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: keystone-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: keystone-operator-metrics-server-cert

--- a/bindata/services/manila-operator-services.yaml
+++ b/bindata/services/manila-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: manila-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: manila-operator-metrics-server-cert

--- a/bindata/services/mariadb-operator-services.yaml
+++ b/bindata/services/mariadb-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: mariadb-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: mariadb-operator-metrics-server-cert

--- a/bindata/services/neutron-operator-services.yaml
+++ b/bindata/services/neutron-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: neutron-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: neutron-operator-metrics-server-cert

--- a/bindata/services/nova-operator-services.yaml
+++ b/bindata/services/nova-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: nova-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: nova-operator-metrics-server-cert

--- a/bindata/services/octavia-operator-services.yaml
+++ b/bindata/services/octavia-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: octavia-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: octavia-operator-metrics-server-cert

--- a/bindata/services/openstack-baremetal-operator-services.yaml
+++ b/bindata/services/openstack-baremetal-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: openstack-baremetal-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: openstack-baremetal-operator-metrics-server-cert

--- a/bindata/services/ovn-operator-services.yaml
+++ b/bindata/services/ovn-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: ovn-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: ovn-operator-metrics-server-cert

--- a/bindata/services/swift-operator-services.yaml
+++ b/bindata/services/swift-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: swift-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: swift-operator-metrics-server-cert

--- a/bindata/services/telemetry-operator-services.yaml
+++ b/bindata/services/telemetry-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: telemetry-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: telemetry-operator-metrics-server-cert

--- a/bindata/services/test-operator-services.yaml
+++ b/bindata/services/test-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: test-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: test-operator-metrics-server-cert

--- a/bindata/services/watcher-operator-services.yaml
+++ b/bindata/services/watcher-operator-services.yaml
@@ -52,4 +52,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: watcher-operator-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: watcher-operator-metrics-server-cert

--- a/hack/sync-bindata.sh
+++ b/hack/sync-bindata.sh
@@ -91,6 +91,9 @@ spec:
   issuerRef:
     kind: Issuer
     name: $OPERATOR_NAME-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: $OPERATOR_NAME-webhook-server-cert
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -229,6 +232,9 @@ spec:
   issuerRef:
     kind: Issuer
     name: $OPERATOR_NAME-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
   secretName: $OPERATOR_NAME-metrics-server-cert
 EOF_CAT
 


### PR DESCRIPTION
Switch all `cert-manager` `Certificate` resources from the default `RSA` algorithm to `ECDSA` `P-256`. This applies to `webhook` serving certs, `metrics` server certs, and all operator `bindata` `certificates`. The `sync-bindata.sh` script is updated accordingly (and it properly regenerates all the services files).

Jira: https://redhat.atlassian.net/browse/OSPRH-27314 