### PR TITLE
Move watcher to s2i container images

### DIFF
--- a/config/operator/default_images.yaml
+++ b/config/operator/default_images.yaml
@@ -181,12 +181,8 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-swift-proxy-server:current-podified
         - name: RELATED_IMAGE_TEST_TEMPEST_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-tempest-all:current-podified
-        - name: RELATED_IMAGE_WATCHER_API_IMAGE_URL_DEFAULT
-          value: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
-        - name: RELATED_IMAGE_WATCHER_APPLIER_IMAGE_URL_DEFAULT
-          value: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
-        - name: RELATED_IMAGE_WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT
-          value: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
+        - name: RELATED_IMAGE_WATCHER_BASE_IMAGE_URL_DEFAULT
+          value: quay.io/openstack-k8s-operators/openstack-watcher-base:master-latest
           # NOTE: TEST_ images below do not get released downstream. They should not be prefixed with RELATED
         - name: TEST_TOBIKO_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified

--- a/hack/export_related_images.sh
+++ b/hack/export_related_images.sh
@@ -87,9 +87,7 @@ export RELATED_IMAGE_OPENSTACK_NETWORK_EXPORTER_IMAGE_URL_DEFAULT=quay.io/openst
 export RELATED_IMAGE_EDPM_KEPLER_IMAGE_URL_DEFAULT=quay.io/sustainable_computing_io/kepler:release-0.7.12
 export RELATED_IMAGE_EDPM_PODMAN_EXPORTER_IMAGE_URL_DEFAULT=quay.io/openstack-k8s-operators/prometheus-podman-exporter:latest
 export RELATED_IMAGE_TEST_TEMPEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-tempest-all:current-podified
-export RELATED_IMAGE_WATCHER_API_IMAGE_URL_DEFAULT=quay.io/podified-master-centos9/openstack-watcher-api:current-podified
-export RELATED_IMAGE_WATCHER_APPLIER_IMAGE_URL_DEFAULT=quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
-export RELATED_IMAGE_WATCHER_DECISION_ENGINE_IMAGE_URL_DEFAULT=quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified
+export RELATED_IMAGE_WATCHER_BASE_IMAGE_URL_DEFAULT=quay.io/openstack-k8s-operators/openstack-watcher-base:master-latest
 #NOTE: TEST_ images below do not get released downstream. They should not be prefixed with RELATED
 export TEST_TOBIKO_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
 export TEST_ANSIBLETEST_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ansible-tests:current-podified

--- a/internal/openstack/version.go
+++ b/internal/openstack/version.go
@@ -77,6 +77,12 @@ func InitializeOpenStackVersionImageDefaults(ctx context.Context, envImages map[
 	if envImages["TEST_HORIZONTEST_IMAGE_URL_DEFAULT"] != nil {
 		defaults.TestHorizontestImage = envImages["TEST_HORIZONTEST_IMAGE_URL_DEFAULT"]
 	}
+	// s2i base image: a single watcher base image populates all three service images
+	if envImages["RELATED_IMAGE_WATCHER_BASE_IMAGE_URL_DEFAULT"] != nil {
+		defaults.WatcherAPIImage = envImages["RELATED_IMAGE_WATCHER_BASE_IMAGE_URL_DEFAULT"]
+		defaults.WatcherApplierImage = envImages["RELATED_IMAGE_WATCHER_BASE_IMAGE_URL_DEFAULT"]
+		defaults.WatcherDecisionEngineImage = envImages["RELATED_IMAGE_WATCHER_BASE_IMAGE_URL_DEFAULT"]
+	}
 
 	Log.Info("Initialize OpenStackVersion return defaults")
 	return defaults

--- a/test/functional/ctlplane/openstackoperator_controller_test.go
+++ b/test/functional/ctlplane/openstackoperator_controller_test.go
@@ -2125,7 +2125,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			Expect(watcher.Spec.APIContainerImageURL).Should(Not(BeNil()))
 			Expect(watcher.Spec.ApplierContainerImageURL).Should(Not(BeNil()))
 			Expect(watcher.Spec.DecisionEngineContainerImageURL).Should(Not(BeNil()))
-			Expect(watcher.Spec.DecisionEngineContainerImageURL).Should(Equal("quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"))
+			Expect(watcher.Spec.DecisionEngineContainerImageURL).Should(Equal("quay.io/openstack-k8s-operators/openstack-watcher-base:master-latest"))
 
 			Expect(watcher.Spec.APIServiceTemplate.TLS.Ca.CaBundleSecretName).Should(Equal("combined-ca-bundle"))
 
@@ -2232,9 +2232,9 @@ var _ = Describe("OpenStackOperator controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			OSCtlplane := GetOpenStackControlPlane(names.OpenStackControlplaneName)
-			Expect(OSCtlplane.Status.ContainerImages.WatcherAPIImage).Should(Equal(ptr.To("quay.io/podified-master-centos9/openstack-watcher-api:current-podified")))
-			Expect(OSCtlplane.Status.ContainerImages.WatcherApplierImage).Should(Equal(ptr.To("quay.io/podified-master-centos9/openstack-watcher-applier:current-podified")))
-			Expect(OSCtlplane.Status.ContainerImages.WatcherDecisionEngineImage).Should(Equal(ptr.To("quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified")))
+			Expect(OSCtlplane.Status.ContainerImages.WatcherAPIImage).Should(Equal(ptr.To("quay.io/openstack-k8s-operators/openstack-watcher-base:master-latest")))
+			Expect(OSCtlplane.Status.ContainerImages.WatcherApplierImage).Should(Equal(ptr.To("quay.io/openstack-k8s-operators/openstack-watcher-base:master-latest")))
+			Expect(OSCtlplane.Status.ContainerImages.WatcherDecisionEngineImage).Should(Equal(ptr.To("quay.io/openstack-k8s-operators/openstack-watcher-base:master-latest")))
 		})
 	})
 
@@ -2311,7 +2311,7 @@ var _ = Describe("OpenStackOperator controller", func() {
 			// default Watche container images are set
 			Expect(watcher.Spec.APIContainerImageURL).Should(Not(BeNil()))
 			Expect(watcher.Spec.ApplierContainerImageURL).Should(Not(BeNil()))
-			Expect(watcher.Spec.DecisionEngineContainerImageURL).Should(Equal("quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified"))
+			Expect(watcher.Spec.DecisionEngineContainerImageURL).Should(Equal("quay.io/openstack-k8s-operators/openstack-watcher-base:master-latest"))
 
 		})
 


### PR DESCRIPTION
This is just changing the variable used in defaulting logic to the new consolidated container image from s2i.

So far, this is just to test the approach. We may want to move all defaults to s2i in openstack-operator.
