### PR TITLE
Add seccompProfile to sub-operator deployment template

### DIFF
--- a/bindata/operator/managers.yaml
+++ b/bindata/operator/managers.yaml
@@ -86,6 +86,8 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: {{ .Name }}-operator-controller-manager
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/config/operator/managers.yaml
+++ b/config/operator/managers.yaml
@@ -86,6 +86,8 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: {{ .Name }}-operator-controller-manager
       terminationGracePeriodSeconds: 10
       tolerations:


### PR DESCRIPTION
The managers.yaml template generates Deployments for ~20 child operators. While the template already includes `readOnlyRootFilesystem` and capability drop (added in `010517ca`), it was missing `seccompProfile` at the pod security context level.

This adds `seccompProfile: type: RuntimeDefault` to match the umbrella operator's own deployment and satisfy the Restricted Pod Security Standard.