### PR TITLE
Preserve user EDPM registry configuration

### DIFF
--- a/internal/dataplane/inventory.go
+++ b/internal/dataplane/inventory.go
@@ -153,9 +153,8 @@ func GenerateNodeSetInventory(ctx context.Context, helper *helper.Helper,
 				return "", fmt.Errorf("failed to get MachineConfig registry configuration: %w", err)
 			}
 		} else {
-			helper.GetLogger().Info("Mirror registries detected via IDMS/ICSP. Using OCP registry configuration.")
-			nodeSetGroup.Vars["edpm_podman_registries_conf"] = registryConfig
-			nodeSetGroup.Vars["edpm_podman_disconnected_ocp"] = hasMirrorRegistries
+			helper.GetLogger().Info("Mirror registries detected via IDMS/ICSP. Using OCP registry configuration defaults.")
+			setDefaultPodmanRegistryConfigVars(nodeSetGroup.Vars, hasMirrorRegistries, registryConfig)
 		}
 
 		mirrorScopes, sourceByMirror, err := util.GetMirrorRegistryScopes(ctx, helper)
@@ -304,6 +303,15 @@ func populateInventoryFromIPAM(
 		dnsSearchDomains = append(dnsSearchDomains, res.DNSDomain)
 	}
 	host.Vars["dns_search_domains"] = dnsSearchDomains
+}
+
+func setDefaultPodmanRegistryConfigVars(vars map[string]interface{}, hasMirrorRegistries bool, registryConfig string) {
+	if _, ok := vars["edpm_podman_registries_conf"]; !ok {
+		vars["edpm_podman_registries_conf"] = registryConfig
+	}
+	if _, ok := vars["edpm_podman_disconnected_ocp"]; !ok {
+		vars["edpm_podman_disconnected_ocp"] = hasMirrorRegistries
+	}
 }
 
 // set group ansible vars from NodeTemplate

--- a/internal/dataplane/inventory_test.go
+++ b/internal/dataplane/inventory_test.go
@@ -86,6 +86,48 @@ func TestProcessConfigMapData_NumbersAsInts(t *testing.T) {
 	}
 }
 
+func TestSetDefaultPodmanRegistryConfigVars(t *testing.T) {
+	tests := []struct {
+		name           string
+		vars           map[string]interface{}
+		expectedConfig string
+		expectedOCP    bool
+	}{
+		{
+			name:           "sets registry configuration defaults",
+			vars:           map[string]interface{}{},
+			expectedConfig: "ocp registry config",
+			expectedOCP:    true,
+		},
+		{
+			name: "preserves user registry configuration vars",
+			vars: map[string]interface{}{
+				"edpm_podman_registries_conf":  "director local mirror config",
+				"edpm_podman_disconnected_ocp": false,
+			},
+			expectedConfig: "director local mirror config",
+			expectedOCP:    false,
+		},
+		{
+			name: "preserves independently overridden registry configuration vars",
+			vars: map[string]interface{}{
+				"edpm_podman_disconnected_ocp": false,
+			},
+			expectedConfig: "ocp registry config",
+			expectedOCP:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setDefaultPodmanRegistryConfigVars(tt.vars, true, "ocp registry config")
+
+			assert.Equal(t, tt.expectedConfig, tt.vars["edpm_podman_registries_conf"])
+			assert.Equal(t, tt.expectedOCP, tt.vars["edpm_podman_disconnected_ocp"])
+		})
+	}
+}
+
 func TestProcessSecretData_NumbersAsInts(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Sometimes users explicitly set edpm_podman_registries_conf and edpm_podman_disconnected_ocp to false in OpenStackDataPlaneNodeSet spec even if cluster has IDMS objects which we assume as disconnected deployment. Let's give preference to user set ansible vars.

Jira: [OSPRH-30371](https://redhat.atlassian.net/browse/OSPRH-30371)