### PR TITLE
Add 18-stable to Renovate baseBranchPatterns

### DIFF
--- a/.github/workflows/crd-size-badge.yaml
+++ b/.github/workflows/crd-size-badge.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Install yq
         uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
     "github>openstack-k8s-operators/renovate-config:default.json5"
   ],
   "baseBranchPatterns": [
-    "main"
+    "main",
+    "18-stable"
   ],
   "useBaseBranchConfig": "merge",
   "packageRules": [


### PR DESCRIPTION
Enable Renovate to process the 18-stable branch alongside main. With useBaseBranchConfig: merge, Renovate uses the 18-stable branch's renovate.json which points to 18-stable.json5 for dependency bounds.