### PR TITLE
Add dedicated RELATED_IMAGE for instanceha instead of reusing openstackclient

### DIFF
--- a/api/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/api/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -21099,6 +21099,8 @@ spec:
                     type: string
                   infraRedisImage:
                     type: string
+                  instanceHaImage:
+                    type: string
                   ironicAPIImage:
                     type: string
                   ironicConductorImage:

--- a/api/bases/core.openstack.org_openstackversions.yaml
+++ b/api/bases/core.openstack.org_openstackversions.yaml
@@ -147,6 +147,8 @@ spec:
                     type: string
                   infraRedisImage:
                     type: string
+                  instanceHaImage:
+                    type: string
                   ironicAPIImage:
                     type: string
                   ironicConductorImage:
@@ -389,6 +391,8 @@ spec:
                       type: string
                     infraRedisImage:
                       type: string
+                    instanceHaImage:
+                      type: string
                     ironicAPIImage:
                       type: string
                     ironicConductorImage:
@@ -588,6 +592,8 @@ spec:
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:
+                    type: string
+                  instanceHaImage:
                     type: string
                   ironicAPIImage:
                     type: string
@@ -806,6 +812,8 @@ spec:
                     infraMemcachedImage:
                       type: string
                     infraRedisImage:
+                      type: string
+                    instanceHaImage:
                       type: string
                     ironicAPIImage:
                       type: string

--- a/api/core/v1beta1/openstackversion_types.go
+++ b/api/core/v1beta1/openstackversion_types.go
@@ -130,6 +130,7 @@ type ContainerTemplate struct {
 	InfraDnsmasqImage                 *string `json:"infraDnsmasqImage,omitempty"`
 	InfraMemcachedImage               *string `json:"infraMemcachedImage,omitempty"`
 	InfraRedisImage                   *string `json:"infraRedisImage,omitempty"`
+	InstanceHaImage                   *string `json:"instanceHaImage,omitempty"`
 	IronicAPIImage                    *string `json:"ironicAPIImage,omitempty"`
 	IronicConductorImage              *string `json:"ironicConductorImage,omitempty"`
 	IronicInspectorImage              *string `json:"ironicInspectorImage,omitempty"`

--- a/api/core/v1beta1/zz_generated.deepcopy.go
+++ b/api/core/v1beta1/zz_generated.deepcopy.go
@@ -567,6 +567,11 @@ func (in *ContainerTemplate) DeepCopyInto(out *ContainerTemplate) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.InstanceHaImage != nil {
+		in, out := &in.InstanceHaImage, &out.InstanceHaImage
+		*out = new(string)
+		**out = **in
+	}
 	if in.IronicAPIImage != nil {
 		in, out := &in.IronicAPIImage, &out.IronicAPIImage
 		*out = new(string)

--- a/bindata/crds/crds.yaml
+++ b/bindata/crds/crds.yaml
@@ -21633,6 +21633,8 @@ spec:
                     type: string
                   infraRedisImage:
                     type: string
+                  instanceHaImage:
+                    type: string
                   ironicAPIImage:
                     type: string
                   ironicConductorImage:
@@ -24551,6 +24553,8 @@ spec:
                     type: string
                   infraRedisImage:
                     type: string
+                  instanceHaImage:
+                    type: string
                   ironicAPIImage:
                     type: string
                   ironicConductorImage:
@@ -24793,6 +24797,8 @@ spec:
                       type: string
                     infraRedisImage:
                       type: string
+                    instanceHaImage:
+                      type: string
                     ironicAPIImage:
                       type: string
                     ironicConductorImage:
@@ -24992,6 +24998,8 @@ spec:
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:
+                    type: string
+                  instanceHaImage:
                     type: string
                   ironicAPIImage:
                     type: string
@@ -25210,6 +25218,8 @@ spec:
                     infraMemcachedImage:
                       type: string
                     infraRedisImage:
+                      type: string
+                    instanceHaImage:
                       type: string
                     ironicAPIImage:
                       type: string

--- a/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
+++ b/config/crd/bases/core.openstack.org_openstackcontrolplanes.yaml
@@ -21099,6 +21099,8 @@ spec:
                     type: string
                   infraRedisImage:
                     type: string
+                  instanceHaImage:
+                    type: string
                   ironicAPIImage:
                     type: string
                   ironicConductorImage:

--- a/config/crd/bases/core.openstack.org_openstackversions.yaml
+++ b/config/crd/bases/core.openstack.org_openstackversions.yaml
@@ -147,6 +147,8 @@ spec:
                     type: string
                   infraRedisImage:
                     type: string
+                  instanceHaImage:
+                    type: string
                   ironicAPIImage:
                     type: string
                   ironicConductorImage:
@@ -389,6 +391,8 @@ spec:
                       type: string
                     infraRedisImage:
                       type: string
+                    instanceHaImage:
+                      type: string
                     ironicAPIImage:
                       type: string
                     ironicConductorImage:
@@ -588,6 +592,8 @@ spec:
                   infraMemcachedImage:
                     type: string
                   infraRedisImage:
+                    type: string
+                  instanceHaImage:
                     type: string
                   ironicAPIImage:
                     type: string
@@ -806,6 +812,8 @@ spec:
                     infraMemcachedImage:
                       type: string
                     infraRedisImage:
+                      type: string
+                    instanceHaImage:
                       type: string
                     ironicAPIImage:
                       type: string

--- a/config/operator/default_images.yaml
+++ b/config/operator/default_images.yaml
@@ -107,6 +107,8 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-memcached:current-podified
         - name: RELATED_IMAGE_INFRA_REDIS_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-redis:current-podified
+        - name: RELATED_IMAGE_INSTANCE_HA_IMAGE_URL_DEFAULT
+          value: quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
         - name: RELATED_IMAGE_IRONIC_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
         - name: RELATED_IMAGE_IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -18,6 +18,7 @@ export RELATED_IMAGE_MANILA_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-cent
 export RELATED_IMAGE_MANILA_SCHEDULER_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-manila-scheduler:current-podified
 export RELATED_IMAGE_MANILA_SHARE_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-manila-share:current-podified
 export RELATED_IMAGE_GLANCE_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+export RELATED_IMAGE_INSTANCE_HA_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-openstackclient:current-podified
 export RELATED_IMAGE_IRONIC_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
 export RELATED_IMAGE_IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
 export RELATED_IMAGE_IRONIC_INSPECTOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified

--- a/internal/openstack/instanceha.go
+++ b/internal/openstack/instanceha.go
@@ -46,7 +46,7 @@ func ReconcileInstanceHa(ctx context.Context, instance *corev1beta1.OpenStackCon
 	}
 
 	customData := map[string]string{
-		InstanceHaImageKey: *getImg(version.Status.ContainerImages.OpenstackClientImage, &missingImageDefault),
+		InstanceHaImageKey: *getImg(version.Status.ContainerImages.InstanceHaImage, &missingImageDefault),
 	}
 
 	cms := []util.Template{

--- a/internal/openstack/version.go
+++ b/internal/openstack/version.go
@@ -165,6 +165,7 @@ func GetContainerImages(defaults *corev1beta1.ContainerDefaults, instance corev1
 			InfraDnsmasqImage:             getImg(instance.Spec.CustomContainerImages.InfraDnsmasqImage, defaults.InfraDnsmasqImage),
 			InfraMemcachedImage:           getImg(instance.Spec.CustomContainerImages.InfraMemcachedImage, defaults.InfraMemcachedImage),
 			InfraRedisImage:               getImg(instance.Spec.CustomContainerImages.InfraRedisImage, defaults.InfraRedisImage),
+			InstanceHaImage:               getImg(instance.Spec.CustomContainerImages.InstanceHaImage, defaults.InstanceHaImage),
 			IronicAPIImage:                getImg(instance.Spec.CustomContainerImages.IronicAPIImage, defaults.IronicAPIImage),
 			IronicConductorImage:          getImg(instance.Spec.CustomContainerImages.IronicConductorImage, defaults.IronicConductorImage),
 			IronicInspectorImage:          getImg(instance.Spec.CustomContainerImages.IronicInspectorImage, defaults.IronicInspectorImage),


### PR DESCRIPTION
Instanceha pods were using OpenstackClientImage, which prevented OLM from independently overriding the instanceha container image for RHOSO deployments. This adds a dedicated RELATED_IMAGE_INSTANCE_HA_IMAGE_URL_DEFAULT env var and InstanceHaImage field so instanceha can be configured separately.