### PR TITLE
Consume the promoted S2I content set in tempest-multinode

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -33,8 +33,13 @@
     name: openstack-operator-tempest-multinode
     parent: podified-multinode-edpm-deployment-crc-3comp
     dependencies: ["openstack-k8s-operators-content-provider"]
+    # Non-voting until soak. See ANVIL-275.
+    voting: false
+    required-projects:
+      - openstack-k8s-operators/s2i-openstack-containers
     irrelevant-files: *irrelevant-files
     vars:
+      cifmw_s2i_content_set: true
       cifmw_operator_build_golang_ct: "docker.io/library/golang:1.26"
       cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.26"
       cifmw_test_operator_tempest_tempestconf_config:


### PR DESCRIPTION
## Summary
- Enable `cifmw_s2i_content_set` on `openstack-operator-tempest-multinode` so the job deploys digest-pinned service images from `quay.io/openstack-s2i-containers` together with the current operator bundle.
- Keep the job non-voting until soak.
- Check out `s2i-openstack-containers` so the resolver can read image mappings; do not add an s2i content-provider parent.
- Inject the full mapped set. `s2i-openstack-deploy-validation` on s2i `main` no longer skips neutron/mariadb (`c0bc00e`, `5c614ee`).

Related-Issue: [ANVIL-275](https://redhat.atlassian.net/browse/ANVIL-275)

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4167
Depends-On: https://github.com/openstack-k8s-operators/s2i-openstack-containers/pull/187
Depends-On: https://review.rdoproject.org/r/c/config/+/59025

## Test plan
- [ ] Zuul check: `openstack-operator-tempest-multinode` is scheduled and remains non-voting
- [ ] Job log shows the resolved content set (s2iCommit + digests) applied via `set_containers`
- [ ] Unmapped keys stay on payload defaults