### PR TITLE
Narrow wildcard RBAC verbs to least-privilege on manager ClusterRole

### DIFF
--- a/config/operator/rbac/role.yaml
+++ b/config/operator/rbac/role.yaml
@@ -7,25 +7,55 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - namespaces
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
-  - '*'
+  - customresourcedefinitions
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,9 +8,18 @@ rules:
   - ""
   resources:
   - configmaps
+  - pods
+  - secrets
+  - serviceaccounts
   - services
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -29,26 +38,9 @@ rules:
   resources:
   - namespaces
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - secrets
-  verbs:
   - create
-  - delete
   - get
-  - list
-  - patch
   - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - '*'
 - apiGroups:
   - ""
   - project.openshift.io
@@ -62,20 +54,23 @@ rules:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
+  - create
+  - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - apps

--- a/internal/controller/operator/openstack_controller.go
+++ b/internal/controller/operator/openstack_controller.go
@@ -110,12 +110,13 @@ func SetupEnv() {
 //+kubebuilder:rbac:groups=operator.openstack.org,resources=openstacks,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=operator.openstack.org,resources=openstacks/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=operator.openstack.org,resources=openstacks/finalizers,verbs=update
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs="*"
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;delete;deletecollection
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;delete
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources="*",verbs="*"
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups="",resources=serviceaccounts;configmaps;namespaces,verbs="*"
-// +kubebuilder:rbac:groups=core,resources=services,verbs="*";
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;create;update
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete;


### PR DESCRIPTION
Replace verbs: `["*"]` with explicit minimal verb sets on the openstack-operator controller's kubebuilder RBAC markers and regenerated manifests:

- `admissionregistration.k8s.io` webhooks: `get/list/watch/create/update/delete/deletecollection`
- `apiextensions.k8s.io`: narrow resources from `"*"` to `customresourcedefinitions`
- `core` `serviceaccounts`: `get/list/delete` (only used for cleanup)
- `core` `namespaces`: `get/create/update`
- `core` `services`: `get/list/create/update/delete`
- Remove `configmaps` from init operator controller markers (unused; other controllers declare their own)