### PR TITLE
[DNM][kuttl] Drop null Job pod template creationTimestamp asserts

### DIFF
--- a/test/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-global-service-test/01-assert.yaml
@@ -205,7 +205,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: download-cache-edpm-compute-global-edpm-compute-global
@@ -303,7 +302,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: bootstrap-edpm-compute-global-edpm-compute-global
@@ -407,7 +405,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: configure-network-edpm-compute-global-edpm-compute-global
@@ -505,7 +502,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: validate-network-edpm-compute-global-edpm-compute-global
@@ -603,7 +599,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: configure-os-edpm-compute-global-edpm-compute-global
@@ -701,7 +696,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: install-certs-edpm-compute-global-edpm-compute-global
@@ -848,7 +842,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: ovn-edpm-compute-global-edpm-compute-global
@@ -957,7 +950,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: neutron-metadata-edpm-compute-global-edpm-compute-global
@@ -1096,7 +1088,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: neutron-ovn-edpm-compute-global-edpm-compute-global
@@ -1235,7 +1226,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: neutron-sriov-edpm-compute-global-edpm-compute-global
@@ -1344,7 +1334,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: neutron-dhcp-edpm-compute-global-edpm-compute-global
@@ -1453,7 +1442,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: libvirt-edpm-compute-global-edpm-compute-global
@@ -1562,7 +1550,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: nova-edpm-compute-global-edpm-compute-global

--- a/test/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-global-service-test/02-assert.yaml
@@ -98,7 +98,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: download-cache-edpm-multinodeset-edpm-compute-beta-nodeset
@@ -195,7 +194,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: bootstrap-edpm-multinodeset-edpm-compute-beta-nodeset

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/01-assert.yaml
@@ -93,7 +93,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: download-cache-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -192,7 +191,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: bootstrap-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -298,7 +296,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: configure-network-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -398,7 +395,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: validate-network-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -498,7 +494,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: configure-os-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -598,7 +593,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: install-certs-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -740,7 +734,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: ovn-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -850,7 +843,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: neutron-metadata-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -990,7 +982,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: neutron-ovn-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -1130,7 +1121,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: neutron-sriov-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -1240,7 +1230,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: neutron-dhcp-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -1350,7 +1339,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: libvirt-edpm-compute-no-nodes-edpm-compute-no-nodes
@@ -1460,7 +1448,6 @@ spec:
   suspend: false
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: nova-edpm-compute-no-nodes-edpm-compute-no-nodes

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/02-assert.yaml
@@ -35,7 +35,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: configure-os-edpm-compute-no-nodes-edpm-compute-no-nodes

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/04-assert.yaml
@@ -94,7 +94,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: ovn-edpm-compute-no-nodes-updated-ovn-cm-edpm-compute-no-nodes

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/06-assert.yaml
@@ -203,7 +203,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: download-cache-edpm-multinodeset-edpm-compute-beta-nodeset

--- a/test/kuttl/tests/dataplane-deploy-no-nodes-test/07-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-no-nodes-test/07-assert.yaml
@@ -28,7 +28,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: configure-os-edpm-compute-node-selection-edpm-compute-no-nodes

--- a/test/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-tls-test/02-assert.yaml
@@ -161,7 +161,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: install-certs-ovrd-openstack-edpm-tls-openstack-edpm-tls
@@ -295,7 +294,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: tls-dnsnames-openstack-edpm-tls-openstack-edpm-tls

--- a/test/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
+++ b/test/kuttl/tests/dataplane-deploy-tls-test/03-assert.yaml
@@ -167,7 +167,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: tls-dns-ips-openstack-edpm-tls-ovrd-openstack-edpm-tls

--- a/test/kuttl/tests/dataplane-extramounts/00-assert.yaml
+++ b/test/kuttl/tests/dataplane-extramounts/00-assert.yaml
@@ -55,7 +55,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: test-service-edpm-extramounts-edpm-extramounts

--- a/test/kuttl/tests/dataplane-service-config/00-assert.yaml
+++ b/test/kuttl/tests/dataplane-service-config/00-assert.yaml
@@ -35,7 +35,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: kuttl-service-edpm-compute-no-nodes-edpm-compute-no-nodes

--- a/test/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
+++ b/test/kuttl/tests/dataplane-service-custom-image/00-assert.yaml
@@ -82,7 +82,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: custom-img-svc-edpm-compute-no-nodes-edpm-no-nodes-custom-svc

--- a/test/kuttl/tests/dataplane-service-failure/00-assert.yaml
+++ b/test/kuttl/tests/dataplane-service-failure/00-assert.yaml
@@ -34,7 +34,6 @@ spec:
     metadata:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[]'
-      creationTimestamp: null
       labels:
         app: openstackansibleee
         batch.kubernetes.io/job-name: failed-service-edpm-compute-no-nodes-edpm-compute-no-nodes


### PR DESCRIPTION
cifmw-multinode-kuttl started failing this test after the GitHub check jobs moved from OCP 4.20 to 4.22. The dataplane deploy itself succeeds; KUTTL then compares live Jobs against a full YAML dump that still has Job.spec.template.metadata.creationTimestamp: null (leftover from oc get -o yaml).

On 4.20 the API still serialized that null key, so the assert matched. On 4.22 Kubernetes omits empty creationTimestamp (omitempty), so the key is missing from the live object. KUTTL waits the full timeout for a field that will never appear, then fails with:

  .spec.template.metadata.creationTimestamp: key is missing from map

Remove the dumped null fields from the Job asserts so the test does not depend on that serialization difference.