### PR TITLE
Removal of monolithic update

### DIFF
--- a/config/services/dataplane_v1beta1_openstackdataplaneservice_update.yaml
+++ b/config/services/dataplane_v1beta1_openstackdataplaneservice_update.yaml
@@ -1,7 +1,0 @@
-apiVersion: dataplane.openstack.org/v1beta1
-kind: OpenStackDataPlaneService
-metadata:
-  name: update
-spec:
-  playbook: osp.edpm.update
-  edpmServiceType: update

--- a/docs/assemblies/proc_updating-the-data-plane-ovn.adoc
+++ b/docs/assemblies/proc_updating-the-data-plane-ovn.adoc
@@ -22,13 +22,13 @@ The following example output shows the condition has been met:
 openstackversion.core.openstack.org/openstack-galera-network-isolation condition met
 ----
 
-. Create an `OpenStackDataPlaneDeployment` CR and save it to a file named `openstack-edpm-update.yaml` on your workstation.
+. Create an `OpenStackDataPlaneDeployment` CR and save it to a file named `openstack-edpm-update-ovn.yaml` on your workstation.
 +
 ----
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: edpm-deployment-ipam-update
+  name: edpm-deployment-ipam-update-ovn
 spec:
   nodeSets:
     - openstack-edpm-ipam
@@ -44,21 +44,21 @@ spec:
 [NOTE]
 The `servicesOverride` field is set to include only `ovn` as the `ovn` service must be updated first in isolation. If using a custom service to manage `ovn`, then use that custom service name instead of `ovn` in `servicesOverride`. Additionally if other custom services must be updated at the same time as `ovn`, then they can be included in `servicesOverride` as well.
 
-. Save the `openstack-edpm-update.yaml` deployment file.
+. Save the `openstack-edpm-update-ovn.yaml` deployment file.
 
 . Update the data plane:
 +
 ----
-$ oc create -f openstack-edpm-update.yaml
+$ oc create -f openstack-edpm-update-ovn.yaml
 ----
 
 . Verify that the data plane update deployment succeeded:
 +
 ----
 $ oc get openstackdataplanedeployment
-NAME             			STATUS   MESSAGE
-edpm-deployment-ipam   		True     Setup Complete
-edpm-deployment-ipam-update True     Setup Complete
+NAME                              STATUS   MESSAGE
+edpm-deployment-ipam              True     Setup Complete
+edpm-deployment-ipam-update-ovn   True     Setup Complete
 ----
 
 Once OVN has been updated on the data plane, the rest of the control plane minor update will automatically proceed. Once the control plane minor update is finished, the rest of the data plane can be updated.

--- a/docs/assemblies/proc_updating-the-data-plane.adoc
+++ b/docs/assemblies/proc_updating-the-data-plane.adoc
@@ -55,10 +55,10 @@ $ oc create -f openstack-edpm-update-services.yaml
 +
 ----
 $ oc get openstackdataplanedeployment
-NAME             						STATUS   MESSAGE
-edpm-deployment-ipam   					True     Setup Complete
-edpm-deployment-ipam-update 			True     Setup Complete
-edpm-deployment-ipam-update-services 	True     Setup Complete
+NAME                                   STATUS   MESSAGE
+edpm-deployment-ipam                   True     Setup Complete
+edpm-deployment-ipam-update-ovn        True     Setup Complete
+edpm-deployment-ipam-update-services   True     Setup Complete
 ----
 
 .Troubleshooting

--- a/docs/assemblies/proc_updating-the-data-plane.adoc
+++ b/docs/assemblies/proc_updating-the-data-plane.adoc
@@ -35,13 +35,13 @@ spec:
     - ...
     - <nodeSet_name>
   servicesOverride:
-    - update
+    - update-services
 ----
 +
 * Replace `<nodeSet_name>` with the names of the `OpenStackDataPlaneNodeSet` CRs that you want to include in your data plane minor update.
 +
 [NOTE]
-The `servicesOverride` field is set to include only `update`. The `update` service applies only the tasks needed to update the packages and containers on the EDPM nodes. When using custom services, include those here as well, or their equivalent custom services that apply the needed update tasks.
+The `servicesOverride` field is set to include only `update-services`. The `update-services` service applies only the tasks needed to update the containers and a limited set of packages on the EDPM nodes. When using custom services, include those here as well, or their equivalent custom services that apply the needed update tasks.
 
 . Save the `openstack-edpm-update-services.yaml` deployment file.
 

--- a/internal/controller/dataplane/openstackdataplanenodeset_controller.go
+++ b/internal/controller/dataplane/openstackdataplanenodeset_controller.go
@@ -636,7 +636,7 @@ func checkDeployment(ctx context.Context, helper *helper.Helper,
 				services = instance.Spec.Services
 			}
 
-			// For each service, check if EDPMServiceType is "update" or "update-services", and
+			// For each service, check if EDPMServiceType is "update-services", and
 			// if so, copy Deployment.Status.DeployedVersion to
 			// NodeSet.Status.DeployedVersion
 			for _, serviceName := range services {
@@ -651,11 +651,11 @@ func checkDeployment(ctx context.Context, helper *helper.Helper,
 					return isNodeSetDeploymentReady, isNodeSetDeploymentRunning, isNodeSetDeploymentFailed, failedDeploymentName, err
 				}
 
-				if service.Spec.EDPMServiceType != "update" && service.Spec.EDPMServiceType != "update-services" {
+				if service.Spec.EDPMServiceType != "update-services" {
 					continue
 				}
 
-				// An "update" or "update-services" service Deployment has been completed, so
+				// An "update-services" service Deployment has been completed, so
 				// set the NodeSet's DeployedVersion to the Deployment's
 				// DeployedVersion.
 				instance.Status.DeployedVersion = deployment.Status.DeployedVersion

--- a/test/functional/dataplane/base_test.go
+++ b/test/functional/dataplane/base_test.go
@@ -335,15 +335,6 @@ func DefaultDataPlaneDeploymentSpec() map[string]interface{} {
 	}
 }
 
-func MinorUpdateDataPlaneDeploymentSpec() map[string]interface{} {
-	return map[string]interface{}{
-		"nodeSets": []string{
-			"edpm-compute-nodeset",
-		},
-		"servicesOverride": []string{"update"},
-	}
-}
-
 func MinorUpdateServicesDataPlaneDeploymentSpec() map[string]interface{} {
 	return map[string]interface{}{
 		"nodeSets": []string{

--- a/test/functional/dataplane/openstackdataplanenodeset_controller_test.go
+++ b/test/functional/dataplane/openstackdataplanenodeset_controller_test.go
@@ -67,7 +67,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 	var dataplaneDeploymentName types.NamespacedName
 	var dataplaneConfigHash string
 	var dataplaneGlobalServiceName types.NamespacedName
-	var dataplaneUpdateServiceName types.NamespacedName
 	var newDataplaneUpdateServiceName types.NamespacedName
 
 	defaultEdpmServiceList := []string{
@@ -118,10 +117,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 		}
 		dataplaneGlobalServiceName = types.NamespacedName{
 			Name:      "global-service",
-			Namespace: namespace,
-		}
-		dataplaneUpdateServiceName = types.NamespacedName{
-			Name:      "update",
 			Namespace: namespace,
 		}
 		newDataplaneUpdateServiceName = types.NamespacedName{
@@ -1276,54 +1271,6 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 				updatedInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
 				return dataplaneConfigHash != updatedInstance.Status.ConfigHash
 			}).Should(BeTrue())
-		})
-	})
-
-	When("A DataPlaneNodeSet is created with NoNodes and a MinorUpdate OpenStackDataPlaneDeployment is created", func() {
-		BeforeEach(func() {
-
-			dataplanev1.SetupDefaults()
-			updateServiceSpec := map[string]interface{}{
-				"playbook": "osp.edpm.update",
-			}
-			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, updateServiceSpec)
-			DeferCleanup(th.DeleteService, dataplaneUpdateServiceName)
-			DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
-			DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
-			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(false)))
-			DeferCleanup(th.DeleteInstance, CreateDataplaneDeployment(dataplaneDeploymentName, MinorUpdateDataPlaneDeploymentSpec()))
-			openstackVersionName := types.NamespacedName{
-				Name:      "openstackversion",
-				Namespace: namespace,
-			}
-			err := os.Setenv("OPENSTACK_RELEASE_VERSION", "0.0.1")
-			Expect(err).NotTo(HaveOccurred())
-			openstackv1.SetupVersionDefaults()
-			DeferCleanup(th.DeleteInstance, CreateOpenStackVersion(openstackVersionName))
-
-			CreateSSHSecret(dataplaneSSHSecretName)
-			CreateCABundleSecret(caBundleSecretName)
-			SimulateDNSMasqComplete(dnsMasqName)
-			SimulateIPSetComplete(dataplaneNodeName)
-			SimulateDNSDataComplete(dataplaneNodeSetName)
-
-			Eventually(func(g Gomega) {
-				// Make an AnsibleEE name for each service
-				ansibleeeName := types.NamespacedName{
-					Name:      "update-edpm-deployment-edpm-compute-nodeset",
-					Namespace: namespace,
-				}
-				ansibleEE := GetAnsibleee(ansibleeeName)
-				ansibleEE.Status.Succeeded = 1
-				g.Expect(th.K8sClient.Status().Update(th.Ctx, ansibleEE)).To(Succeed())
-			}, th.Timeout, th.Interval).Should(Succeed())
-
-		})
-		It("NodeSet.Status.DeployedVersion should be set to latest version", Label("update"), func() {
-			Eventually(func() string {
-				dataplaneNodeSetInstance := GetDataplaneNodeSet(dataplaneNodeSetName)
-				return dataplaneNodeSetInstance.Status.DeployedVersion
-			}).Should(Equal("0.0.1"))
 		})
 	})
 

--- a/test/functional/dataplane/openstackdataplanenodeset_controller_test.go
+++ b/test/functional/dataplane/openstackdataplanenodeset_controller_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 	var dataplaneDeploymentName types.NamespacedName
 	var dataplaneConfigHash string
 	var dataplaneGlobalServiceName types.NamespacedName
-	var newDataplaneUpdateServiceName types.NamespacedName
+	var dataplaneUpdateServiceName types.NamespacedName
 
 	defaultEdpmServiceList := []string{
 		"edpm_frr_image",
@@ -119,7 +119,7 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			Name:      "global-service",
 			Namespace: namespace,
 		}
-		newDataplaneUpdateServiceName = types.NamespacedName{
+		dataplaneUpdateServiceName = types.NamespacedName{
 			Name:      "update-services",
 			Namespace: namespace,
 		}
@@ -1281,8 +1281,8 @@ var _ = Describe("Dataplane NodeSet Test", func() {
 			updateServiceSpec := map[string]interface{}{
 				"playbook": "osp.edpm.update_services",
 			}
-			CreateDataPlaneServiceFromSpec(newDataplaneUpdateServiceName, updateServiceSpec)
-			DeferCleanup(th.DeleteService, newDataplaneUpdateServiceName)
+			CreateDataPlaneServiceFromSpec(dataplaneUpdateServiceName, updateServiceSpec)
+			DeferCleanup(th.DeleteService, dataplaneUpdateServiceName)
 			DeferCleanup(th.DeleteInstance, CreateNetConfig(dataplaneNetConfigName, DefaultNetConfigSpec()))
 			DeferCleanup(th.DeleteInstance, CreateDNSMasq(dnsMasqName, DefaultDNSMasqSpec()))
 			DeferCleanup(th.DeleteInstance, CreateDataplaneNodeSet(dataplaneNodeSetName, DefaultDataPlaneNoNodeSetSpec(false)))


### PR DESCRIPTION
For the upcoming release we'd like to converge our update workflow onto the "split" update with separate `update-services` and `update-system` parts. The monolithic `update` is being removed to slim down the support matrix.