### PR TITLE
Disable ManilaShare v1 by default in 19

### DIFF
--- a/internal/openstack/version.go
+++ b/internal/openstack/version.go
@@ -236,7 +236,7 @@ func InitializeOpenStackVersionServiceDefaults(ctx context.Context) *corev1beta1
 	defaults.GlanceLocationAPI = ptr.To("false") // disable location-api for RHOSO 18: this boolean can be switched to true with RHOSO 19 release
 	// NOTE: In 18 Manila creates sharev1 service and endpoints. From 19 do not create sharev1 anymore
 	// https://review.opendev.org/q/topic:%22remove-v1%22+and+project:openstack/manila
-	defaults.ManilaSharev1 = &trueString // all Manila deployments create sharev1 endpoints by default
+	defaults.ManilaSharev1 = ptr.To("false")
 
 	versionString := "4.2"
 	defaults.RabbitmqVersion = &versionString // all new rabbitmq deployments will have rabbitmq-server 4.2 (FR5)


### PR DESCRIPTION
19 `Manila` services do not provide `ManilaShareV1` endpoints anymore. This change switches this behavior by providing the annotation that instruct manila-operator to not create v1 endpoints anymore.

Jira: https://redhat.atlassian.net/browse/OSPRH-36292