### PR TITLE
Default logger to production mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ run: export ENABLE_WEBHOOKS?=false
 run: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/clean_local_webhook.sh
 	source hack/export_related_images.sh && \
-		go run ./cmd/main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)" -pprof-bind-address ":$(PPROF_PORT)"
+		go run ./cmd/main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)" -pprof-bind-address ":$(PPROF_PORT)" $(ARGS)
 
 .PHONY: run-operator
 run-operator: export METRICS_PORT?=8080
@@ -252,7 +252,7 @@ run-operator: export OPERATOR_IMAGE_URL=${IMG}
 run-operator: manifests generate fmt vet ## Run a controller from your host.
 	source hack/export_related_images.sh && \
 	source hack/export_operator_related_images.sh && \
-	go run ./cmd/operator/main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)" -pprof-bind-address ":$(PPROF_PORT)"
+	go run ./cmd/operator/main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)" -pprof-bind-address ":$(PPROF_PORT)" $(ARGS)
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.

--- a/README.md
+++ b/README.md
@@ -123,19 +123,16 @@ It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controlle
 which provides a reconcile function responsible for synchronizing resources untile the desired state is reached on the cluster
 
 ### Test It Out
-1. Install the CRDs into the cluster:
+
+Install the CRDs into the cluster and run your controller (this will
+run in the foreground, so switch to a new terminal if you want to leave
+it running):
 
 ```sh
-make install
+make install run ARGS="--zap-devel"
 ```
 
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-```sh
-make run
-```
-
-**NOTE:** You can also run this in one step by running: `make install run`
+**NOTE:** `--zap-devel` enable verbose (development) logging locally.
 
 ### Modifying the API definitions
 If you are editing the API definitions, generate the manifests such as CRs or CRDs using:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -171,7 +171,9 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	opts := zap.Options{
-		Development: true,
+		// Development: false uses JSON encoding and omits stack traces / DPanic behaviour.
+		// For local development use: make run ARGS="--zap-devel"
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -87,7 +87,9 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	opts := zap.Options{
-		Development: true,
+		// Development: false uses JSON encoding and omits stack traces / DPanic behaviour.
+		// For local development use: make run ARGS="--zap-devel"
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Switch "Development: false" in both cmd/main.go and cmd/operator/main.go so the controller emits structured JSON logs by default.

Add $(ARGS) to the run and run-operator Makefile targets so dev logging can be restored with: make run ARGS="--zap-devel".

As part of ESS SEC-APP-REQ-1 (Secure Application Development), we need to ensure that proper input and output sanitization is implemented.

While working on the OpenStack Lightspeed Operator, I noticed that this is also missing from the OpenStack Operator. There may be other places requiring changes to complete the ESS, I did not performed a complete analysis of this repository.