### PR TITLE
Remove unnecessary pods RBAC permissions

### DIFF
--- a/internal/controller/client/openstackclient_controller.go
+++ b/internal/controller/client/openstackclient_controller.go
@@ -81,7 +81,7 @@ func (r *OpenStackClientReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch;patch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile -
 func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -165,11 +165,6 @@ func (r *OpenStackClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			ResourceNames: []string{"anyuid"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 		},
 	}
 	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)

--- a/internal/controller/dataplane/openstackdataplanedeployment_controller.go
+++ b/internal/controller/dataplane/openstackdataplanedeployment_controller.go
@@ -64,6 +64,7 @@ func (r *OpenStackDataPlaneDeploymentReconciler) GetLogger(ctx context.Context) 
 // +kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplanedeployments/finalizers,verbs=update;patch
 // +kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplanenodesets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplaneservices,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list;watch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete;

--- a/internal/controller/dataplane/openstackdataplanenodeset_controller.go
+++ b/internal/controller/dataplane/openstackdataplanenodeset_controller.go
@@ -114,7 +114,7 @@ func (r *OpenStackDataPlaneNodeSetReconciler) GetLogger(ctx context.Context) log
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get
 // +kubebuilder:rbac:groups="",resources=projects,verbs=get
 // +kubebuilder:rbac:groups="project.openshift.io",resources=projects,verbs=get


### PR DESCRIPTION
OpenStackClient's workload rbacRules granted full CRUD on core Pods to the ServiceAccount mounted into the OpenStackClient pod itself. That pod's entrypoint is a bare `sleep infinity` - any capability comes from what an admin runs interactively via exec, not from Kubernetes API access, so this grant is unnecessary and is removed entirely. The operator's own kubebuilder marker for pods on this same controller is untouched: it's independently justified by OpenStackClientReconciler directly creating/patching/deleting and watching (Owns(&corev1.Pod{})) that pod.

Also narrow two dataplane controllers to their real usage:
- OpenStackDataPlaneNodeSetReconciler only lists Pods (raw clientset, diagnostic listing of failed-deployment pods). Narrow its marker from full CRUD to list.
- OpenStackDataPlaneDeploymentReconciler had no pods marker of its own at all, despite GetAnsibleExecutionSummary listing Pods via the cached client (needs list;watch for the informer) to build the ansible execution summary. It only worked by relying on the nodeset controller's now-narrowed marker via the ClusterRole merge - add its own list;watch marker so a future change to the nodeset controller can't silently break it.

config/rbac/role.yaml is unchanged: OpenStackClient's own marker already grants full CRUD on pods for a real, direct need, so the merged ClusterRole doesn't shrink. The change is scoped to what gets delegated to workload ServiceAccounts and to per-controller marker correctness.