### PR TITLE
Require confirm-delete annotation for OpenStackDataPlaneDeployment deletion

### DIFF
--- a/api/dataplane/v1beta1/const.go
+++ b/api/dataplane/v1beta1/const.go
@@ -19,4 +19,8 @@ package v1beta1
 const (
 	// CtlPlaneNetwork - default ctlplane Network Name in NetConfig
 	CtlPlaneNetwork = "ctlplane"
+
+	// ConfirmDeleteAnnotation is the annotation key required to allow
+	// deletion of an OpenStackDataPlaneDeployment. The value must be "true".
+	ConfirmDeleteAnnotation = "dataplane.openstack.org/confirm-delete"
 )

--- a/api/dataplane/v1beta1/openstackdataplanedeployment_webhook.go
+++ b/api/dataplane/v1beta1/openstackdataplanedeployment_webhook.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -117,6 +118,23 @@ func (spec *OpenStackDataPlaneDeploymentSpec) ValidateUpdate(old OpenStackDataPl
 func (r *OpenStackDataPlaneDeployment) ValidateDelete() (admission.Warnings, error) {
 	openstackdataplanedeploymentlog.Info("validate delete", "name", r.Name)
 
+	deploymentCondition := r.Status.Conditions.Get(condition.DeploymentReadyCondition)
+	isDeploymentRunning := deploymentCondition != nil &&
+		deploymentCondition.Reason == condition.RequestedReason
+
+	if isDeploymentRunning &&
+		(r.Annotations == nil || r.Annotations[ConfirmDeleteAnnotation] != "true") {
+		warnings := admission.Warnings{
+			"Deleting a running OpenStackDataPlaneDeployment may leave nodes in an inconsistent or " +
+				"unrecoverable state. To confirm deletion, set the annotation " +
+				ConfirmDeleteAnnotation + "=true and retry.",
+		}
+		return warnings, apierrors.NewForbidden(
+			schema.GroupResource{Group: "dataplane.openstack.org", Resource: "openstackdataplanedeployments"},
+			r.Name,
+			fmt.Errorf("deletion of a running deployment not allowed: set annotation %s=true to confirm", ConfirmDeleteAnnotation))
+	}
+
 	errors := r.Spec.ValidateDelete()
 
 	if len(errors) != 0 {
@@ -132,7 +150,5 @@ func (r *OpenStackDataPlaneDeployment) ValidateDelete() (admission.Warnings, err
 
 // ValidateDelete validates the OpenStackDataPlaneDeploymentSpec on delete
 func (spec *OpenStackDataPlaneDeploymentSpec) ValidateDelete() field.ErrorList {
-	// TODO(user): fill in your validation logic upon object creation.
-
 	return field.ErrorList{}
 }

--- a/bindata/operator/operator.yaml
+++ b/bindata/operator/operator.yaml
@@ -419,6 +419,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - openstackdataplanedeployments
   sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -227,6 +227,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - openstackdataplanedeployments
   sideEffects: None

--- a/internal/webhook/dataplane/v1beta1/openstackdataplanedeployment_webhook.go
+++ b/internal/webhook/dataplane/v1beta1/openstackdataplanedeployment_webhook.go
@@ -72,10 +72,7 @@ func (d *OpenStackDataPlaneDeploymentCustomDefaulter) Default(_ context.Context,
 	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
-// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-dataplane-openstack-org-v1beta1-openstackdataplanedeployment,mutating=false,failurePolicy=fail,sideEffects=None,groups=dataplane.openstack.org,resources=openstackdataplanedeployments,verbs=create;update,versions=v1beta1,name=vopenstackdataplanedeployment-v1beta1.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-dataplane-openstack-org-v1beta1-openstackdataplanedeployment,mutating=false,failurePolicy=fail,sideEffects=None,groups=dataplane.openstack.org,resources=openstackdataplanedeployments,verbs=create;update;delete,versions=v1beta1,name=vopenstackdataplanedeployment-v1beta1.kb.io,admissionReviewVersions=v1
 
 // OpenStackDataPlaneDeploymentCustomValidator struct is responsible for validating the OpenStackDataPlaneDeployment resource
 // when it is created, updated, or deleted.

--- a/test/functional/dataplane/base_test.go
+++ b/test/functional/dataplane/base_test.go
@@ -84,6 +84,17 @@ func CreateDataplaneNodeSet(name types.NamespacedName, spec map[string]interface
 // Create OpenStackDataPlaneDeployment in k8s and test that no errors occur
 func CreateDataplaneDeployment(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
 	instance := DefaultDataplaneDeploymentTemplate(name, spec)
+	metadata := instance["metadata"].(map[string]interface{})
+	metadata["annotations"] = map[string]interface{}{
+		dataplanev1.ConfirmDeleteAnnotation: "true",
+	}
+	return th.CreateUnstructured(instance)
+}
+
+// Create OpenStackDataPlaneDeployment in k8s without the confirm-delete annotation.
+// Use this only in tests that need to verify delete rejection behavior.
+func CreateDataplaneDeploymentWithoutConfirm(name types.NamespacedName, spec map[string]interface{}) *unstructured.Unstructured {
+	instance := DefaultDataplaneDeploymentTemplate(name, spec)
 	return th.CreateUnstructured(instance)
 }
 

--- a/test/functional/dataplane/openstackdataplanedeployment_webhook_test.go
+++ b/test/functional/dataplane/openstackdataplanedeployment_webhook_test.go
@@ -1,0 +1,136 @@
+package functional
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	dataplanev1 "github.com/openstack-k8s-operators/openstack-operator/api/dataplane/v1beta1"
+)
+
+var _ = Describe("DataplaneDeployment Webhook", func() {
+	var dataplaneDeploymentName types.NamespacedName
+
+	createDeployment := func(name types.NamespacedName) {
+		CreateDataplaneDeploymentWithoutConfirm(name, DefaultDataPlaneDeploymentSpec())
+		DeferCleanup(func() {
+			instance := &dataplanev1.OpenStackDataPlaneDeployment{}
+			err := th.K8sClient.Get(th.Ctx, name, instance)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			if instance.Annotations == nil {
+				instance.Annotations = map[string]string{}
+			}
+			instance.Annotations[dataplanev1.ConfirmDeleteAnnotation] = "true"
+			Expect(th.K8sClient.Update(th.Ctx, instance)).To(Succeed())
+			Expect(th.K8sClient.Delete(th.Ctx, instance)).To(Succeed())
+		})
+	}
+
+	setDeploymentRunning := func(name types.NamespacedName) {
+		Eventually(func(g Gomega) error {
+			instance := &dataplanev1.OpenStackDataPlaneDeployment{}
+			g.Expect(th.K8sClient.Get(th.Ctx, name, instance)).To(Succeed())
+			instance.Status.Conditions = condition.Conditions{}
+			instance.Status.Conditions.MarkFalse(
+				condition.DeploymentReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				condition.DeploymentReadyRunningMessage,
+			)
+			return th.K8sClient.Status().Update(th.Ctx, instance)
+		}).Should(Succeed())
+	}
+
+	setDeploymentCompleted := func(name types.NamespacedName) {
+		Eventually(func(g Gomega) error {
+			instance := &dataplanev1.OpenStackDataPlaneDeployment{}
+			g.Expect(th.K8sClient.Get(th.Ctx, name, instance)).To(Succeed())
+			instance.Status.Conditions = condition.Conditions{}
+			instance.Status.Conditions.MarkTrue(
+				condition.DeploymentReadyCondition,
+				condition.DeploymentReadyMessage,
+			)
+			return th.K8sClient.Status().Update(th.Ctx, instance)
+		}).Should(Succeed())
+	}
+
+	When("a running deployment is deleted without the confirm annotation", func() {
+		BeforeEach(func() {
+			dataplaneDeploymentName = types.NamespacedName{
+				Name:      "edpm-running-delete-blocked",
+				Namespace: namespace,
+			}
+			createDeployment(dataplaneDeploymentName)
+			setDeploymentRunning(dataplaneDeploymentName)
+		})
+
+		It("should reject the delete request", func() {
+			Eventually(func() string {
+				instance := GetDataplaneDeployment(dataplaneDeploymentName)
+				err := th.K8sClient.Delete(th.Ctx, instance)
+				return fmt.Sprintf("%s", err)
+			}).Should(ContainSubstring("deletion of a running deployment not allowed"))
+		})
+	})
+
+	When("a running deployment is deleted with the confirm annotation", func() {
+		BeforeEach(func() {
+			dataplaneDeploymentName = types.NamespacedName{
+				Name:      "edpm-running-delete-confirmed",
+				Namespace: namespace,
+			}
+			createDeployment(dataplaneDeploymentName)
+			setDeploymentRunning(dataplaneDeploymentName)
+		})
+
+		It("should allow the delete request", func() {
+			Eventually(func(g Gomega) error {
+				instance := GetDataplaneDeployment(dataplaneDeploymentName)
+				if instance.Annotations == nil {
+					instance.Annotations = map[string]string{}
+				}
+				instance.Annotations[dataplanev1.ConfirmDeleteAnnotation] = "true"
+				g.Expect(th.K8sClient.Update(th.Ctx, instance)).To(Succeed())
+				return th.K8sClient.Delete(th.Ctx, instance)
+			}).Should(Succeed())
+
+			Eventually(func() bool {
+				instance := &dataplanev1.OpenStackDataPlaneDeployment{}
+				err := th.K8sClient.Get(th.Ctx, dataplaneDeploymentName, instance)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		})
+	})
+
+	When("a completed deployment is deleted without the confirm annotation", func() {
+		BeforeEach(func() {
+			dataplaneDeploymentName = types.NamespacedName{
+				Name:      "edpm-completed-delete-allowed",
+				Namespace: namespace,
+			}
+			createDeployment(dataplaneDeploymentName)
+			setDeploymentCompleted(dataplaneDeploymentName)
+		})
+
+		It("should allow the delete request", func() {
+			Eventually(func() error {
+				instance := GetDataplaneDeployment(dataplaneDeploymentName)
+				return th.K8sClient.Delete(th.Ctx, instance)
+			}).Should(Succeed())
+
+			Eventually(func() bool {
+				instance := &dataplanev1.OpenStackDataPlaneDeployment{}
+				err := th.K8sClient.Get(th.Ctx, dataplaneDeploymentName, instance)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		})
+	})
+})

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/08-ansiblevars-deploy.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/08-ansiblevars-deploy.yaml
@@ -3,8 +3,22 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: oc delete openstackdataplanedeployment edpm-compute-no-nodes-non-existent-service -n openstack-kuttl-tests --ignore-not-found=true
-  - script: oc delete openstackdataplanedeployment edpm-compute-node-selection -n openstack-kuttl-tests --ignore-not-found=true
+  - script: |
+      if oc get openstackdataplanedeployment edpm-compute-no-nodes-non-existent-service \
+        -n openstack-kuttl-tests >/dev/null 2>&1; then
+        oc annotate openstackdataplanedeployment edpm-compute-no-nodes-non-existent-service \
+          -n openstack-kuttl-tests dataplane.openstack.org/confirm-delete=true --overwrite
+        oc delete openstackdataplanedeployment edpm-compute-no-nodes-non-existent-service \
+          -n openstack-kuttl-tests --ignore-not-found=true
+      fi
+  - script: |
+      if oc get openstackdataplanedeployment edpm-compute-node-selection \
+        -n openstack-kuttl-tests >/dev/null 2>&1; then
+        oc annotate openstackdataplanedeployment edpm-compute-node-selection \
+          -n openstack-kuttl-tests dataplane.openstack.org/confirm-delete=true --overwrite
+        oc delete openstackdataplanedeployment edpm-compute-node-selection \
+          -n openstack-kuttl-tests --ignore-not-found=true
+      fi
 ---
 # Create ConfigMap and Secret for ansibleVarsFrom
 apiVersion: v1

--- a/test/kuttl/tests/dataplane-deploy-tls-test/05-dataplane-redeploy.yaml
+++ b/test/kuttl/tests/dataplane-deploy-tls-test/05-dataplane-redeploy.yaml
@@ -3,6 +3,8 @@ apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
   name: certs-refresh
+  annotations:
+    dataplane.openstack.org/confirm-delete: "true"
 spec:
   nodeSets:
     - openstack-edpm-tls

--- a/test/kuttl/tests/dataplane-extramounts/00-dataplane-create.yaml
+++ b/test/kuttl/tests/dataplane-extramounts/00-dataplane-create.yaml
@@ -32,6 +32,8 @@ apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
   name: edpm-extramounts
+  annotations:
+    dataplane.openstack.org/confirm-delete: "true"
 spec:
   nodeSets:
     - edpm-extramounts

--- a/test/kuttl/tests/dataplane-service-config/00-create.yaml
+++ b/test/kuttl/tests/dataplane-service-config/00-create.yaml
@@ -74,6 +74,8 @@ apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
   name: edpm-compute-no-nodes
+  annotations:
+    dataplane.openstack.org/confirm-delete: "true"
 spec:
   nodeSets:
     - edpm-compute-no-nodes

--- a/test/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
+++ b/test/kuttl/tests/dataplane-service-custom-image/00-dataplane-create.yaml
@@ -25,6 +25,8 @@ apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
   name: edpm-compute-no-nodes
+  annotations:
+    dataplane.openstack.org/confirm-delete: "true"
 spec:
   nodeSets:
     - edpm-no-nodes-custom-svc


### PR DESCRIPTION
Deleting a Deployment mid-execution may leave data plane nodes in an inconsistent or unrecoverable state. Require users to set the annotation dataplane.openstack.org/confirm-delete=true before deletion is allowed.

jira: [OSPRH-32794](https://redhat.atlassian.net/browse/OSPRH-32794)