### PR TITLE
Set readOnlyRootFilesystem on service operator controller-manager containers

### DIFF
--- a/bindata/operator/managers.yaml
+++ b/bindata/operator/managers.yaml
@@ -67,7 +67,13 @@ spec:
             memory: {{ .Deployment.Manager.Resources.Requests.Memory }}
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+          readOnlyRootFilesystem: true
         volumeMounts:
+        - mountPath: /tmp
+          name: tmp
 {{- if isEnvVarTrue .Deployment.Manager.Env "ENABLE_WEBHOOKS" }}
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
@@ -99,6 +105,8 @@ spec:
 {{- end }}
 {{- end }}
       volumes:
+      - emptyDir: {}
+        name: tmp
 {{- if isEnvVarTrue .Deployment.Manager.Env "ENABLE_WEBHOOKS" }}
       - name: cert
         secret:

--- a/config/operator/managers.yaml
+++ b/config/operator/managers.yaml
@@ -67,7 +67,13 @@ spec:
             memory: {{ .Deployment.Manager.Resources.Requests.Memory }}
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+          readOnlyRootFilesystem: true
         volumeMounts:
+        - mountPath: /tmp
+          name: tmp
 {{- if isEnvVarTrue .Deployment.Manager.Env "ENABLE_WEBHOOKS" }}
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
@@ -99,6 +105,8 @@ spec:
 {{- end }}
 {{- end }}
       volumes:
+      - emptyDir: {}
+        name: tmp
 {{- if isEnvVarTrue .Deployment.Manager.Env "ENABLE_WEBHOOKS" }}
       - name: cert
         secret:


### PR DESCRIPTION
Harden the manager container securityContext by adding readOnlyRootFilesystem: true and dropping ALL capabilities. Mount an emptyDir at /tmp to support controller-runtime cert auto-generation and Go stdlib temporary file needs.

Jira: [OSPRH-34174](https://redhat.atlassian.net/browse/OSPRH-34174)