### PR TITLE
Add per-branch CRD sync check workflows

### DIFF
--- a/.github/workflows/crd-sync-check-18-stable.yaml
+++ b/.github/workflows/crd-sync-check-18-stable.yaml
@@ -1,0 +1,13 @@
+name: CRD sync check 18-stable
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # every 2 hours
+  workflow_dispatch:
+
+jobs:
+  call-build-workflow:
+    if: github.repository_owner == 'openstack-k8s-operators'
+    uses: ./.github/workflows/crd-sync-check.yaml
+    with:
+      branch_name: 18-stable

--- a/.github/workflows/crd-sync-check-18.0-fr6.yaml
+++ b/.github/workflows/crd-sync-check-18.0-fr6.yaml
@@ -1,4 +1,4 @@
-name: CRD sync check latest fr branch
+name: CRD sync check 18.0-fr6
 
 on:
   schedule:
@@ -10,4 +10,4 @@ jobs:
     if: github.repository_owner == 'openstack-k8s-operators'
     uses: ./.github/workflows/crd-sync-check.yaml
     with:
-      branch_name: 18.0-fr5
+      branch_name: 18.0-fr6

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![CodeQL](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/codeql.yml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/codeql.yml)
 [![CRD sync check main](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check.yaml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check.yaml)
-[![CRD sync check latest fr](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check-fr.yaml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check-fr.yaml)
+[![CRD sync check 18-stable](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check-18-stable.yaml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check-18-stable.yaml)
+[![CRD sync check 18.0-fr6](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check-18.0-fr6.yaml/badge.svg)](https://github.com/openstack-k8s-operators/openstack-operator/actions/workflows/crd-sync-check-18.0-fr6.yaml)
 [![CtrlPlane CRD Size](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/openstack-k8s-ci-robot/cb95c1626e1946e428bed7ee50a73348/raw/crd-size-main.json)](https://github.com/openstack-k8s-ci-robot/openstack-operator/actions/workflows/crd-size-badge.yaml)
 
 This is the primary operator for OpenStack. It is a "meta" operator, meaning it


### PR DESCRIPTION
Replace the generic crd-sync-check-fr.yaml (stale, pointed at fr5) with per-branch workflow files for 18.0-fr6 and 18-stable. This makes it easier to add/remove branches and avoids stale references.

Jira: [OSPRH-32639](https://redhat.atlassian.net/browse/OSPRH-32639)