### PR TITLE
Fix crd-size workflow: set GH_TOKEN for gh api call

### DIFF
--- a/.github/workflows/crd-size-badge.yaml
+++ b/.github/workflows/crd-size-badge.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Compute CRD JSON size
         id: size
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |


### PR DESCRIPTION
The "Compute CRD JSON size" step uses `gh api` to fetch the PR head's CRD file, but did not set GH_TOKEN. gh requires GH_TOKEN in Actions and exited with code 4 before producing output, failing the check.

Add GH_TOKEN: ${{ github.token }} to the step env. The existing
`contents: read` permission is sufficient for the contents API read.