### PR TITLE
Propagate MariaDB TargetVersion to the Galera CR (OSPRH-32083)

### DIFF
--- a/api/bases/core.openstack.org_openstackversions.yaml
+++ b/api/bases/core.openstack.org_openstackversions.yaml
@@ -258,6 +258,8 @@ spec:
                       type: string
                     manilaSharev1:
                       type: string
+                    mariadbVersion:
+                      type: string
                     rabbitmqVersion:
                       type: string
                   type: object
@@ -698,6 +700,8 @@ spec:
                   glanceWsgi:
                     type: string
                   manilaSharev1:
+                    type: string
+                  mariadbVersion:
                     type: string
                   rabbitmqVersion:
                     type: string

--- a/api/core/v1beta1/openstackversion_types.go
+++ b/api/core/v1beta1/openstackversion_types.go
@@ -301,6 +301,7 @@ type ContainerTemplate struct {
 type ServiceDefaults struct {
 	GlanceWsgi      *string `json:"glanceWsgi,omitempty"`
 	RabbitmqVersion *string `json:"rabbitmqVersion,omitempty"`
+	MariadbVersion  *string `json:"mariadbVersion,omitempty"`
 	GlanceLocationAPI *string `json:"glanceLocationAPI,omitempty"`
 	ManilaSharev1   *string `json:"manilaSharev1,omitempty"`
 }

--- a/api/core/v1beta1/zz_generated.deepcopy.go
+++ b/api/core/v1beta1/zz_generated.deepcopy.go
@@ -1768,6 +1768,11 @@ func (in *ServiceDefaults) DeepCopyInto(out *ServiceDefaults) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MariadbVersion != nil {
+		in, out := &in.MariadbVersion, &out.MariadbVersion
+		*out = new(string)
+		**out = **in
+	}
 	if in.GlanceLocationAPI != nil {
 		in, out := &in.GlanceLocationAPI, &out.GlanceLocationAPI
 		*out = new(string)

--- a/bindata/crds/crds.yaml
+++ b/bindata/crds/crds.yaml
@@ -22620,6 +22620,8 @@ spec:
                       type: string
                     manilaSharev1:
                       type: string
+                    mariadbVersion:
+                      type: string
                     rabbitmqVersion:
                       type: string
                   type: object
@@ -23060,6 +23062,8 @@ spec:
                   glanceWsgi:
                     type: string
                   manilaSharev1:
+                    type: string
+                  mariadbVersion:
                     type: string
                   rabbitmqVersion:
                     type: string

--- a/config/crd/bases/core.openstack.org_openstackversions.yaml
+++ b/config/crd/bases/core.openstack.org_openstackversions.yaml
@@ -258,6 +258,8 @@ spec:
                       type: string
                     manilaSharev1:
                       type: string
+                    mariadbVersion:
+                      type: string
                     rabbitmqVersion:
                       type: string
                   type: object
@@ -698,6 +700,8 @@ spec:
                   glanceWsgi:
                     type: string
                   manilaSharev1:
+                    type: string
+                  mariadbVersion:
                     type: string
                   rabbitmqVersion:
                     type: string

--- a/internal/openstack/galera.go
+++ b/internal/openstack/galera.go
@@ -282,6 +282,18 @@ func reconcileGalera(
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), galera, func() error {
 		spec.DeepCopyInto(&galera.Spec.GaleraSpecCore)
 		galera.Spec.ContainerImage = *version.Status.ContainerImages.MariadbImage
+
+		// set the target mariadb major.minor version in spec.  when the deployed
+		// OpenStack version predates this field, leave TargetVersion empty rather
+		// than asserting the version currently running: the mariadb-operator folds
+		// TargetVersion into the ClusterProperties hash, so writing it where it was
+		// previously absent would trip StopRequired and stop a healthy cluster that
+		// is not being upgraded at all.
+		if version.Status.ServiceDefaults.MariadbVersion != nil {
+			galera.Spec.TargetVersion = *version.Status.ServiceDefaults.MariadbVersion
+		} else {
+			galera.Spec.TargetVersion = ""
+		}
 		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), galera, helper.GetScheme())
 		if err != nil {
 			return err

--- a/internal/openstack/version.go
+++ b/internal/openstack/version.go
@@ -241,6 +241,14 @@ func InitializeOpenStackVersionServiceDefaults(ctx context.Context) *corev1beta1
 	versionString := "4.2"
 	defaults.RabbitmqVersion = &versionString // all new rabbitmq deployments will have rabbitmq-server 4.2 (FR5)
 
+	// NOTE: MariadbVersion is deliberately left unset for now, which leaves
+	// Galera's TargetVersion empty (see reconcileGalera()).  The mariadb image
+	// this build ships is still MariaDB 10.5, so declaring "10.11" here would
+	// stop every existing cluster once and then leave it permanently reporting
+	// MariaDBServerUpgradeReady=False/UpgradeVersionMismatch.  Set this to
+	// "10.11" in the same change that moves
+	// RELATED_IMAGE_MARIADB_IMAGE_URL_DEFAULT to a 10.11 image.
+
 	return defaults
 }
 

--- a/test/functional/ctlplane/openstackoperator_controller_test.go
+++ b/test/functional/ctlplane/openstackoperator_controller_test.go
@@ -3110,6 +3110,98 @@ var _ = Describe("OpenStackOperator controller", func() {
 	})
 
 	//
+	// MariaDB major version upgrade (ServiceDefaults.MariadbVersion -> Galera TargetVersion)
+	//
+	// ServiceDefaults.MariadbVersion is not defaulted yet: the mariadb image
+	// currently shipped is still 10.5, so nothing may be written to Galera's
+	// TargetVersion. The mariadb-operator folds TargetVersion into the
+	// ClusterProperties hash, so writing it where it was previously absent would
+	// trip StopRequired and stop a healthy cluster that is not being upgraded.
+	When("A OpenStackControlPlane is created at the current OpenStack version", func() {
+		BeforeEach(func() {
+			spec := GetDefaultOpenStackControlPlaneSpec()
+			spec["tls"] = GetTLSPublicSpec()
+
+			DeferCleanup(
+				th.DeleteInstance,
+				CreateOpenStackControlPlane(names.OpenStackControlplaneName, spec),
+			)
+		})
+
+		It("leaves the Galera TargetVersion empty while MariadbVersion is undefaulted", func() {
+			Eventually(func(g Gomega) {
+				version := GetOpenStackVersion(names.OpenStackVersionName)
+				g.Expect(version.Status.ServiceDefaults.MariadbVersion).Should(BeNil())
+
+				g.Expect(mariadb.GetGalera(names.DBName).Spec.TargetVersion).To(Equal(""))
+				g.Expect(mariadb.GetGalera(names.DBCell1Name).Spec.TargetVersion).To(Equal(""))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	// Guards the propagation itself, so that turning the default on later is a
+	// one-line change in InitializeOpenStackVersionServiceDefaults.
+	When("A OpenStackControlPlane is created at a version declaring a MariadbVersion", func() {
+		const mariadbVersion = "10.11"
+		const taggedVersion = "0.0.0"
+
+		BeforeEach(func() {
+			DeferCleanup(
+				th.DeleteInstance,
+				CreateOpenStackVersion(names.OpenStackVersionName, GetDefaultOpenStackVersionSpec()),
+			)
+
+			th.ExpectCondition(
+				names.OpenStackVersionName,
+				ConditionGetterFunc(OpenStackVersionConditionGetter),
+				corev1.OpenStackVersionInitialized,
+				k8s_corev1.ConditionTrue,
+			)
+
+			// record a version whose ServiceDefaults declare a MariadbVersion, as
+			// InitializeOpenStackVersionServiceDefaults will once a 10.11 mariadb
+			// image ships
+			Eventually(func(g Gomega) {
+				version := GetOpenStackVersion(names.OpenStackVersionName)
+				version.Status.ContainerImageVersionDefaults[taggedVersion] =
+					version.Status.ContainerImageVersionDefaults[version.Spec.TargetVersion]
+				version.Status.AvailableServiceDefaults[taggedVersion] = &corev1.ServiceDefaults{
+					MariadbVersion: ptr.To(mariadbVersion),
+				}
+				g.Expect(th.K8sClient.Status().Update(th.Ctx, version)).To(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				version := GetOpenStackVersion(names.OpenStackVersionName)
+				version.Spec.TargetVersion = taggedVersion
+				g.Expect(th.K8sClient.Update(th.Ctx, version)).To(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				version := GetOpenStackVersion(names.OpenStackVersionName)
+				g.Expect(version.Spec.TargetVersion).To(Equal(taggedVersion))
+				g.Expect(version.Status.ServiceDefaults.MariadbVersion).ShouldNot(BeNil())
+				g.Expect(*version.Status.ServiceDefaults.MariadbVersion).To(Equal(mariadbVersion))
+			}, timeout, interval).Should(Succeed())
+
+			spec := GetDefaultOpenStackControlPlaneSpec()
+			spec["tls"] = GetTLSPublicSpec()
+
+			DeferCleanup(
+				th.DeleteInstance,
+				CreateOpenStackControlPlane(names.OpenStackControlplaneName, spec),
+			)
+		})
+
+		It("propagates ServiceDefaults.MariadbVersion onto the Galera CRs", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(mariadb.GetGalera(names.DBName).Spec.TargetVersion).To(Equal(mariadbVersion))
+				g.Expect(mariadb.GetGalera(names.DBCell1Name).Spec.TargetVersion).To(Equal(mariadbVersion))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	//
 	// Galera Secret field behavior tests
 	//
 	When("A OpenStackControlPlane with blank Galera secret is created", func() {


### PR DESCRIPTION
Adds ServiceDefaults.MariadbVersion to OpenStackVersion and propagates it to the Galera CR's spec.targetVersion, following the pattern already used by ServiceDefaults.RabbitmqVersion for the rabbitmq-server 3.9->4.2 upgrade.

Currently does not indicate a "default" version for mariadb-galera, as 10.5 is already deployed in existing deployments that dont have the "targetversion" field at all; setting it to 10.5 here would force a restart of those clusters.

Once this change is running on a rhel-10 environment with mariadb 10.11 available as the mariadb image,
the RELATED_IMAGE_MARIADB_IMAGE_URL_DEFAULT should be added as "10.11"; when deployed on an existing cluster that runs 10.5, this will apply the new version to the galera cluster which will then do a restart and run the mariadb upgrade scripts.  Doing so before a 10.11 image is present would put running clusters into a state that includes MariaDBServerUpgradeReady=False with UpgradeVersionMismatch (however those clusters would still remain in a ready state).

References: [OSPRH-32083](https://redhat.atlassian.net/browse/OSPRH-32083)